### PR TITLE
move version in schedule URLs from querystring to urlpath

### DIFF
--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -4,17 +4,32 @@ from pretalx.event.models.event import SLUG_CHARS
 
 from .views import feed, location, schedule, speaker, talk
 
+def get_schedule_urls(regex_prefix, name_prefix=""):
+    """
+    given a prefix (e.g. /schedule) generate matching schedule-ruls (e.g. /schedule.json, /schedule/feed.xml, ...)
+    """
+
+    regex_prefix = regex_prefix.rstrip('/')
+
+    return [
+        url(f"{regex_prefix}{regex}", view, name=f"{name_prefix}{name}")
+        for regex, view, name in [
+            ('/$', schedule.ScheduleView.as_view(), 'schedule'),
+            ('.xml$', schedule.FrabXmlView.as_view(), 'frab-xml'),
+            ('.xcal$', schedule.FrabXCalView.as_view(), 'frab-xcal'),
+            ('.json$', schedule.FrabJsonView.as_view(), 'frab-json'),
+            ('.ics$', schedule.ICalView.as_view(), 'ical'),
+            ('/feed.xml$', feed.ScheduleFeed(), 'feed'),
+        ]
+    ]
+
+
 app_name = 'agenda'
 urlpatterns = [
     url(f'^(?P<event>[{SLUG_CHARS}]+)/', include([
-        url('^schedule/$', schedule.ScheduleView.as_view(), name='schedule'),
         url('^schedule/changelog$', schedule.ChangelogView.as_view(), name='schedule.changelog'),
-        url('^schedule.xml$', schedule.FrabXmlView.as_view(), name='frab-xml'),
-        url('^schedule.xcal$', schedule.FrabXCalView.as_view(), name='frab-xcal'),
-        url('^schedule.json$', schedule.FrabJsonView.as_view(), name='frab-json'),
-        url('^schedule.ics$', schedule.ICalView.as_view(), name='ical'),
-        url('^schedule/feed.xml$', feed.ScheduleFeed(), name='feed'),
-
+        *get_schedule_urls('^schedule'),
+        *get_schedule_urls('^schedule/v/(?P<version>\w+)', 'versioned-'),
         url('^location/$', location.LocationView.as_view(), name='location'),
         url('^talk/(?P<slug>\w+)/$', talk.TalkView.as_view(), name='talk'),
         url('^talk/(?P<slug>\w+)/feedback/$', talk.FeedbackView.as_view(), name='feedback'),

--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     url(f'^(?P<event>[{SLUG_CHARS}]+)/', include([
         url('^schedule/changelog$', schedule.ChangelogView.as_view(), name='schedule.changelog'),
         *get_schedule_urls('^schedule'),
-        *get_schedule_urls('^schedule/v/(?P<version>\w+)', 'versioned-'),
+        *get_schedule_urls('^schedule/v/(?P<version>.+)', 'versioned-'),
         url('^location/$', location.LocationView.as_view(), name='location'),
         url('^talk/(?P<slug>\w+)/$', talk.TalkView.as_view(), name='talk'),
         url('^talk/(?P<slug>\w+)/feedback/$', talk.FeedbackView.as_view(), name='feedback'),

--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -4,6 +4,7 @@ from pretalx.event.models.event import SLUG_CHARS
 
 from .views import feed, location, schedule, speaker, talk
 
+
 def get_schedule_urls(regex_prefix, name_prefix=""):
     """
     given a prefix (e.g. /schedule) generate matching schedule-ruls (e.g. /schedule.json, /schedule/feed.xml, ...)

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -36,7 +36,7 @@ class Schedule(LogMixin, models.Model):
         unique_together = (('event', 'version'), )
 
     class urls(EventUrls):
-        public = '{self.event.urls.schedule}?version={self.url_version}'
+        public = '{self.event.urls.schedule}/v/{self.url_version}'
 
     @transaction.atomic
     def freeze(self, name, user=None, notify_speakers=True):

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -408,7 +408,7 @@ def availability(event):
 
 @pytest.fixture
 def schedule(event):
-    event.release_schedule('Best Version')
+    event.release_schedule('🍪 Version')
     return event.current_schedule
 
 


### PR DESCRIPTION
Fixes #276 

## How Has This Been Tested?
Not yet.

## Screenshots (if appropriate):
N/A

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.

## TODO

- [x] non-ascii URLs (e.g. versions containing emoji or Japanese versions)
- [x] redirect old query string URLs w/ 301
- [x] add testes because there do not seem to be any?