### PR TITLE
[orga] don't 404 on speaker profile if speaker's submission has been deleted

### DIFF
--- a/src/pretalx/orga/views/speaker.py
+++ b/src/pretalx/orga/views/speaker.py
@@ -1,5 +1,6 @@
 from csp.decorators import csp_update
 from django.contrib import messages
+from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.decorators import method_decorator
@@ -58,7 +59,11 @@ class SpeakerDetail(PermissionRequired, ActionFromUrl, CreateOrUpdateView):
 
     def get_object(self):
         return get_object_or_404(
-            User.objects.filter(submissions__in=self.request.event.submissions.all()).order_by('id').distinct(),
+            User.objects.filter(
+                Q(submissions__in=self.request.event.submissions.all())
+                |
+                Q(submissions__in=self.request.event.submissions(manager='deleted_objects').all())
+            ).order_by('id').distinct(),
             pk=self.kwargs['pk'],
         )
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -11,7 +11,7 @@ from pretalx.person.models import SpeakerProfile, User
 from pretalx.schedule.models import Availability, Room, TalkSlot
 from pretalx.submission.models import (
     Answer, AnswerOption, Feedback, Question, QuestionVariant,
-    Resource, Review, Submission, SubmissionType,
+    Resource, Review, Submission, SubmissionStates, SubmissionType,
 )
 
 
@@ -406,6 +406,15 @@ def withdrawn_submission(submission_data, speaker):
     sub.save()
     sub.speakers.add(speaker)
     sub.withdraw(force=True)
+    return sub
+
+
+@pytest.fixture
+def deleted_submission(submission_data, other_speaker):
+    submission_data['state'] = SubmissionStates.DELETED
+
+    sub = Submission.objects.create(**submission_data)
+    sub.speakers.add(other_speaker)
     return sub
 
 

--- a/src/tests/functional/orga/test_speaker.py
+++ b/src/tests/functional/orga/test_speaker.py
@@ -24,6 +24,13 @@ def test_reviewer_can_access_speaker_page(review_client, speaker, event, submiss
 
 
 @pytest.mark.django_db
+def test_reviewer_can_access_speaker_page_with_deleted_submission(review_client, other_speaker, event, deleted_submission):
+    response = review_client.get(reverse('orga:speakers.view', kwargs={'event': event.slug, 'pk': other_speaker.pk}), follow=True)
+    assert response.status_code == 200
+    assert other_speaker.name in response.content.decode()
+
+
+@pytest.mark.django_db
 def test_orga_can_edit_speaker(orga_client, speaker, event, submission):
     response = orga_client.post(
         reverse('orga:speakers.view', kwargs={'event': event.slug, 'pk': speaker.pk}),


### PR DESCRIPTION
This PR closes/references issue #442. It does so by showing the speaker's profile even if his only submission has been deleted.

## How Has This Been Tested?
1. Create a submission for a speaker, that didn't have a submission, for example by submitting a new one.
2. For some reason, delete said submission again. You end up with an existing speaker profile, that has 0 submissions.
3. From the list of speakers, click on the speaker's name.
4. Does not 404 and goes to his profile.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Not sure about the formatting of `get_object()` though. 

Also another way of solving this issue would be to not show the speaker with deleted submissions at all. Let me know if this one makes more sense. 