### PR TITLE
[orga] Avoid duplicate listing of submissions

### DIFF
--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -300,7 +300,7 @@ class SubmissionList(PermissionRequired, Sortable, Filterable, ListView):
         qs = self.request.event.submissions.select_related('submission_type').order_by('-id').all()
         qs = self.filter_queryset(qs)
         qs = self.sort_queryset(qs)
-        return qs
+        return qs.distinct()
 
 
 class FeedbackList(SubmissionViewMixin, ListView):


### PR DESCRIPTION
Submissions with two speakers show up in the submission list twice, but *only* if the the list is filtered (using any of the available filters). This happens because by searching in ``speakers__name__icontains``, Django creates SQL that SELECTs not only from the submission table, but makes a cross product with the speakers table.

In this case, a simple ``distinct()`` is luckily sufficient to fix it.

## How Has This Been Tested?
Manually.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
