### PR TITLE
[common] Refs #372 -- Swap priorities of timezone selection

### DIFF
--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -66,7 +66,6 @@ class EventPermissionMiddleware:
                 else:
                     request.is_orga = False
                     request.is_reviewer = False
-                timezone.activate(pytz.timezone(request.event.timezone))
 
         self._set_orga_events(request)
 

--- a/src/pretalx/common/middleware/event.py
+++ b/src/pretalx/common/middleware/event.py
@@ -90,10 +90,10 @@ class EventPermissionMiddleware:
         request.LANGUAGE_CODE = translation.get_language()
 
         with suppress(pytz.UnknownTimeZoneError):
-            if request.user.is_authenticated:
-                tzname = request.user.timezone
-            elif hasattr(request, 'event') and request.event:
+            if hasattr(request, 'event') and request.event:
                 tzname = request.event.timezone
+            elif request.user.is_authenticated:
+                tzname = request.user.timezone
             else:
                 tzname = settings.TIME_ZONE
             timezone.activate(pytz.timezone(tzname))


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR references issue #372. It does so by prioritizing event timezone over user timezone in the backend.

## How Has This Been Tested?

Manually and with a regression test. I'm not sure if it fixes the original problem of #372 as I can't reproduce that one locally.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change is listed in the CHANGELOG.rst if appropriate.
