### PR TITLE
Fixes on MySQL

### DIFF
--- a/doc/administrator/installation_docker.rst
+++ b/doc/administrator/installation_docker.rst
@@ -43,7 +43,7 @@ Next, we need a database and a database user. We can create these with any kind 
 tool or directly on our database's shell, e.g. for MySQL::
 
     mysql -u root -p
-    mysql> CREATE DATABASE pretalx DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+    mysql> CREATE DATABASE pretalx DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;
     mysql> GRANT ALL PRIVILEGES ON pretalx.* TO pretalx@'localhost' IDENTIFIED BY '*********';
     mysql> FLUSH PRIVILEGES;
 

--- a/doc/administrator/installation_pip.rst
+++ b/doc/administrator/installation_pip.rst
@@ -44,7 +44,7 @@ Having the database server installed, we still need a database and a database us
 of database managing tool or directly on our database's shell, e.g. for MySQL::
 
     $ mysql -u root -p
-    mysql> CREATE DATABASE pretalx DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+    mysql> CREATE DATABASE pretalx DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_general_ci;
     mysql> GRANT ALL PRIVILEGES ON pretalx.* TO pretalx@'localhost' IDENTIFIED BY '*********';
     mysql> FLUSH PRIVILEGES;
 

--- a/src/pretalx/schedule/migrations/0001_initial.py
+++ b/src/pretalx/schedule/migrations/0001_initial.py
@@ -47,7 +47,7 @@ class Migration(migrations.Migration):
             name='Schedule',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('version', models.CharField(blank=True, max_length=200, null=True)),
+                ('version', models.CharField(blank=True, max_length=190, null=True)),
                 ('event', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='schedules', to='event.Event')),
             ],
             bases=(pretalx.common.mixins.LogMixin, models.Model),

--- a/src/pretalx/schedule/migrations/0010_auto_20171001_1358.py
+++ b/src/pretalx/schedule/migrations/0010_auto_20171001_1358.py
@@ -36,6 +36,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='schedule',
             name='version',
-            field=models.CharField(blank=True, max_length=200, null=True, verbose_name='version'),
+            field=models.CharField(blank=True, max_length=190, null=True, verbose_name='version'),
         ),
     ]

--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -24,7 +24,7 @@ class Schedule(LogMixin, models.Model):
         related_name='schedules',
     )
     version = models.CharField(
-        max_length=200,
+        max_length=190,
         null=True, blank=True,
         verbose_name=_('version'),
     )

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -127,6 +127,14 @@ else:
 ## DATABASE SETTINGS
 db_backend = config.get('database', 'backend')
 db_name = config.get('database', 'name', fallback=os.path.join(DATA_DIR, 'db.sqlite3'))
+if db_backend == 'mysql':
+    db_opts = {
+        'charset': 'utf8mb4',
+        'init_command': 'SET storage_engine=INNODB,character_set_connection=utf8mb4,'
+                        'collation_connection=utf8mb4_unicode_ci;'
+    }
+else:
+    db_opts = {}
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.' + db_backend,
@@ -136,6 +144,7 @@ DATABASES = {
         'HOST': config.get('database', 'host'),
         'PORT': config.get('database', 'port'),
         'CONN_MAX_AGE': 0 if db_backend == 'sqlite3' else 120,
+        'OPTIONS': db_opts
     }
 }
 


### PR DESCRIPTION
Schedule.version allows for 200 characters and has a UNIQUE index. However, on MySQL, ~190 characters are at most allowed for indexed fields with 4-byte utf8 support, since 4*190=767 and 767 bytes are their limit for indexed data.

This PR fixes this issue as well as changing the docs to instruct users to use ``utf8mb4`` which fully supports Emojis.

For the tests to pass on MySQL, merging #389 as well is required.

We might want to make the change to settings.py configurable since [converting an existing database](https://mathiasbynens.be/notes/mysql-utf8mb4) isn't trivial and I haven't tested what happens if you run this with a non-mb4 database.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
