### PR TITLE
split admin dashboard into event/organiser list

### DIFF
--- a/src/pretalx/common/mixins/views.py
+++ b/src/pretalx/common/mixins/views.py
@@ -158,13 +158,14 @@ class PermissionRequired(PermissionRequiredMixin):
         result = super().has_permission()
         if not result:
             request = getattr(self, 'request', None)
-            key = f'pretalx_event_access_{request.event.pk}'
-            if request and hasattr(request, 'event') and key in request.session:
-                sparent = SessionStore(request.session.get(key))
-                parentdata = []
-                with suppress(Exception):
-                    parentdata = sparent.load()
-                return 'event_access' in parentdata
+            if request and hasattr(request, 'event'):
+                key = f'pretalx_event_access_{request.event.pk}'
+                if key in request.session:
+                    sparent = SessionStore(request.session.get(key))
+                    parentdata = []
+                    with suppress(Exception):
+                        parentdata = sparent.load()
+                    return 'event_access' in parentdata
         return result
 
     def get_login_url(self):

--- a/src/pretalx/orga/permissions.py
+++ b/src/pretalx/orga/permissions.py
@@ -26,8 +26,18 @@ def can_change_organiser_settings(user, obj):
 
 
 @rules.predicate
+def can_change_any_organiser_settings(user, obj):
+    return user.is_administrator or user.teams.filter(can_change_organiser_settings=True).exists()
+
+
+@rules.predicate
 def can_create_events(user, obj):
     return user.is_administrator or user.teams.filter(can_create_events=True).exists()
+
+
+@rules.predicate
+def can_change_any_event_settings(user, obj):
+    return user.is_administrator or user.get_events_for_permission(can_change_event_settings=True).exists()
 
 
 @rules.predicate
@@ -69,6 +79,8 @@ def is_event_over(user, obj):
 rules.add_perm('orga.view_orga_area', can_change_submissions | is_reviewer)
 rules.add_perm('orga.change_settings', can_change_event_settings)
 rules.add_perm('orga.change_organiser_settings', can_change_organiser_settings)
