### PR TITLE
Add missing action logs and display them

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
@@ -67,4 +67,8 @@
             {% endblocktrans %}
         </p>
     {% endif %}
+
+    <div class="user-logs">
+        {% include "common/logs.html" with obj=submission hide_orga="true" %}
+    </div>
 {% endblock %}

--- a/src/pretalx/cfp/views/user.py
+++ b/src/pretalx/cfp/views/user.py
@@ -246,7 +246,7 @@ class SubmissionInviteView(LoggedInEventPageMixin, SubmissionViewMixin, FormView
     def form_valid(self, form):
         form.save()
         messages.success(self.request, _('The invitation was sent!'))
-        submission.log_action('pretalx.submission.speakers.invite', person=self.request.user)
+        self.get_object().log_action('pretalx.submission.speakers.invite', person=self.request.user)
         return super().form_valid(form)
 
     def get_success_url(self):

--- a/src/pretalx/cfp/views/user.py
+++ b/src/pretalx/cfp/views/user.py
@@ -142,7 +142,8 @@ class SubmissionConfirmView(LoggedInEventPageMixin, SubmissionViewMixin, View):
             return redirect(request.event.urls.login)
         submission = self.get_object()
         if submission.state == SubmissionStates.ACCEPTED:
-            submission.confirm(person=request.user, orga=False)
+            submission.confirm(person=request.user)
+            submission.log_action('pretalx.submission.confirm', person=request.user)
             messages.success(self.request, _('Your submission has been confirmed – we\'re looking forward to seeing you!'))
         elif submission.state == SubmissionStates.CONFIRMED:
             messages.success(self.request, _('This submission has already been confirmed – we\'re looking forward to seeing you!'))
@@ -245,6 +246,7 @@ class SubmissionInviteView(LoggedInEventPageMixin, SubmissionViewMixin, FormView
     def form_valid(self, form):
         form.save()
         messages.success(self.request, _('The invitation was sent!'))
+        submission.log_action('pretalx.submission.speakers.invite', person=self.request.user)
         return super().form_valid(form)
 
     def get_success_url(self):

--- a/src/pretalx/common/templates/common/logs.html
+++ b/src/pretalx/common/templates/common/logs.html
@@ -13,18 +13,23 @@
                 <p class="meta">
                     <span class="fa fa-clock-o"></span> {{ log.timestamp|date:"Y-m-d H:i" }}
                     {% if log.person %}
-                        <br><span class="fa fa-user fa-fw"></span>
-                        {% if log.person.name %}
-                            {{ log.person.name }}
+                        {% if log.is_orga_action %}
+                            <br><span class="fa fa-check-circle fa-fw"
+                                    data-toggle="tooltip"
+                                    title="{% trans "This change was performed by a member of the event orga." %}">
+                            </span>
                         {% else %}
-                            {{ log.person.nick }}
+                            <br><span class="fa fa-user fa-fw"></span>
                         {% endif %}
-                    {% endif %}
-                    {% if log.is_orga_action %}
-                        <span class="fa fa-check-circle fa-fw"
-                                data-toggle="tooltip"
-                                title="{% trans "This change was performed by a member of the event orga." %}">
-                        </span>
+                        {% if log.is_orga_action and hide_orga %}
+                            {% trans "An orga member" %}
+                        {% else %}
+                            {% if log.person.name %}
+                                {{ log.person.name }}
+                            {% else %}
+                                {{ log.person.nick }}
+                            {% endif %}
+                        {% endif %}
                     {% endif %}
                 </p>
 

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -77,6 +77,7 @@ class SubmissionAccept(SubmissionViewMixin, View):
 
         try:
             submission.accept(person=request.user)
+            submission.log_action('pretalx.submission.accept', person=request.user, orga=True)
             messages.success(request, _('The submission has been accepted.'))
         except SubmissionError:
             messages.error(request, _('A submission must be submitted or rejected to become accepted.'))
@@ -90,6 +91,7 @@ class SubmissionConfirm(SubmissionViewMixin, View):
 
         try:
             submission.confirm(person=request.user, orga=True)
+            submission.log_action('pretalx.submission.confirm', person=request.user, orga=True)
             messages.success(request, _('The submission has been confirmed.'))
         except SubmissionError:
             messages.error(request, _('A submission must be accepted to become confirmed.'))
@@ -103,6 +105,7 @@ class SubmissionUnconfirm(SubmissionViewMixin, View):
 
         try:
             submission.unconfirm(person=request.user, orga=True)
+            submission.log_action('pretalx.submission.unconfirm', person=request.user, orga=True)
             messages.success(request, _('The submission has been unconfirmed. It is now accepted.'))
         except SubmissionError:
             messages.error(request, _('A submission must be confirmed to be unconfirmed, naturally.'))
@@ -256,7 +259,9 @@ class SubmissionDelete(SubmissionViewMixin, TemplateView):
     template_name = 'orga/submission/delete.html'
 
     def post(self, request, *args, **kwargs):
-        self.get_object().remove(person=request.user)
+        submission = self.get_object()
+        submission.remove(person=request.user)
+        submission.log_action('pretalx.submission.delete', person=request.user, orga=True)
         messages.success(request, _('The submission has been deleted.'))
         return redirect(request.event.orga_urls.submissions)
 

--- a/src/pretalx/static/cfp/scss/_layout.scss
+++ b/src/pretalx/static/cfp/scss/_layout.scss
@@ -165,3 +165,17 @@ table .btn-secondary {
     margin: 0 16px;
   }
 }
+
+.user-logs {
+  position: absolute;
+  left: 100%;
+  top: 5%;
+  width: 240px;
+  z-index: -1;
+
+  .panel-heading {
+    background-color: $gray-lightest;
+    margin-bottom: -10px;
+    padding: 8px;
+  }
+}

--- a/src/tests/functional/orga/test_submission.py
+++ b/src/tests/functional/orga/test_submission.py
@@ -85,6 +85,20 @@ def test_orga_can_confirm_submission(orga_client, accepted_submission):
 
 
 @pytest.mark.django_db
+def test_orga_can_unconfirm_submission(orga_client, confirmed_submission):
+    assert confirmed_submission.state == SubmissionStates.CONFIRMED
+
+    response = orga_client.get(
+        confirmed_submission.orga_urls.unconfirm,
+        follow=True,
+    )
+    confirmed_submission.refresh_from_db()
+
+    assert response.status_code == 200
+    assert confirmed_submission.state == SubmissionStates.ACCEPTED
+
+
+@pytest.mark.django_db
 def test_orga_can_delete_submission(orga_client, submission):
     assert submission.state == SubmissionStates.SUBMITTED
     assert Submission.objects.count() == 1


### PR DESCRIPTION
Displays log entries in the user's frontend.

![2017-10-30-001641_1467x805_scrot](https://user-images.githubusercontent.com/2657547/32149625-b2855f6a-bd07-11e7-9022-299474be43d0.png)
