### PR TITLE
Make all tests run on PostgreSQL

### DIFF
--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -194,6 +194,9 @@ class Event(LogMixin, models.Model):
         schedules = '{base}/schedules'
         speakers = '{base}/speakers'
 
+    class Meta:
+        ordering = ('date_from',)
+
     def __str__(self) -> str:
         return f'Event(slug={self.slug}, date_from={self.date_from.isoformat()})'
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -36,8 +36,9 @@ def event():
 @pytest.fixture
 def other_event():
     event = Event.objects.create(
-        name='Boring testevent', is_public=True, slug='test2', email='orga2@orga.org',
-        date_from=datetime.date.today(), date_to=datetime.date.today()
+        name='Boring testevent', is_public=True, slug='other', email='orga2@orga.org',
+        date_from=datetime.date.today() + datetime.timedelta(days=1),
+        date_to=datetime.date.today() + datetime.timedelta(days=1)
     )
     event.settings.export_html_on_schedule_release = False
     return event

--- a/src/tests/functional/agenda/test_schedule_export.py
+++ b/src/tests/functional/agenda/test_schedule_export.py
@@ -85,10 +85,10 @@ def test_schedule_speaker_ical_export(slot, other_slot, client):
 
 
 @pytest.mark.django_db
-def test_feed_view(slot, client, schedule_schema):
+def test_feed_view(slot, client, schedule_schema, schedule):
     response = client.get(slot.submission.event.urls.feed)
     assert response.status_code == 200
-    assert slot.submission.event.schedules.first().version in response.content.decode()
+    assert schedule.version in response.content.decode()
 
 
 @pytest.mark.django_db

--- a/src/tests/functional/orga/test_frab_import.py
+++ b/src/tests/functional/orga/test_frab_import.py
@@ -16,8 +16,8 @@ def test_frab_import_minimal(superuser):
     assert Room.objects.all()[0].name == 'Volkskundemuseum'
 
     assert TalkSlot.objects.count() == 2
-    assert TalkSlot.objects.all()[0].schedule.version == '1.99b 🍕'
-    assert TalkSlot.objects.all()[1].schedule.version is None
+    assert TalkSlot.objects.order_by('pk')[0].schedule.version == '1.99b 🍕'
+    assert TalkSlot.objects.order_by('pk')[1].schedule.version is None
 
     assert Event.objects.count() == 1
     event = Event.objects.first()

--- a/src/tests/functional/orga/test_schedule.py
+++ b/src/tests/functional/orga/test_schedule.py
@@ -10,8 +10,8 @@ from pretalx.schedule.models import Availability, Schedule, TalkSlot
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures('room', 'room_availability')
-def test_room_list(orga_client, event):
+@pytest.mark.usefixtures('room')
+def test_room_list(orga_client, event, room_availability):
     response = orga_client.get(reverse(f'orga:schedule.api.rooms', kwargs={'event': event.slug}), follow=True)
     content = json.loads(response.content.decode())
     assert response.status_code == 200
@@ -21,7 +21,7 @@ def test_room_list(orga_client, event):
     assert content['end']
     availabilities = content['rooms'][0]['availabilities']
     assert len(availabilities) == 1
-    assert availabilities[0]['id'] == 1
+    assert availabilities[0]['id'] == room_availability.pk
     assert availabilities[0]['start']
     assert availabilities[0]['end']
 
@@ -56,7 +56,7 @@ def test_talk_schedule_api_update(orga_client, event, schedule, slot, room):
     start = now()
     assert slot.start != start
     response = orga_client.patch(
-        reverse(f'orga:schedule.api.update', kwargs={'event': event.slug, 'pk': slot.submission.pk}),
+        reverse(f'orga:schedule.api.update', kwargs={'event': event.slug, 'pk': slot.pk}),
         data=json.dumps({'room': room.pk, 'start': start.isoformat()}),
         follow=True,
     )
@@ -75,7 +75,7 @@ def test_talk_schedule_api_update_reset(orga_client, event, schedule, slot, room
     slot.save()
     assert slot.start
     response = orga_client.patch(
-        reverse(f'orga:schedule.api.update', kwargs={'event': event.slug, 'pk': slot.submission.pk}),
+        reverse(f'orga:schedule.api.update', kwargs={'event': event.slug, 'pk': slot.pk}),
         data=json.dumps(dict()),
         follow=True,
     )


### PR DESCRIPTION
Parts of the test suite currently rely on database quirks like auto-incrementing-columns starting at 1 in every test, natural ordering, etc. These tests fail on PostgreSQL, where those assumptions are not true.

## How Has This Been Tested?
Manually by running the test suite with PostgreSQL. We should make this automatic with #388.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
