### PR TITLE
fixed 404 link in dashboard (edit cfp)

### DIFF
--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -138,6 +138,8 @@ class Event(LogMixin, models.Model):
         create = '/orga/event/new'
         base = '/orga/event/{self.slug}'
         cfp = '{base}/cfp'
+        view_cfp = '{cfp}/text'
+        edit_cfp = '{cfp}/text/edit'
         users = '{base}/users'
         mail = '{base}/mails'
         send_mails = '{mail}/send'

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -104,7 +104,7 @@
                 <a class="nav-link {% if "settings." in url_name %}active{% endif %}" href="{{ request.event.orga_urls.settings }}">
                     <span class="fa fa-wrench"></span> {% trans "Settings" %}
                 </a>
-                <a class="nav-link {% if "cfp." in url_name %}active{% endif %}" href="{{ request.event.cfp.urls.text }}">
+                <a class="nav-link {% if "cfp." in url_name %}active{% endif %}" href="{{ request.event.orga_urls.view_cfp }}">
                     <span class="fa fa-bullhorn"></span> {% trans "CfP" %}
                 </a>
             {% endif %}

--- a/src/pretalx/orga/templates/orga/event/dashboard.html
+++ b/src/pretalx/orga/templates/orga/event/dashboard.html
@@ -16,7 +16,7 @@
                     <li><a href="{{ request.event.orga_urls.team_settings }}">
                             {% trans "Gather your team" %}
                     </a></li>
-                    <li><a href="{{ request.event.orga_urls.cfp }}">
+                    <li><a href="{{ request.event.orga_urls.edit_cfp }}">
                             {% trans "Write a CfP" %}
                     </a></li>
                     <li><a href="{{ request.event.orga_urls.mail_templates }}">


### PR DESCRIPTION
the link "Write a cfp" in the dashboard lead to a 404.
used new url definition since it looks more similar to the other
orga_urls. Don't know if that is how it is supposed to be or another value would have been better.

- [ ] My code follows the code style of this project.
good question ;o)
- [X] All new and existing tests passed.
