### PR TITLE
[agenda] add xml, json, ical, xcal export views

### DIFF
--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
         url('^location/$', location.LocationView.as_view(), name='location'),
         url('^talk/(?P<slug>\w+)/$', talk.TalkView.as_view(), name='talk'),
         url('^talk/(?P<slug>\w+)/feedback/$', talk.FeedbackView.as_view(), name='feedback'),
-        url('^talk/(?P<slug>\w+)/ical/$', talk.SingleICalView.as_view(), name='ical'),
+        url('^talk/(?P<slug>\w+).ics$', talk.SingleICalView.as_view(), name='ical'),
         url('^speaker/(?P<code>\w+)/$', speaker.SpeakerView.as_view(), name='speaker'),
     ])),
 ]

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -408,8 +408,13 @@ COMPRESS_CSS_FILTERS = (
 BUILD_DIR = HTMLEXPORT_ROOT
 BAKERY_VIEWS = (
     'pretalx.agenda.views.htmlexport.ExportScheduleView',
+    'pretalx.agenda.views.htmlexport.ExportFrabXmlView',
+    'pretalx.agenda.views.htmlexport.ExportFrabXCalView',
+    'pretalx.agenda.views.htmlexport.ExportFrabJsonView',
+    'pretalx.agenda.views.htmlexport.ExportICalView',
     'pretalx.agenda.views.htmlexport.ExportScheduleVersionsView',
     'pretalx.agenda.views.htmlexport.ExportTalkView',
+    'pretalx.agenda.views.htmlexport.ExportTalkICalView',
     'pretalx.agenda.views.htmlexport.ExportSpeakerView',
 )
 REST_FRAMEWORK = {

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -149,7 +149,7 @@ class Submission(LogMixin, models.Model):
         confirm = '{user_base}/confirm'
         public = '{self.event.urls.base}/talk/{self.code}'
         feedback = '{public}/feedback/'
-        ical = '{public}/ical/'
+        ical = '{public}.ics'
         invite = '{user_base}/invite'
         accept_invitation = '{self.event.urls.base}/invitation/{self.code}/{self.invitation_token}'
 

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -108,10 +108,16 @@ def test_html_export(event, other_event, slot, past_slot):
     paths = [
         'static/common/img/logo.svg',
         'test/schedule/index.html',
+        'test/schedule.json',
+        'test/schedule.xcal',
+        'test/schedule.xml',
+        'test/schedule.ics',
         *[f'test/speaker/{speaker.code}/index.html' for speaker in slot.submission.speakers.all()],
         f'test/talk/{slot.submission.code}/index.html',
+        f'test/talk/{slot.submission.code}.ics',
         *[f'test/speaker/{speaker.code}/index.html' for speaker in past_slot.submission.speakers.all()],
         f'test/talk/{past_slot.submission.code}/index.html',
+        f'test/talk/{past_slot.submission.code}.ics',
     ]
 
     for path in paths:
@@ -131,3 +137,21 @@ def test_html_export(event, other_event, slot, past_slot):
     schedule_html = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule/index.html')).read()
     assert 'Contact us' in schedule_html  # locale
     assert past_slot.submission.title in schedule_html
+
+    schedule_json = json.load(open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule.json')))
+    assert schedule_json['schedule']['conference']['title'] == event.name
+
+    schedule_ics = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule.ics')).read()
+    assert slot.submission.code in schedule_ics
+    assert past_slot.submission.code in schedule_ics
+
+    schedule_xcal = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule.xcal')).read()
+    assert event.slug in schedule_xcal
+    assert speaker.name in schedule_xcal
+
+    schedule_xml = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/schedule.xml')).read()
+    assert slot.submission.title in schedule_xml
+    assert past_slot.submission.code in schedule_xml
+
+    talk_ics = open(os.path.join(settings.HTMLEXPORT_ROOT, f'test/talk/{slot.submission.code}.ics')).read()
+    assert slot.submission.title in talk_ics


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #280 . It does so by …
 
Adding views in src/pretalx/agenda/views/htmlexport.py
  - [x] ical
  - [x] frab xml
  - [x] frab json
  - [x] frab xcal
  - [ ] feed.xml
  - [x] talk ical

 - [x] adding those views to BAKERY_VIEWS in src/pretalx/settings.py

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Hey guys, I had a lot of trouble with feed.xml (BuildableFeed). I was able to generate it but in the wrong place and it broker everything else 😅 I did everything else though. Maybe someone else with more experience in this project can take up the feed.xml.

If all look OK, I will try to add tests. Thanks.



