### PR TITLE
[agenda] make schedule available offline with service worker

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -110,4 +110,12 @@
         </div>
     {% endfor %}
 </div>
+
+
+<script>
+  if('serviceWorker' in navigator) {
+    var scope = '/{{ request.event.name }}/schedule/';
+    navigator.serviceWorker.register('/sw.js', {scope: scope})
+  }
+</script>
 {% endblock %}

--- a/src/pretalx/agenda/templates/agenda/sw.js
+++ b/src/pretalx/agenda/templates/agenda/sw.js
@@ -1,0 +1,29 @@
+var cacheName = 'orgaScheduleCache';
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    fetch(event.request)
+      .then(function (response) {
+        // if request is successful, save it in cache
+        var responseToCache = response.clone();
+
+        caches.open(cacheName).then(function (cache) {
+          cache.put(event.request, responseToCache);
+        });
+
+        return response;
+      })
+      .catch(function () {
+        // if request failed, serve the content from cache
+        return fromCache(event.request);
+      })
+  )
+});
+
+function fromCache(request) {
+  return caches.open(cacheName).then(function (cache) {
+    return cache.match(request).then(function (matching) {
+      return matching;
+    })
+  });
+}

--- a/src/pretalx/agenda/urls.py
+++ b/src/pretalx/agenda/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 
 from pretalx.event.models.event import SLUG_CHARS
 
-from .views import feed, schedule, sneakpeek, speaker, talk
+from .views import feed, schedule, sneakpeek, speaker, talk, serviceworker
 
 
 def get_schedule_urls(regex_prefix, name_prefix=""):
@@ -40,4 +40,5 @@ urlpatterns = [
         url('^speaker/(?P<code>\w+)/$', speaker.SpeakerView.as_view(), name='speaker'),
         url('^speaker/(?P<code>\w+)/talks.ics$', speaker.SpeakerTalksIcalView.as_view(), name='speaker.talks.ical'),
     ])),
+    url('^sw.js$', serviceworker.ServiceWorker.as_view(), name='service-worker')
 ]

--- a/src/pretalx/agenda/views/serviceworker.py
+++ b/src/pretalx/agenda/views/serviceworker.py
@@ -1,0 +1,6 @@
+from django.views.generic import TemplateView
+
+
+class ServiceWorker(TemplateView):
+    template_name = 'agenda/sw.js'
+    content_type = 'application/javascript'


### PR DESCRIPTION
This PR closes/references issue #128 . It does so by using service worker with the scope `/<event_name>/schedule/`. 

## How Has This Been Tested?
1. Start the development server.
2. Go to the event schedule page.
3. Switch off the server.
4. Reload the page and see that the schedule page is loaded with no problem even if the server is not started.

Not sure if I put `sw.js` in the right place...