### PR TITLE
Remove public domains as placeholders in user facing code

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
@@ -29,7 +29,7 @@
                 {% endblocktrans %}
                 {{ submission.display_speaker_names }},
                 <div class="input-group">
-                    <input name="email" class="form-control form-control-sm" placeholder="another.speaker@mail.org">
+                    <input name="email" class="form-control form-control-sm" placeholder="another.speaker@example.org">
                     <span class="input-group-btn">
                         <button class="btn btn-success btn-sm">
                             <i class="fa fa-plus"></i>

--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -93,7 +93,7 @@ class EventSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):
 
     custom_domain = forms.URLField(
         label=_('Custom domain'),
-        help_text=_('Enter a custom domain, such as https://my.event.org'),
+        help_text=_('Enter a custom domain, such as https://my.event.example.org'),
         required=False,
     )
     show_on_dashboard = forms.BooleanField(


### PR DESCRIPTION
This PR changes two user facing placeholders which use domains that are registered by other companies and so shouldn't be used as examples. To solve the problem I changed them to example.org like on other parts of the code.

## How Has This Been Tested?
Not needed.
