### PR TITLE
[agenda] fix agenda table layout for long room names

### DIFF
--- a/src/pretalx/static/agenda/scss/_agenda.scss
+++ b/src/pretalx/static/agenda/scss/_agenda.scss
@@ -29,6 +29,8 @@
                 font-size: 16pt;
                 text-align: center;
                 padding: 8px 0;
+                overflow-wrap: break-word;
+                overflow: hidden;
             }
         }
 


### PR DESCRIPTION
The agenda table headers do not line up properly, if one of the room names is too long to fit:

![image](https://user-images.githubusercontent.com/2158203/30613235-a9a6fbc8-9d87-11e7-9fc9-c4a25312d66d.png)

This MR just makes the name wrap:

![image](https://user-images.githubusercontent.com/2158203/30613254-b573f28a-9d87-11e7-8e2c-5b19195ef05c.png)

Is this a smart enough solution or do we want to expand the table? Or cut the name off? Ellipsis do not seem to work with `overflow-wrap`.