### PR TITLE
173 typeahead fix

### DIFF
--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -13,6 +13,7 @@
         {% endcompress %}
     {% endif %}
     <link rel="stylesheet" type="text/css" href="{% static "vendored/fullcalendar/fullcalendar.min.css" %}"/>
+    <link rel="stylesheet" type="text/css" href="{% static "vendored/typeahead.css" %}"/>
     {% block stylesheets %}
     {% endblock %}
     {% if request.event and request.event.custom_css %}

--- a/src/pretalx/orga/templates/orga/settings/review.html
+++ b/src/pretalx/orga/templates/orga/settings/review.html
@@ -3,9 +3,6 @@
 {% load compress %}
 {% load i18n %}
 {% load staticfiles %}
-{% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/typeahead.css" %}"/>
-{% endblock %}
 {% block settings_content %}
 
 <div>

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -3,10 +3,6 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block stylesheets %}
-    <link rel="stylesheet" type="text/css" href="{% static "vendored/typeahead.css" %}"/>
-{% endblock %}
-
 {% block submission_content %}
 
     <table class="table table-condensed">


### PR DESCRIPTION
Since the stylesheet for typeahead.js wasn't included on all sites, some instances of the typeahead searches weren't visually pleasing.

This PR closes issue #173. It does so by removing the typeahead.css from two individual places and puts it into the main orga base.html template, so it is included on all orga pages.

I suggest to have a bigger issue to track some sort of "theming" support/plugin?

- [X] All new and existing tests passed.
