### PR TITLE
Orga schedule export

### DIFF
--- a/src/pretalx/agenda/__init__.py
+++ b/src/pretalx/agenda/__init__.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 from django.apps import AppConfig
 
 
@@ -7,3 +9,7 @@ class AgendaConfig(AppConfig):
     def ready(self):
         from . import permissions  # noqa
         from .phrases import AgendaPhrases  # noqa
+
+
+with suppress(ImportError):
+    import pretalx.celery_app as celery  # NOQA

--- a/src/pretalx/agenda/management/commands/export_schedule_html.py
+++ b/src/pretalx/agenda/management/commands/export_schedule_html.py
@@ -3,8 +3,6 @@ from shutil import make_archive
 
 from bakery.management.commands.build import Command as BakeryBuildCommand
 from django.conf import settings
-from django.core.files.base import ContentFile
-from django.core.files.storage import default_storage
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.urls import get_callable

--- a/src/pretalx/agenda/management/commands/export_schedule_html.py
+++ b/src/pretalx/agenda/management/commands/export_schedule_html.py
@@ -1,3 +1,5 @@
+import os.path
+
 from bakery.management.commands.build import Command as BakeryBuildCommand
 from django.conf import settings
 from django.core.management import call_command
@@ -15,6 +17,10 @@ class Command(BakeryBuildCommand):
         super().add_arguments(parser)
         parser.add_argument('event', type=str)
 
+    @classmethod
+    def get_output_dir(cls, event):
+        return os.path.join(settings.HTMLEXPORT_ROOT, event.slug)
+
     def handle(self, *args, **options):
         try:
             event = Event.objects.get(slug__iexact=options['event'])
@@ -27,6 +33,8 @@ class Command(BakeryBuildCommand):
         settings.COMPRESS_ENABLED = True
         settings.COMPRESS_OFFLINE = True
         call_command('rebuild')  # collect static files and combine/compress them
+
+        settings.BUILD_DIR = self.get_output_dir(event)
 
         super().handle(*args, **options)
 

--- a/src/pretalx/agenda/management/commands/export_schedule_html.py
+++ b/src/pretalx/agenda/management/commands/export_schedule_html.py
@@ -25,6 +25,10 @@ class Command(BakeryBuildCommand):
     def get_output_dir(cls, event):
         return os.path.join(settings.HTMLEXPORT_ROOT, event.slug)
 
+    @classmethod
+    def get_output_zip_path(cls, event):
+        return cls.get_output_dir(event) + '.zip'
+
     def handle(self, *args, **options):
         try:
             event = Event.objects.get(slug__iexact=options['event'])
@@ -43,16 +47,7 @@ class Command(BakeryBuildCommand):
         super().handle(*args, **options)
 
         if options.get('zip'):
-            self.make_zip(event, settings.BUILD_DIR)
-
-    def make_zip(self, event, output_dir):
-        destination = output_dir
-        make_archive(destination, 'zip', destination, destination)
-
-        with open(destination + '.zip', 'br') as f:
-            contentfile = ContentFile(f.read())
-
-        default_storage.save(f'{event.slug}/schedule_{event.slug}.zip', contentfile)
+            make_archive(settings.BUILD_DIR, 'zip', settings.BUILD_DIR, settings.BUILD_DIR)
 
     def build_views(self):
         for view_str in self.view_list:

--- a/src/pretalx/agenda/tasks.py
+++ b/src/pretalx/agenda/tasks.py
@@ -1,0 +1,19 @@
+from pretalx.celery_app import app
+from pretalx.event.models import Event
+
+
+@app.task()
+def export_schedule_html(*, event_id: int, make_zip=True):
+    from django.core.management import call_command
+
+    event = Event.objects.get(pk=event_id)
+
+    cmd = [
+        'export_schedule_html',
+        event.slug,
+    ]
+
+    if make_zip:
+        cmd.append('--zip')
+
+    call_command(*cmd)

--- a/src/pretalx/api/serializers/event.py
+++ b/src/pretalx/api/serializers/event.py
@@ -9,5 +9,5 @@ class EventSerializer(ModelSerializer):
         model = Event
         fields = (
             'name', 'slug', 'subtitle', 'is_public', 'date_from', 'date_to',
-            'timezone',
+            'timezone', 'html_export_url'
         )

--- a/src/pretalx/common/models/settings.py
+++ b/src/pretalx/common/models/settings.py
@@ -11,6 +11,7 @@ class GlobalSettings(GlobalSettingsBase):
 
 
 settings_hierarkey.add_default('show_schedule', 'True', bool)
