### PR TITLE
Changed media directory in example pretalx config to correspond to th…

### DIFF
--- a/src/pretalx.example.cfg
+++ b/src/pretalx.example.cfg
@@ -1,6 +1,6 @@
 [filesystem]
 data = /var/pretalx/data
-media = /var/pretalx/media
+media = /var/pretalx/data/media
 logs = /var/pretalx/data/logs
 
 [site]


### PR DESCRIPTION
…e example nginx config

To fix issue #535: 

<!--- Why is this change required? What problem does it solve? -->
The media directory created and used by nginx in the installation manual differs from the one in the example pretalx config, leading to missing images and mails not being sent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Checked if logo upload and sending mails to reviewers work in the final setup.

<!--- Include details of your testing environment, and the tests you ran to -->
Ubuntu 18.04, virtualenv according to installation manual.

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
