### PR TITLE
more visible icon for the "do not record" flag

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -67,7 +67,10 @@
                                      data-time="{{ talk.start|date:"H:i" }}–{{ talk.end|date:"H:i" }}">
                                     <div class="talk-content">
                                         {% if talk.submission.do_not_record %}
-                                            <i class="fa fa-ban do-not-record" aria-hidden="true"></i>
+                                            <span class="fa-stack">
+                                              <i class="fa fa-video-camera fa-stack-1x"></i>
+                                              <i class="fa fa-ban fa-stack-2x do-not-record" aria-hidden="true" title="{% trans "This talk will not be recorded." %}"></i>
+                                            </span>
                                         {% endif %}
                                         <span class="talk-title">{{ talk.submission.title }}</span>
                                         {% if talk.submission.speakers.exists %}

--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -33,6 +33,10 @@
     <div class="talk row">
         <div class="talk-content col-lg-8 col-md-6 col-xs-12">
             {% if talk.do_not_record %}
+                <span class="fa-stack">
+                    <i class="fa fa-video-camera fa-stack-1x"></i>
+                    <i class="fa fa-ban fa-stack-2x do-not-record" aria-hidden="true" title="{% trans "This talk will not be recorded." %}"></i>
+                </span>
                 <em>{% trans "This talk will not be recorded." %}</em>
             {% endif %}
             {% if talk.recording_url %}


### PR DESCRIPTION
This PR closes issue #176. It does so by adding a "hover" tooltip to the icon and changes it by stacking the font-awesome "video camera" icon with the "banned" icon on top.

- [x] All new and existing tests passed.
