### PR TITLE
[WIP] Display deleted talks as [deleted] and remove their links

### DIFF
--- a/src/pretalx/static/orga/js/schedule.js
+++ b/src/pretalx/static/orga/js/schedule.js
@@ -122,10 +122,13 @@ Vue.component('talk', {
   template: `
     <div class="talk-box" :class="[talk.state, {dragged: isDragged}]" v-bind:style="style" @mousedown="onMouseDown"
          :title="title">
-      <span class="time" v-if="this.talk.start">
-        {{ humanStart }}
-      </span>
-      {{ talk.title }} ({{ talk.duration }} minutes)
+      <div v-if="this.talk.state != 'deleted'">
+        <span class="time" v-if="this.talk.start">
+          {{ humanStart }}
+        </span>
+        <span >{{ talk.title }} ({{ talk.duration }} minutes)</span>
+      </div>
+      <span v-else>[deleted]</span>
     </div>
   `,
   props: {
@@ -363,7 +366,9 @@ var app = new Vue({
             })
           })
         } else {
-          window.open(dragController.draggedTalk.url)
+          if (dragController.draggedTalk.state != 'deleted'){
+            window.open(dragController.draggedTalk.url)
+          }
           dragController.stopDragging()
         }
       }


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #281 . It does so by displaying deleted submissions as "[deleted]" and removing links to them.

## Screenshots (if appropriate):
http://take.ms/q590Z