+settings_hierarkey.add_default('export_html_on_schedule_release', 'True', bool)
 settings_hierarkey.add_default('custom_domain', '', str)
 
 settings_hierarkey.add_default('allow_override_votes', 'False', bool)

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -139,6 +139,7 @@ class Event(LogMixin, models.Model):
         ical = '{schedule}.ics'
         feed = '{schedule}/feed.xml'
         location = '{schedule}/location'
+        html_export = f'{settings.MEDIA_URL}/{{self.slug}}/schedule_{{self.slug}}.zip'
 
     class orga_urls(EventUrls):
         create = '/orga/event/new'

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -169,6 +169,8 @@ class Event(LogMixin, models.Model):
         invite_reviewer = '{review_settings}/add'
         new_room = '{room_settings}/new'
         schedule = '{base}/schedule'
+        schedule_export = '{base}/schedule/export'
+        schedule_export_trigger = '{base}/schedule/export/trigger'
         release_schedule = '{schedule}/release'
         reset_schedule = '{schedule}/reset'
         toggle_schedule = '{schedule}/toggle'

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -13,7 +13,7 @@ from i18nfield.fields import I18nCharField, I18nTextField
 
 from pretalx.common.mixins import LogMixin
 from pretalx.common.models.settings import settings_hierarkey
-from pretalx.common.urls import EventUrls
+from pretalx.common.urls import EventUrls, get_base_url
 
 SLUG_CHARS = 'a-zA-Z0-9.-'
 
@@ -194,6 +194,10 @@ class Event(LogMixin, models.Model):
     def named_locales(self) -> list:
         enabled = set(self.locale_array.split(","))
         return [a for a in settings.LANGUAGES_NATURAL_NAMES if a[0] in enabled]
+
+    @property
+    def html_export_url(self) -> str:
+        return get_base_url(self) + self.urls.html_export
 
     def save(self, *args, **kwargs):
         was_created = not bool(self.pk)

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -139,7 +139,6 @@ class Event(LogMixin, models.Model):
         ical = '{schedule}.ics'
         feed = '{schedule}/feed.xml'
         location = '{schedule}/location'
-        html_export = f'{settings.MEDIA_URL}/{{self.slug}}/schedule_{{self.slug}}.zip'
 
     class orga_urls(EventUrls):
         create = '/orga/event/new'
@@ -171,6 +170,7 @@ class Event(LogMixin, models.Model):
         schedule = '{base}/schedule'
         schedule_export = '{base}/schedule/export'
         schedule_export_trigger = '{base}/schedule/export/trigger'
+        schedule_export_download = '{base}/schedule/export/download'
         release_schedule = '{schedule}/release'
         reset_schedule = '{schedule}/reset'
         toggle_schedule = '{schedule}/toggle'
@@ -199,7 +199,7 @@ class Event(LogMixin, models.Model):
 
     @property
     def html_export_url(self) -> str:
-        return get_base_url(self) + self.urls.html_export
+        return get_base_url(self) + self.orga_urls.schedule_export_download
 
     def save(self, *args, **kwargs):
         was_created = not bool(self.pk)

--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -99,6 +99,11 @@ class EventSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):
         help_text=_('Unset to hide your schedule, e.g. if you want to use the HTML export exclusively.'),
         required=False,
     )
+    export_html_on_schedule_release = forms.BooleanField(
+        label=_('Generate HTML export on schedule release'),
+        help_text=_('Set to make pretalx generate a static HTML version of your schedule, each time a new version is released.'),
+        required=False,
+    )
 
 
 class MailSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):

--- a/src/pretalx/orga/templates/orga/schedule/base.html
+++ b/src/pretalx/orga/templates/orga/schedule/base.html
@@ -1,0 +1,16 @@
+{% extends "orga/base.html" %}
+{% load i18n %}
+{% block content %}
+    <ul class="nav nav-pills">
+      <li class="nav-item">
+          <a
+            class="nav-link {% if "schedule.main" in url_name %}active{% endif %}"
+            href="{{ request.event.orga_urls.schedule }}"
+          >
+            {% trans "Editor" %}
+          </a>
+      </li>
+
+    {% block schedule_content %}
+    {% endblock %}
+{% endblock %}