+rules.add_perm('orga.view_organisers', can_change_any_organiser_settings)
+rules.add_perm('orga.view_events', can_change_any_event_settings | can_create_events)
 rules.add_perm('orga.change_teams', is_administrator | can_change_teams)
 rules.add_perm('orga.view_submission_cards', can_change_submissions)
 rules.add_perm('orga.edit_cfp', can_change_submissions)

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -299,10 +299,18 @@
                 {% endfor %}
             {% endif %}
             {% else %}  {# if request.event #}
+                {% if perms.orga.view_events %}
+                <a class="nav-link {% if request.path == "/orga/event/" %} active{% endif %}" href="/orga/">
+                    <i class="fa fa-calendar-o"></i>
+                    <span>{% trans "Events" %}</span>
+                </a>
+                {% endif %}
+                {% if perms.orga.view_organisers %}
                 <a class="nav-link {% if "/orga/organiser/" in request.path %} active{% endif %}" href="/orga/organiser/">
                     <i class="fa fa-users"></i>
                     <span>{% trans "Organisers" %}</span>
                 </a>
+                {% endif %}
                 {% for nav_element in nav_global %}
                     <a class="nav-link {% if nav_element.active %} active{% endif %}" href="{{ nav_element.url }}">
                         {% if nav_element.icon and "." in nav_element.icon %}

--- a/src/pretalx/orga/templates/orga/event_list.html
+++ b/src/pretalx/orga/templates/orga/event_list.html
@@ -25,14 +25,6 @@
                 </span>
             </a>
         {% endfor %}
-        {% for organiser in organisers %}
-            <a href="{{ organiser.orga_urls.base }}" class="dashboard-block">
-                <h1>{{ organiser.name }}</h1>
-                <span class="dashboard-description">
-                    ({% trans "Organiser" %})
-                </span>
-            </a>
-        {% endfor %}
         {% if can_create_event %}
             <a href="{% url "orga:event.create" %}" class="dashboard-block">
                 <h1><i class="fa fa-plus"></i>{% trans "New event" %}</h1>

--- a/src/pretalx/orga/templates/orga/organiser_list.html
+++ b/src/pretalx/orga/templates/orga/organiser_list.html
@@ -1,0 +1,35 @@
+{% extends "orga/base.html" %}
+{% load bootstrap4 %}
+{% load i18n %}
+{% load rules %}
+
+{% block title %}Organisers{% endblock %}
+
+{% block content %}
+{% has_perm 'orga.change_organiser_settings' request.user None as can_create_organiser %}
+<div class="dashboard-list">
+    {% for organiser in organisers %}
+        <a href="{{ organiser.orga_urls.base }}" class="dashboard-block">
+            <h1>{{ organiser.name }}</h1>
+            <span class="dashboard-description">
+                {% blocktrans count count=organiser.teams.all|length trimmed %}
+                {{ count }} Team
+                {% plural %}
+                {{ count }} Teams
+                {% endblocktrans %}
+            </span>
+        </a>
+    {% endfor %}
+    {% if can_create_organiser %}
+        <a href="{% url "orga:organiser.create" %}" class="dashboard-block">
+            <h1><i class="fa fa-plus"></i>{% trans "New organiser" %}</h1>
+            <span class="dashboard-description">{% trans "Uh, a new organiser?<br>Head over here, please!" %}</span>
+        </a>
+    {% endif %}
+</div>
+{% if not organisers and not can_create_organiser %}
+<div class="alert alert-info">
+    {% trans "There are no organisers you can edit." %}
+</div>
+{% endif %}
+{% endblock %}

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.views.generic.base import RedirectView
 
 from pretalx.event.models.event import SLUG_CHARS
 from pretalx.orga.views import cards
@@ -13,11 +14,12 @@ urlpatterns = [
     url('^login/$', auth.LoginView.as_view(), name='login'),
     url('^logout/$', auth.logout_view, name='logout'),
 
-    url('^$', dashboard.DashboardView.as_view(), name='dashboard'),
+    url('^$', RedirectView.as_view(url='event', permanent=False)),
     url('^me$', event.UserSettings.as_view(), name='user.view'),
     url('^me/subuser$', person.SubuserView.as_view(), name='user.subuser'),
     url('^invitation/(?P<code>\w+)$', event.InvitationView.as_view(), name='invitation.view'),
 
+    url('^organiser/$', dashboard.DashboardOrganiserListView.as_view(), name='organiser.list'),
     url('^organiser/new$', organiser.OrganiserDetail.as_view(), name='organiser.create'),
     url(f'^organiser/(?P<organiser>[{SLUG_CHARS}]+)/', include([
         url('^$', organiser.OrganiserDetail.as_view(), name='organiser.view'),
@@ -31,6 +33,7 @@ urlpatterns = [
 
     url('^event/new/$', event.EventWizard.as_view(), name='event.create'),
 
+    url('^event/$', dashboard.DashboardEventListView.as_view(), name='event.list'),
     url(f'^event/(?P<event>[{SLUG_CHARS}]+)/', include([
         url('^$', dashboard.EventDashboardView.as_view(), name='event.dashboard'),
         url('^live$', event.EventLive.as_view(), name='event.live'),

--- a/src/pretalx/orga/views/auth.py
+++ b/src/pretalx/orga/views/auth.py
@@ -35,7 +35,7 @@ class LoginView(TemplateView):
             return redirect(url + ('?' + params.urlencode() if params else ''))
 
         messages.success(request, phrases.orga.logged_in)
-        return redirect(reverse('orga:dashboard'))
+        return redirect(reverse('orga:event.list'))
 
 
 def logout_view(request: HttpRequest) -> HttpResponseRedirect:

--- a/src/pretalx/orga/views/dashboard.py
+++ b/src/pretalx/orga/views/dashboard.py
@@ -10,8 +10,25 @@ from pretalx.event.stages import get_stages
 from pretalx.submission.models.submission import SubmissionStates
 
 
-class DashboardView(TemplateView):
-    template_name = 'orga/dashboard.html'
+class DashboardEventListView(PermissionRequired, TemplateView):
+    template_name = 'orga/event_list.html'
+    permission_required = 'orga.view_events'
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        now_date = now().date()
+        context['current_orga_events'] = [
+            e for e in self.request.orga_events if e.date_to >= now_date
+        ]
+        context['past_orga_events'] = [
+            e for e in self.request.orga_events if e.date_to < now_date
+        ]
+        return context
+
+
+class DashboardOrganiserListView(PermissionRequired, TemplateView):
+    template_name = 'orga/organiser_list.html'
+    permission_required = 'orga.view_organisers'
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
@@ -24,13 +41,6 @@ class DashboardView(TemplateView):
                     can_change_organiser_settings=True
                 )
             )
-        now_date = now().date()
-        context['current_orga_events'] = [
-            e for e in self.request.orga_events if e.date_to >= now_date
-        ]
-        context['past_orga_events'] = [
-            e for e in self.request.orga_events if e.date_to < now_date
-        ]
         return context
 
 

--- a/src/pretalx/orga/views/person.py
+++ b/src/pretalx/orga/views/person.py
@@ -48,4 +48,4 @@ class SubuserView(View):
         url = urllib.parse.unquote(params.pop('next', [''])[0])
         if url and is_safe_url(url, request.get_host()):
             return redirect(url + ('?' + params.urlencode() if params else ''))
-        return redirect(reverse('orga:dashboard'))
+        return redirect(reverse('orga:event.list'))

--- a/src/tests/functional/orga/test_access.py
+++ b/src/tests/functional/orga/test_access.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 
 @pytest.mark.parametrize('url', [
-    'login', 'logout', 'dashboard', 'user.view',
+    'login', 'logout', 'event.list', 'organiser.list', 'user.view',
 ])
 @pytest.mark.parametrize('logged_in', (True, False))
 @pytest.mark.django_db

--- a/src/tests/functional/orga/test_admin_dashboard.py
+++ b/src/tests/functional/orga/test_admin_dashboard.py
@@ -1,0 +1,54 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.parametrize('test_user', ('orga', 'speaker', 'superuser', 'None'))
+@pytest.mark.django_db
+def test_dashboard_event_list(orga_user, orga_client, speaker, event, other_event, test_user):
+    if test_user == 'speaker':
+        orga_client.force_login(speaker)
+    elif test_user == 'None':
+        orga_client.logout()
+    elif test_user == 'superuser':
+        orga_user.is_administrator = True
+        orga_user.save()
+
+    response = orga_client.get(reverse('orga:event.list'), follow=True)
+
+    if test_user == 'speaker':
+        assert response.status_code == 404, response.status_code
+    elif test_user == 'orga':
+        assert event.slug in response.content.decode()
+        assert other_event.slug not in response.content.decode()
+    elif test_user == 'superuser':
+        assert event.slug in response.content.decode(), response.content.decode()
+        assert other_event.slug in response.content.decode(), response.content.decode()
+    else:
+        current_url = response.redirect_chain[-1][0]
+        assert 'login' in current_url
+
+
+@pytest.mark.parametrize('test_user', ('orga', 'speaker', 'superuser', 'None'))
+@pytest.mark.django_db
+def test_dashboard_event_list(orga_user, orga_client, speaker, event, other_event, test_user):
+    if test_user == 'speaker':
+        orga_client.force_login(speaker)
+    elif test_user == 'None':
+        orga_client.logout()
+    elif test_user == 'superuser':
+        orga_user.is_administrator = True
+        orga_user.save()
+
+    response = orga_client.get(reverse('orga:organiser.list'), follow=True)
+
+    if test_user == 'speaker':
+        assert response.status_code == 404, response.status_code
+    elif test_user == 'orga':
+        assert event.organiser.name in response.content.decode()
+        assert other_event.organiser.name not in response.content.decode()
+    elif test_user == 'superuser':
+        assert event.organiser.name in response.content.decode(), response.content.decode()
+        assert other_event.organiser.name in response.content.decode(), response.content.decode()
+    else:
+        current_url = response.redirect_chain[-1][0]
+        assert 'login' in current_url

--- a/src/tests/functional/orga/test_admin_dashboard.py
+++ b/src/tests/functional/orga/test_admin_dashboard.py
@@ -30,7 +30,7 @@ def test_dashboard_event_list(orga_user, orga_client, speaker, event, other_even
 
 @pytest.mark.parametrize('test_user', ('orga', 'speaker', 'superuser', 'None'))
 @pytest.mark.django_db
-def test_dashboard_event_list(orga_user, orga_client, speaker, event, other_event, test_user):
+def test_dashboard_organiser_list(orga_user, orga_client, speaker, event, other_event, test_user):
     if test_user == 'speaker':
         orga_client.force_login(speaker)
     elif test_user == 'None':

--- a/src/tests/functional/orga/test_auth.py
+++ b/src/tests/functional/orga/test_auth.py
@@ -9,7 +9,7 @@ def test_orga_successful_login(client, user, template_patch):
     user.set_password('testtest')
     user.save()
     response = client.post(reverse('orga:login'), data={'email': user.email, 'password': 'testtest'}, follow=True)
-    assert response.status_code == 200
+    assert response.redirect_chain[-1][0] == '/orga/event/'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The admin dashboard currently shows organisers and events in a single list. The sidebar has a link to "organisers", which 404s.

This splits up the list into an event and an organiser list. The sidebar has been reworked to show links to those lists, each of which is only visible, if the users can actually see or do something there.

## How Has This Been Tested?

Manually and using the supplied tests.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2158203/46262414-3931bc00-c501-11e8-832f-5186cc046a80.png)
![image](https://user-images.githubusercontent.com/2158203/46262416-3b941600-c501-11e8-8910-f2f490f5d94b.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
