### PR TITLE
fix crash on go-live page, caused by i18n strings not having a len()

### DIFF
--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -91,9 +91,9 @@ class EventLive(EventSettingsPermission, TemplateView):
         context = super().get_context_data(**kwargs)
         warnings = []
         suggestions = []
-        if not self.request.event.cfp.text or len(self.request.event.cfp.text) < 50:
+        if not self.request.event.cfp.text or len(str(self.request.event.cfp.text)) < 50:
             warnings.append({'text': _('The CfP doesn\'t have a full text yet.'), 'url': self.request.event.cfp.urls.text})
-        if not self.request.event.landing_page_text or len(self.request.event.landing_page_text) < 50:
+        if not self.request.event.landing_page_text or len(str(self.request.event.landing_page_text)) < 50:
             warnings.append({'text': _('The event doesn\'t have a landing page text yet.'), 'url': self.request.event.orga_urls.settings})
         # TODO: test that mails can be sent
         if not self.request.event.submission_types.count() > 1:


### PR DESCRIPTION
The go-live page in master crashes when I open it:

```
TypeError at /orga/event/evt/live
object of type 'LazyI18nString' has no len()

File "/home/luto/c3w/pretalx/src/pretalx/orga/views/event.py" in get_context_data
  94.         if not self.request.event.cfp.text or len(self.request.event.cfp.text) < 50:
```

I am not sure if that page is final and open to contributions yet, so accept or reject this MR at will :)

## How Has This Been Tested?

manually.

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
