### PR TITLE
hide avatar-image when no avatar is selected and gravatar is disabled

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`-` Speaker without an avatar and with gravatar disabled had a broken avatar-image in the speaker's view in the orga-backend.
 - :bug:`583` When signing up with an email address with upper case letters included, pretalx only allowed to log in with a lower-cased email address.
 - :bug:`572` People who had only deleted submissions in an event were still shown in the submitter list, which was unexpected and was since fixed.
 - :feature:`-` If only one conference language is available, pretalx doesn't as speakers to choose it from a drop-down, as this behaviour is rather silly.

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -34,17 +34,19 @@
         {% bootstrap_form_errors form %}
         <div class="speaker-info avatar-form">
             <div class="col-md-3 col-form-label">
-                <img
-                  class="avatar float-right"
-                  data-gravatar="{{ form.instance.user.gravatar_parameter }}"
-                  data-avatar="{% if form.instance.user.avatar %}{{ form.instance.user.avatar.url }}{% endif %}"
-                  alt="{% trans "The speaker's profile picture" %}"
-                  {% if form.instance.user.get_gravatar %}
-                  src="https://www.gravatar.com/avatar/{{ form.instance.user.gravatar_parameter }}"
-                  {% elif form.instance.user.avatar and form.instance.user.avatar != 'False' %}
-                  src="{{ form.instance.user.avatar.url }}"
-                  {% endif %}
-                />
+                {% if form.instance.user.has_avatar %}
+                    <img
+                      class="avatar float-right"
+                      data-gravatar="{{ form.instance.user.gravatar_parameter }}"
+                      data-avatar="{% if form.instance.user.avatar %}{{ form.instance.user.avatar.url }}{% endif %}"
+                      alt="{% trans "The speaker's profile picture" %}"
+                      {% if form.instance.user.get_gravatar %}
+                      src="https://www.gravatar.com/avatar/{{ form.instance.user.gravatar_parameter }}"
+                      {% elif form.instance.user.has_local_avatar %}
+                      src="{{ form.instance.user.avatar.url }}"
+                      {% endif %}
+                    />
+                {% endif %}
             </div>
             <div class="avatar-form-fields col-md-9">
                 {% bootstrap_field form.get_gravatar layout='event-inline' %}

--- a/src/pretalx/person/models/user.py
+++ b/src/pretalx/person/models/user.py
@@ -174,6 +174,12 @@ class User(PermissionsMixin, AbstractBaseUser):
     def gravatar_parameter(self):
         return md5(self.email.strip().encode()).hexdigest()
 
+    def has_avatar(self):
+        return self.get_gravatar or self.has_local_avatar()
+
+    def has_local_avatar(self):
+        return self.avatar and self.avatar != 'False'
+
     def get_events_with_any_permission(self):
         from pretalx.event.models import Event
 

--- a/src/pretalx/static/cfp/js/profile.js
+++ b/src/pretalx/static/cfp/js/profile.js
@@ -1,14 +1,23 @@
 ['#id_get_gravatar', '#id_profile-get_gravatar'].forEach((selector) => {
+    var $avatarImg = $('.avatar-form img');
+    var $avatarInput = $('.user-avatar-display');
     $(selector).click(() => {
         if ($(selector).is(':checked')) {
-            $('.user-avatar-display').slideUp();
-            $('.avatar-form img').attr('src', 'https://www.gravatar.com/avatar/' + $('.avatar-form img').attr('data-gravatar'));
+            $avatarInput.slideUp();
+            $avatarImg.css('display', 'block');
+            $avatarImg.attr('src', 'https://www.gravatar.com/avatar/' + $avatarImg.attr('data-gravatar'));
         } else {
-            $('.user-avatar-display').slideDown();
-            $('.avatar-form img').attr('src', $('.avatar-form img').attr('data-avatar'));
+            $avatarInput.slideDown();
+            var local_avatar = $avatarImg.attr('data-avatar');
+            if (local_avatar) {
+                $avatarImg.css('display', 'block');
+                $avatarImg.attr('src', $avatarImg.attr('data-avatar'));
+            } else {
+                $avatarImg.css('display', 'none');
+            }
         }
     })
-})
+});
 if ($('#id_get_gravatar').is(':checked')) {
     $('.user-avatar-display').hide()
 }


### PR DESCRIPTION
When a Speaker does not have an avatar image and Gravatar ist disabled, an empty <img>-Tag without a src-Attributes is generated from the template.

Similar, when the Gravatar-Functionality is deactivated, profile.js tries to reset the Avatar's Image-URL to its original value, which is empty in this case.

This results in the broken-image icon being shown in Chrome.

## How Has This Been Tested?
Scenario 1:
- Create a Submission in the Backend
- Open the Speaker view
- The Avatar-Icon is broken

Scenario 2:
- Enable Gravatar, the Gravatar-Icon is shown
- Save
- Disable Gravatar
- The Avatar-Icon is broken

## Screenshots (if appropriate):
![avatar-img](https://user-images.githubusercontent.com/142237/52346186-5599b400-2a1f-11e9-988e-7b1e84806463.gif)

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change is listed in the CHANGELOG.rst if appropriate.
