### PR TITLE
Fix issues in the talks API

### DIFF
--- a/doc/api/resources/talks.rst
+++ b/doc/api/resources/talks.rst
@@ -4,8 +4,8 @@ Talks
 Resource description
 --------------------
 
-The talk resource is the same as the submission resource, guaranteed to be
-either accepted or confirmed.  It contains the following public fields:
+The talk resource is the same as the submission resource, but will only return talks
+that already have a slot on the current schedule. It contains the following public fields:
 
 .. rst-class:: rest-resource-table
 
@@ -30,7 +30,7 @@ Endpoints
 
 .. http:get:: /api/events/{event}/talks
 
-   Returns a list of all accepted and confirmed submissions the authenticated user/token has access to, or
+   Returns a list of all scheduled submissions the authenticated user/token has access to, or
    all confirmed, publicly scheduled submissions for unauthenticated users.
    For a list of all submissions regardless of their state, authenticated users may choose
    to use the ``/api/events/{event}/submissions`` endpoint instead.

--- a/src/pretalx/api/urls.py
+++ b/src/pretalx/api/urls.py
@@ -9,7 +9,7 @@ default_router.register(r'events', event.EventViewSet)
 
 event_router = routers.DefaultRouter()
 event_router.register(r'submissions', submission.SubmissionViewSet)
-event_router.register(r'talks', submission.SubmissionViewSet)
+event_router.register(r'talks', submission.TalkViewSet)
 event_router.register(r'schedules', submission.ScheduleViewSet)
 event_router.register(r'speakers', speaker.SpeakerViewSet)
 

--- a/src/pretalx/api/views/submission.py
+++ b/src/pretalx/api/views/submission.py
@@ -21,9 +21,14 @@ class SubmissionViewSet(viewsets.ReadOnlyModelViewSet):
             return self.request.event.submissions.filter(slots__in=self.request.event.current_schedule.talks.all())
 
     def get_queryset(self):
+        return self.get_base_queryset() or self.queryset
+
+
+class TalkViewSet(SubmissionViewSet):
+
+    def get_queryset(self):
         qs = self.get_base_queryset() or self.queryset
-        if 'talks' in self.request._request.path:
-            qs = qs.filter(slots__schedule=self.request.event.current_schedule)
+        qs = qs.filter(slots__schedule=self.request.event.current_schedule)
         return qs
 
 

--- a/src/pretalx/api/views/submission.py
+++ b/src/pretalx/api/views/submission.py
@@ -28,6 +28,8 @@ class TalkViewSet(SubmissionViewSet):
 
     def get_queryset(self):
         qs = self.get_base_queryset() or self.queryset
+        if not self.request.event.current_schedule:
+            return qs.none()
         qs = qs.filter(slots__schedule=self.request.event.current_schedule)
         return qs
 

--- a/src/tests/functional/api/test_api_views.py
+++ b/src/tests/functional/api/test_api_views.py
@@ -75,6 +75,14 @@ def test_orga_can_see_all_submissions_even_nonpublic(orga_client, slot, accepted
 
 
 @pytest.mark.django_db
+def test_only_see_talks_when_a_release_exists(orga_client, confirmed_submission, rejected_submission, submission):
+    response = orga_client.get(submission.event.api_urls.talks, follow=True)
+    content = json.loads(response.content.decode())
+    assert response.status_code == 200
+    assert content['count'] == 0
+
+
+@pytest.mark.django_db
 def test_can_only_see_public_talks(client, slot, accepted_submission, rejected_submission, submission):
     response = client.get(submission.event.api_urls.talks, follow=True)
     content = json.loads(response.content.decode())


### PR DESCRIPTION
The behaviour of the talks API was inconsistent with the documentation and inconsistent with between different databases. This PR fixes both inconsistencies.

## How Has This Been Tested?
With a regression test.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
