### PR TITLE
Specific version of redis to work with celery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN mkdir /static && \
     pip3 install -U pip setuptools wheel typing && \
     pip3 install -e src/ && \
     pip3 install django-redis pylibmc mysqlclient psycopg2 && \
-    pip3 install gunicorn && \
+    pip3 install gunicorn && \    
+    pip3 install redis==2.10.6 && \
     chmod +x /usr/local/bin/pretalx
 
 RUN mkdir -p /data/logs /data/media


### PR DESCRIPTION
This is needed for using with pretalx-docker due to https://github.com/pretalx/pretalx/issues/534 and https://github.com/celery/celery/issues/5175

## How Has This Been Tested?
Tested by installing it on a server and celeryd no longer crashed