--- a/src/pretalx/orga/templates/orga/schedule/base.html
+++ b/src/pretalx/orga/templates/orga/schedule/base.html
@@ -10,6 +10,15 @@
             {% trans "Editor" %}
           </a>
       </li>
+      <li class="nav-item">
+        <a
+          class="nav-link {% if "schedule.export" in url_name %}active{% endif %}"
+          href="{{ request.event.orga_urls.schedule_export }}"
+        >
+            {% trans "Export" %}
+        </a>
+      </li>
+    </ul>
 
     {% block schedule_content %}
     {% endblock %}

--- a/src/pretalx/orga/templates/orga/schedule/export.html
+++ b/src/pretalx/orga/templates/orga/schedule/export.html
@@ -11,7 +11,7 @@ release, but you can also trigger that action here.
 {% endblocktrans %}
 </p>
 
-<a href='{{ request.event.urls.html_export }}' class="btn btn-primary">
+<a href='{{ request.event.orga_urls.schedule_export_download }}' class="btn btn-primary">
     <i class="fa fa-download"></i>
     {% trans "Download ZIP" %}
 </a>

--- a/src/pretalx/orga/templates/orga/schedule/export.html
+++ b/src/pretalx/orga/templates/orga/schedule/export.html
@@ -1,0 +1,23 @@
+{% extends "orga/schedule/base.html" %}
+{% load i18n %}
+{% block schedule_content %}
+<legend>Schedule Export</legend>
+
+<p>
+{% blocktrans trimmed %}
+The event schedule can be exported to a static html dump, so you can upload it to a
+normal file-serving webserver like nginx. This is done automatically on schedule
+release, but you can also trigger that action here.
+{% endblocktrans %}
+</p>
+
+<a href='{{ request.event.urls.html_export }}' class="btn btn-primary">
+    <i class="fa fa-download"></i>
+    {% trans "Download ZIP" %}
+</a>
+<a href='{{ request.event.orga_urls.schedule_export_trigger }}' class="btn btn-secondary">
+    <i class="fa fa-refresh"></i>
+    {% trans "Regenerate Export" %}
+</a>
+
+{% endblock %}

--- a/src/pretalx/orga/templates/orga/schedule/export.html
+++ b/src/pretalx/orga/templates/orga/schedule/export.html
@@ -15,9 +15,12 @@ release, but you can also trigger that action here.
     <i class="fa fa-download"></i>
     {% trans "Download ZIP" %}
 </a>
-<a href='{{ request.event.orga_urls.schedule_export_trigger }}' class="btn btn-secondary">
-    <i class="fa fa-refresh"></i>
-    {% trans "Regenerate Export" %}
-</a>
+<form action="{{ request.event.orga_urls.schedule_export_trigger }}" method="POST" class="d-inline-block">
+    {% csrf_token %}
+    <button type="submit" class="btn btn-secondary">
+        <i class="fa fa-refresh"></i>
+        {% trans "Regenerate Export" %}
+    </button>
+</form>
 
 {% endblock %}

--- a/src/pretalx/orga/templates/orga/schedule/index.html
+++ b/src/pretalx/orga/templates/orga/schedule/index.html
@@ -1,4 +1,4 @@
-{% extends "orga/base.html" %}
+{% extends "orga/schedule/base.html" %}
 {% load bootstrap4 %}
 {% load compress %}
 {% load i18n %}
@@ -17,7 +17,7 @@
     {% endcompress %}
 {% endblock %}
 
-{% block content %}
+{% block schedule_content %}
     {% if not request.event.rooms.count %}
         <div class="alert alert-warning schedule-alert">
             {% trans "You can start planning your schedule once you have configured some rooms for talks to take place in." %}

--- a/src/pretalx/orga/templates/orga/settings/form.html
+++ b/src/pretalx/orga/templates/orga/settings/form.html
@@ -29,6 +29,7 @@
         {% bootstrap_field form.custom_css layout='event' %}
         {% bootstrap_field form.logo layout='event' %}
         {% bootstrap_field sform.show_schedule layout='event' %}
