### PR TITLE
[WIP] Remove links to talk pages from old schedule views

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -58,7 +58,9 @@
                     <div class="room">
                         <div class="talk-container" style="height: {{ day.height }}px">
                             {% for talk in room.talks %}
-                            <a href="{{ talk.submission.urls.public }}">
+                                {% if not schedule.is_archived %}
+                                  <a href="{{ talk.submission.urls.public }}">
+                                {% endif %}
 
                                 <div class="talk{% if request.user in talk.submission.speakers.all %} talk-personal{% endif %}{% if talk.is_active %} active{% endif %}"
                                      id="{{ talk.submission.code }}"

--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -76,7 +76,7 @@
                                         {% endif %}
 
                                         {% if talk.submission.is_deleted %}
-                                          <span class="talk-title">[deleted]</span>
+                                          <span class="talk-title">[{% trans deleted %}]</span>
                                         {% else %}
                                             <span class="talk-title">{{ talk.submission.title }}</span>
 

--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -74,9 +74,15 @@
                                               <i class="fa fa-ban fa-stack-2x do-not-record" aria-hidden="true" title="{{ phrases.agenda.schedule_do_not_record }}"></i>
                                             </span>
                                         {% endif %}
-                                        <span class="talk-title">{{ talk.submission.title }}</span>
-                                        {% if talk.submission.speakers.exists %}
-                                            <span class="talk-speakers">({{ talk.submission.display_speaker_names }})</span><br>
+
+                                        {% if talk.submission.is_deleted %}
+                                          <span class="talk-title">[deleted]</span>
+                                        {% else %}
+                                            <span class="talk-title">{{ talk.submission.title }}</span>
+
+                                            {% if talk.submission.speakers.exists %}
+                                              <span class="talk-speakers">({{ talk.submission.display_speaker_names }})</span><br>
+                                            {% endif %}
                                         {% endif %}
                                     </div>
                                 </div>

--- a/src/pretalx/agenda/views/schedule.py
+++ b/src/pretalx/agenda/views/schedule.py
@@ -62,11 +62,11 @@ class ScheduleDataView(TemplateView):
                 'start': current_date,
                 'end': current_date + timedelta(days=1),
                 'first_start': min([t.start for t in talks if t.start and t.start.astimezone(tz).date() == current_date.date()] or [0]),
-                'last_end': max([t.end for t in talks if t.start.astimezone(tz).date() == current_date.date()] or [0]),
+                'last_end': max([t.end for t in talks if t.start and t.start.astimezone(tz).date() == current_date.date()] or [0]),
                 'rooms': [{
                     'name': room.name,
                     'talks': [talk for talk in talks
-                              if talk.start.astimezone(tz).date() == current_date.date() and talk.room_id == room.pk],
+                              if talk.start and talk.start.astimezone(tz).date() == current_date.date() and talk.room_id == room.pk],
                 } for room in rooms],
             } for index, current_date in enumerate([
                 event.datetime_from + timedelta(days=i) for i in range((event.date_to - event.date_from).days + 1)

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -133,12 +133,12 @@ class Schedule(LogMixin, models.Model):
         new_slots = set(
             talk
             for talk in self.talks.select_related('submission', 'submission__event', 'room').all()
-            if talk.is_visible
+            if talk.is_visible and not talk.submission.is_deleted
         )
         old_slots = set(
             talk
             for talk in self.previous_schedule.talks.select_related('submission', 'submission__event', 'room').all()
-            if talk.is_visible
+            if talk.is_visible and not talk.submission.is_deleted
         )
 
         new_submissions = set(talk.submission for talk in new_slots)

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -205,5 +205,12 @@ class Schedule(LogMixin, models.Model):
     def url_version(self):
         return quote(self.version) if self.version else 'wip'
 
+    @property
+    def is_archived(self):
+        if not self.version:
+            return False
+
+        return self != self.event.current_schedule
+
     def __str__(self) -> str:
         return str(self.version) or _(f'WIP Schedule for {self.event}')

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -268,8 +268,6 @@ class Submission(LogMixin, models.Model):
 
     def remove(self, person=None, force=False):
         self._set_state(SubmissionStates.DELETED, force)
-        from pretalx.schedule.models import TalkSlot
-        TalkSlot.objects.filter(submission=self, schedule=self.event.wip_schedule).delete()
         self.log_action('pretalx.submission.deleted', person=person, orga=False)
 
     @property
@@ -328,6 +326,10 @@ class Submission(LogMixin, models.Model):
     @property
     def active_resources(self):
         return self.resources.filter(resource__isnull=False)
+
+    @property
+    def is_deleted(self):
+        return self.state == SubmissionStates.DELETED
 
     def __str__(self):
         return self.title

--- a/src/tests/unit/schedule/test_schedule_model.py
+++ b/src/tests/unit/schedule/test_schedule_model.py
@@ -100,3 +100,17 @@ def test_scheduled_talks(slot, room):
     current_slot.save()
     old, new = current_slot.schedule.freeze('test-version2')
     assert new.scheduled_talks.count() == slot_count - 1
+
+
+@pytest.mark.django_db
+def test_is_archived(event):
+    event.release_schedule(name='v1')
+    event.release_schedule(name='v2')
+
+    v1_schedule = Schedule.objects.get(version='v1')
+    v2_schedule = Schedule.objects.get(version='v2')
+    unreleased_schedule = event.schedules.filter(version=None).first()
+
+    assert v1_schedule.is_archived
+    assert not v2_schedule.is_archived
+    assert not unreleased_schedule.is_archived

--- a/src/tests/unit/submission/test_submission_model.py
+++ b/src/tests/unit/submission/test_submission_model.py
@@ -179,3 +179,15 @@ def test_set_state_error_msg(submission):
         submission._set_state(SubmissionStates.SUBMITTED)
 
     assert 'must be rejected or accepted or withdrawn not submitted to be submitted' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('state,expected', (
+    (SubmissionStates.ACCEPTED, False),
+    (SubmissionStates.DELETED, True)
+))
+@pytest.mark.django_db
+def test_is_deleted(submission, state, expected):
+    submission.state = state
+    submission.save()
+
+    assert submission.is_deleted == expected


### PR DESCRIPTION
Please, let me know if I am on the right path.

P.S. I couldn't run the tests locally. There is this error coming up: `You have offline compression enabled but key "1354bed19bb78fa1bb9f122d6ee27708" is missing from offline manifest. You may need to run "python manage.py compress".` Running "python manage.py compress" did not help. Any ideas how I can fix it?

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #281 . 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Release multiple schedules. Go to an old version. None of the talks should have a link.
2. Delete some submission. It should be displayed as "[deleted]"

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/9026972/33185397-25d0bcd0-d0a4-11e7-9849-d94fe371742b.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
