### PR TITLE
[doc] update dev setup guide for moved requirements file

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -54,7 +54,7 @@ Working with the code
 The first thing you need are all the main application's dependencies::
 
     (env)$ cd src/
-    (env)$ pip3 install -r requirements/production.txt -r requirements/dev.txt -r requirements/fancy.txt
+    (env)$ pip3 install -r requirements.txt -r requirements/dev.txt -r requirements/fancy.txt
 
 Then, create the local database::
 


### PR DESCRIPTION
7c97891b moved `src/requirements/production.txt` to `src/requirements.txt`.
The development setup instructions do not reflect this change, resulting in an error during dependency installation:
```Could not open requirements file: [Errno 2] No such file or directory: 'requirements/production.txt'```

## How Has This Been Tested?
Updated command runs without error.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.

The other boxes don't apply, IMO.