+        {% bootstrap_field sform.export_html_on_schedule_release layout='event' %}
 
         <div class="form-group row">
             <div class="ml-auto col-md-9">

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -100,6 +100,8 @@ urlpatterns = [
         url('^settings/rooms/(?P<pk>[0-9]+)/delete$', event.RoomDelete.as_view(), name='settings.rooms.delete'),
 
         url('^schedule/$', schedule.ScheduleView.as_view(), name='schedule.main'),
+        url('^schedule/export$', schedule.ScheduleExportView.as_view(), name='schedule.export'),
+        url('^schedule/export/trigger$', schedule.ScheduleExportTriggerView.as_view(), name='schedule.export.trigger'),
         url('^schedule/release$', schedule.ScheduleReleaseView.as_view(), name='schedule.release'),
         url('^schedule/reset$', schedule.ScheduleResetView.as_view(), name='schedule.reset'),
         url('^schedule/toggle$', schedule.ScheduleToggleView.as_view(), name='schedule.toggle'),

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -102,6 +102,7 @@ urlpatterns = [
         url('^schedule/$', schedule.ScheduleView.as_view(), name='schedule.main'),
         url('^schedule/export$', schedule.ScheduleExportView.as_view(), name='schedule.export'),
         url('^schedule/export/trigger$', schedule.ScheduleExportTriggerView.as_view(), name='schedule.export.trigger'),
+        url('^schedule/export/download$', schedule.ScheduleExportDownloadView.as_view(), name='schedule.export.download'),
         url('^schedule/release$', schedule.ScheduleReleaseView.as_view(), name='schedule.release'),
         url('^schedule/reset$', schedule.ScheduleResetView.as_view(), name='schedule.reset'),
         url('^schedule/toggle$', schedule.ScheduleToggleView.as_view(), name='schedule.toggle'),

--- a/src/pretalx/orga/views/schedule.py
+++ b/src/pretalx/orga/views/schedule.py
@@ -4,14 +4,16 @@ from datetime import timedelta
 
 import dateutil.parser
 from django.contrib import messages
-from django.http import JsonResponse, FileResponse
+from django.http import FileResponse, JsonResponse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import TemplateView, View
 from i18nfield.utils import I18nJSONEncoder
 
+from pretalx.agenda.management.commands.export_schedule_html import (
+    Command as ExportScheduleHtml,
+)
 from pretalx.agenda.tasks import export_schedule_html
-from pretalx.agenda.management.commands.export_schedule_html import Command as ExportScheduleHtml
 from pretalx.common.mixins.views import PermissionRequired
 from pretalx.orga.forms.schedule import ScheduleReleaseForm
 from pretalx.schedule.models import Availability

--- a/src/pretalx/orga/views/schedule.py
+++ b/src/pretalx/orga/views/schedule.py
@@ -47,7 +47,7 @@ class ScheduleExportTriggerView(PermissionRequired, View):
     def get_permission_object(self):
         return self.request.event
 
-    def get(self, request, event):
+    def post(self, request, event):
         export_schedule_html.apply_async(kwargs={'event_id': self.request.event.id})
         messages.success(self.request, _('A new export is beging generated and will be avialiable soon.'))
         return redirect(self.request.event.orga_urls.schedule_export)

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -73,7 +73,8 @@ class Schedule(LogMixin, models.Model):
         with suppress(AttributeError):
             del wip_schedule.event.current_schedule
 
-        export_schedule_html.apply_async(kwargs={'event_id': self.event.id})
+        if self.event.settings.export_html_on_schedule_release:
+            export_schedule_html.apply_async(kwargs={'event_id': self.event.id})
 
         return self, wip_schedule
 

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -9,6 +9,7 @@ from django.utils.functional import cached_property
 from django.utils.timezone import now, override as tzoverride
 from django.utils.translation import override, ugettext_lazy as _
 
+from pretalx.agenda.tasks import export_schedule_html
 from pretalx.common.mixins import LogMixin
 from pretalx.common.urls import EventUrls
 from pretalx.mail.models import QueuedMail
@@ -71,6 +72,8 @@ class Schedule(LogMixin, models.Model):
             del wip_schedule.event.wip_schedule
         with suppress(AttributeError):
             del wip_schedule.event.current_schedule
+
+        export_schedule_html.apply_async(kwargs={'event_id': self.event.id})
 
         return self, wip_schedule
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -54,7 +54,6 @@ def multilingual_event():
     return event
 
 
-
 @pytest.fixture
 def resource(submission):
     f = SimpleUploadedFile('testresource.txt', b'a resource')

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -24,25 +24,35 @@ def template_patch(monkeypatch):
 @pytest.fixture
 def event():
     today = datetime.date.today()
-    return Event.objects.create(
+    event = Event.objects.create(
         name='Fancy testevent', is_public=True, slug='test', email='orga@orga.org',
         date_from=today, date_to=today + datetime.timedelta(days=3)
     )
+    # exporting takes quite some time, so this speeds up our tests
+    event.settings.export_html_on_schedule_release = False
+    return event
 
 
 @pytest.fixture
 def other_event():
-    return Event.objects.create(name='Boring testevent', is_public=True, slug='test2', email='orga2@orga.org',
-                                date_from=datetime.date.today(), date_to=datetime.date.today())
+    event = Event.objects.create(
+        name='Boring testevent', is_public=True, slug='test2', email='orga2@orga.org',
+        date_from=datetime.date.today(), date_to=datetime.date.today()
+    )
+    event.settings.export_html_on_schedule_release = False
+    return event
 
 
 @pytest.fixture
 def multilingual_event():
     today = datetime.date.today()
-    return Event.objects.create(
+    event = Event.objects.create(
         name='Fancy testevent', is_public=True, slug='test2', email='orga@orga.org',
         date_from=today, date_to=today + datetime.timedelta(days=3), locale_array='en,de',
     )
+    event.settings.export_html_on_schedule_release = False
+    return event
+
 
 
 @pytest.fixture

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -84,6 +84,28 @@ def test_html_export_event_unknown():
 
 
 @pytest.mark.django_db
+def test_html_export_release(mocker, event):
+    mocker.patch('django.core.management.call_command')
+
+    event.settings.export_html_on_schedule_release = True
+    event.wip_schedule.freeze(name="ohaio means hello")
+
+    from django.core.management import call_command
+    call_command.assert_called_with('export_schedule_html', event.slug, '--zip')
+
+
+@pytest.mark.django_db
+def test_html_export_release_disabled(mocker, event):
+    mocker.patch('django.core.management.call_command')
+
+    event.settings.export_html_on_schedule_release = False
+    event.wip_schedule.freeze(name="ohaio means hello")
+
+    from django.core.management import call_command
+    call_command.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_html_export_language(event, slot):
     from django.core.management import call_command
     from django.conf import settings

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -103,7 +103,7 @@ def test_html_export(event, other_event, slot, past_slot):
     from django.conf import settings
     import os.path
 
-    call_command('export_schedule_html', event.slug)
+    call_command('export_schedule_html', event.slug, '--zip')
 
     paths = [
         'static/common/img/logo.svg',
@@ -117,6 +117,9 @@ def test_html_export(event, other_event, slot, past_slot):
     for path in paths:
         full_path = os.path.join(settings.HTMLEXPORT_ROOT, 'test', path)
         assert os.path.exists(full_path)
+
+    full_path = os.path.join(settings.HTMLEXPORT_ROOT, 'test.zip')
+    assert os.path.exists(full_path)
 
     assert not os.path.exists(os.path.join(settings.HTMLEXPORT_ROOT, 'test2')), "wrong event exported"
 

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -98,6 +98,28 @@ def test_html_export_language(event, slot):
 
 
 @pytest.mark.django_db
+def test_schedule_export_schedule_html_task(mocker, orga_client, event):
+    mocker.patch('django.core.management.call_command')
+
+    from pretalx.agenda.tasks import export_schedule_html
+    export_schedule_html.apply_async(kwargs={'event_id': event.id})
+
+    from django.core.management import call_command
+    call_command.assert_called_with('export_schedule_html', event.slug, '--zip')
+
+
+@pytest.mark.django_db
+def test_schedule_export_schedule_html_task_nozip(mocker, orga_client, event):
+    mocker.patch('django.core.management.call_command')
+
+    from pretalx.agenda.tasks import export_schedule_html
+    export_schedule_html.apply_async(kwargs={'event_id': event.id, 'make_zip': False})
+
+    from django.core.management import call_command
+    call_command.assert_called_with('export_schedule_html', event.slug)
+
+
+@pytest.mark.django_db
 def test_html_export(event, other_event, slot, past_slot):
     from django.core.management import call_command
     from django.conf import settings

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -120,6 +120,17 @@ def test_schedule_export_schedule_html_task_nozip(mocker, orga_client, event):
 
 
 @pytest.mark.django_db
+def test_schedule_orga_trigger_export(mocker, orga_client, event):
+    from pretalx.agenda.tasks import export_schedule_html
+
+    mocker.patch('pretalx.agenda.tasks.export_schedule_html.apply_async')
+
+    response = orga_client.get(event.orga_urls.schedule_export_trigger, follow=True)
+    assert response.status_code == 200
+    export_schedule_html.apply_async.assert_called_once_with(kwargs={'event_id': event.id})
+
+
+@pytest.mark.django_db
 def test_html_export(event, other_event, slot, past_slot):
     from django.core.management import call_command
     from django.conf import settings

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -153,6 +153,14 @@ def test_schedule_orga_trigger_export(mocker, orga_client, event):
 
 
 @pytest.mark.django_db
+def test_schedule_orga_download_export(mocker, orga_client, event):
+    from pretalx.agenda.tasks import export_schedule_html
+    export_schedule_html.apply_async(kwargs={'event_id': event.id, 'make_zip': True})
+    response = orga_client.get(event.orga_urls.schedule_export_download, follow=True)
+    assert len(b"".join(response.streaming_content)) > 1000000  # 1MB
+
+
+@pytest.mark.django_db
 def test_html_export(event, other_event, slot, past_slot):
     from django.core.management import call_command
     from django.conf import settings

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -93,7 +93,7 @@ def test_html_export_language(event, slot):
     event.save()
     call_command('export_schedule_html', event.slug)
 
-    schedule_html = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule/index.html')).read()
+    schedule_html = open(os.path.join(settings.HTMLEXPORT_ROOT, 'test', 'test/schedule/index.html')).read()
     assert 'Kontakt' in schedule_html
 
 
@@ -115,19 +115,19 @@ def test_html_export(event, other_event, slot, past_slot):
     ]
 
     for path in paths:
-        full_path = os.path.join(settings.HTMLEXPORT_ROOT, path)
+        full_path = os.path.join(settings.HTMLEXPORT_ROOT, 'test', path)
         assert os.path.exists(full_path)
 
     assert not os.path.exists(os.path.join(settings.HTMLEXPORT_ROOT, 'test2')), "wrong event exported"
 
     # views and templates are the same for export and online viewing, so we just need a very basic test here
-    talk_html = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/talk/{past_slot.submission.code}/index.html')).read()
+    talk_html = open(os.path.join(settings.HTMLEXPORT_ROOT, 'test', f'test/talk/{past_slot.submission.code}/index.html')).read()
     assert talk_html.count(past_slot.submission.title) >= 2
 
     speaker = slot.submission.speakers.all()[0]
-    speaker_html = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/speaker/{speaker.code}/index.html')).read()
+    speaker_html = open(os.path.join(settings.HTMLEXPORT_ROOT, 'test', f'test/speaker/{speaker.code}/index.html')).read()
     assert speaker.name in speaker_html
 
-    schedule_html = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule/index.html')).read()
+    schedule_html = open(os.path.join(settings.HTMLEXPORT_ROOT, 'test', f'test/schedule/index.html')).read()
     assert 'Contact us' in schedule_html  # locale
     assert past_slot.submission.title in schedule_html

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -125,7 +125,7 @@ def test_schedule_orga_trigger_export(mocker, orga_client, event):
 
     mocker.patch('pretalx.agenda.tasks.export_schedule_html.apply_async')
 
-    response = orga_client.get(event.orga_urls.schedule_export_trigger, follow=True)
+    response = orga_client.post(event.orga_urls.schedule_export_trigger, follow=True)
     assert response.status_code == 200
     export_schedule_html.apply_async.assert_called_once_with(kwargs={'event_id': event.id})
 

--- a/src/tests/unit/api/test_serializers.py
+++ b/src/tests/unit/api/test_serializers.py
@@ -10,7 +10,7 @@ def test_event_serializer(event):
     data = EventSerializer(event).data
     assert data.keys() == {
         'name', 'slug', 'subtitle', 'is_public', 'date_from', 'date_to',
-        'timezone',
+        'timezone', 'html_export_url',
     }
 
 


### PR DESCRIPTION
Fixes #275 
Refs #277

## How Has This Been Tested?

By frantically clicking around. Real tests will follow.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.

## TODO

- [x] if a schedule is exported before the first version is published, it is publicly accessible. That's probably not smart.
- [x] make ScheduleExportTriggerView only accept POSTs
- [x] add setting to not always export schedule on release
- [x] tests: do not export normally
- [x] tests: add test for html export on schedule release
- [x] make export view in orga pretty
- [x] give the management command the ability to zip export
- [x] test `export_schedule_html` celery task
- [x] make celery task use kwargs, instead of args
- [x] test zipping
- [x] test `ScheduleExportTriggerView`
- [x] fix schedule export tests, as they probably fail now
- [x] test zip download