### PR TITLE
Review Dashboard: Clarify German wording

### DIFF
--- a/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
@@ -3368,7 +3368,7 @@ msgstr "Reviews insgesamt"
 msgid "lonely active reviewer"
 msgid_plural "total active reviewers"
 msgstr[0] "einsamer Reviewer"
-msgstr[1] "Reviewer insgesamt"
+msgstr[1] "aktive Reviewer"
 
 #: pretalx/orga/templates/orga/review/dashboard.html:42
 #, python-format


### PR DESCRIPTION
Currently, the review dashboard shows things like

```
9
Reviewer insgesamt
(13 insgesamt)
```

which doesn't give a way what's the difference between the two numbers.