### PR TITLE
Added PrivacyWeek 2018 and EasterHegg 2019 to the list of conferences…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,9 @@ their respective changelogs on GitHub_ or install pretalx via PyPI_.
 
 Previous conferences using pretalx include:
 
+
+- `EasterHegg 2019`_
+- `PrivacyWeek 2018`_
 - `hack.lu 2018`_
 - `DjangoCon 2018`_
 - `OsmoDevCon 2018`_
@@ -91,3 +94,5 @@ to this project.
 .. _DjangoCon Europe 2018: https://2018.djangocontent.eu/hd/schedule/
 .. _hack.lu 2018: https://cfp.hack.lu/hacklu18/
 .. _DjangoCon 2018: https://2018.djangocon.eu
+.. _PrivacyWeek 2018: https://privacyweek.at/
+.. _EasterHegg 2019: https://eh19.easterhegg.eu/


### PR DESCRIPTION
Happily using pretalx!

<!--- Why is this change required? What problem does it solve? -->
Because PrivacyWeek 2018 and EasterHegg 2019 are happy to use pretalx.

## How Has This Been Tested?
n/a

## Screenshots (if appropriate):
n/a
## Checklist
n/a just Marketing.