### PR TITLE
Always display speaker-image in the same size

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`-` The visual representation of a speaker's avatar is now consistent across all image-sizes and bio-texts.
 - :bug:`583` When signing up with an email address with upper case letters included, pretalx only allowed to log in with a lower-cased email address.
 - :bug:`572` People who had only deleted submissions in an event were still shown in the submitter list, which was unexpected and was since fixed.
 - :feature:`-` If only one conference language is available, pretalx doesn't as speakers to choose it from a drop-down, as this behaviour is rather silly.

--- a/src/pretalx/agenda/templates/agenda/speaker.html
+++ b/src/pretalx/agenda/templates/agenda/speaker.html
@@ -8,23 +8,25 @@
 
 {% block agenda_content %}
 <article>
-<h3>
-    {% blocktrans with event=request.event.name trimmed %}
-    {{ event }} speaker:
-    {% endblocktrans %}
-    {{ speaker.get_display_name }}
-    <div class="buttons float-right">
+<div class="d-flex mb-2">
+    <h3>
+        {% blocktrans with event=request.event.name trimmed %}
+        {{ event }} speaker:
+        {% endblocktrans %}
+        {{ speaker.get_display_name }}
+    </h3>
+    <div class="buttons ml-auto">
         <a class="btn btn-outline-primary" href="{{ profile.urls.talks_ical }}">
             <i class="fa fa-calendar"></i> .ical
         </a>
     </div>
-</h3>
+</div>
 <div class="speaker-container">
     <section class="speaker-info">
         <div class="speaker-bio">
             {{ profile.biography|rich_text }}
         </div>
-        <div class="speaker-info">
+        <div class="speaker-avatar">
             {% if speaker.get_gravatar %}
             <img width="100%" src="https://www.gravatar.com/avatar/{{ speaker.gravatar_parameter }}" alt="{% trans "The speaker's profile picture" %}"/>
             {% elif speaker.avatar %}

--- a/src/pretalx/cfp/templates/cfp/event/cfp.html
+++ b/src/pretalx/cfp/templates/cfp/event/cfp.html
@@ -8,8 +8,10 @@
 {% has_perm 'agenda.view_schedule' request.user request.event as can_view_schedule %}
 {% has_perm 'agenda.view_sneak_peek' request.user request.event as can_view_sneak_peek %}
 {% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
-    {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.text %}{% endif %}
-    <h1>{{ cfp.headline|default:"" }}</h1>
+    <div class="d-flex">
+        <h1>{{ cfp.headline|default:"" }}</h1>
+        {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.text %}{% endif %}
+    </div>
     {{ cfp.text|rich_text }}
     {% if request.event.settings.cfp_show_deadline and request.event.cfp.max_deadline %}
         <p>

--- a/src/pretalx/cfp/templates/cfp/event/submission_info.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_info.html
@@ -5,9 +5,11 @@
 {% load rules %}
 
 {% block inner %}
-    <h2>{% trans "Hey, nice to meet you!" %}</h2>
-    {% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
-    {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.text "information" %}{% endif %}
+    <div class="d-flex">
+        <h2>{% trans "Hey, nice to meet you!" %}</h2>
+        {% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
+        {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.text "information" %}{% endif %}
+    </div>
     <p>
         {% blocktrans trimmed %}
             We're glad that you want to contribute to our event with your submission.

--- a/src/pretalx/cfp/templates/cfp/event/submission_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_profile.html
@@ -17,27 +17,27 @@
     </p>
 
     {% bootstrap_form_errors wizard.form %}
-    <div class="avatar-form">
-        <label class="col-md-3 left-side col-form-label">
+    <div class="avatar-form form-group row">
+        <label class="col-md-3 col-form-label">
             {% trans "Profile picture" %}
-            <br><span class="optional">{% trans "Optional" %}</span>
             <br>
-        <img
-          class="avatar float-right"
-          data-gravatar="{{ gravatar_parameter }}"
-          data-avatar=""
-          alt="{% trans "Your avatar" %}"
-        />
+            <img
+            class="avatar float-right"
+            data-gravatar="{{ gravatar_parameter }}"
+            data-avatar=""
+            alt="{% trans "Your avatar" %}"
+            />
         </label>
-        <div class="avatar-form-fields">
+        <div class="avatar-form-fields col-md-9">
             {% bootstrap_field wizard.form.get_gravatar layout='event-inline' %}
             <div class="user-avatar-display">
                 {% bootstrap_field wizard.form.avatar layout='inline' %}
+                <small class="form-text text-muted d-block">{{ profile_form.avatar.help_text }}</small>
             </div>
         </div>
     </div>
     {% bootstrap_field wizard.form.name layout='event' %}
     {% if wizard.form.biography %}{% bootstrap_field wizard.form.biography layout='event' %}{% endif %}
 
-<script src="{% static "cfp/js/profile.js" %}"></script>
+    <script src="{% static "cfp/js/profile.js" %}"></script>
 {% endblock %}

--- a/src/pretalx/cfp/templates/cfp/event/submission_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_profile.html
@@ -6,9 +6,11 @@
 {% load static %}
 
 {% block inner %}
-    <h2>{% trans "Tell us something about yourself!" %}</h2>
-    {% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
-    {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.text "information" %}{% endif %}
+    <div class="d-flex">
+        <h2>{% trans "Tell us something about yourself!" %}</h2>
+        {% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
+        {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.text "information" %}{% endif %}
+    </div>
     <p>
         {% blocktrans trimmed %}
             This information will be publicly displayed next to your talk - you can always edit

--- a/src/pretalx/cfp/templates/cfp/event/submission_questions.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_questions.html
@@ -5,9 +5,11 @@
 {% load rules %}
 
 {% block inner %}
-{% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
-    {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.questions %}{% endif %}
-    <h2>{% trans "Tell us more!" %}</h2>
+    <div class="d-flex">
+        <h2>{% trans "Tell us more!" %}</h2>
+        {% has_perm 'orga.edit_cfp' request.user request.event as can_edit_cfp %}
+        {% if can_edit_cfp %}{% orga_edit_link request.event.cfp.urls.questions %}{% endif %}
+    </div>
     <p>
         {% blocktrans trimmed with step=wizard.steps.step1 steps=wizard.steps.count %}
             Before we can save your submission, we have some more questions for you.

--- a/src/pretalx/cfp/templates/cfp/event/user_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_profile.html
@@ -34,6 +34,7 @@
                 {% bootstrap_field profile_form.get_gravatar layout='event-inline' %}
                 <div class="user-avatar-display">
                     {% bootstrap_field profile_form.avatar layout='inline' %}
+                    <small class="form-text text-muted d-block">{{ profile_form.avatar.help_text }}</small>
                 </div>
             </div>
         </div>

--- a/src/pretalx/cfp/templates/cfp/event/user_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_profile.html
@@ -13,10 +13,9 @@
     <form method="post" enctype="multipart/form-data" class="speaker-profile-form">
         {% csrf_token %}
         {% bootstrap_form_errors profile_form %}
-        <div class="avatar-form">
-            <label class="col-md-3 col-form-label left-side">
+        <div class="avatar-form form-group row">
+            <label class="col-md-3 col-form-label">
             {% trans "Profile picture" %}
-            <br><span class="optional">{% trans "Optional" %}</span>
             <br>
             <img
               class="avatar float-right"
@@ -30,7 +29,7 @@
               {% endif %}
             />
             </label>
-            <div class="avatar-form-fields">
+            <div class="avatar-form-fields col-md-9">
                 {% bootstrap_field profile_form.get_gravatar layout='event-inline' %}
                 <div class="user-avatar-display">
                     {% bootstrap_field profile_form.avatar layout='inline' %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -32,7 +32,7 @@
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form %}
-        <div class="speaker-info avatar-form">
+        <div class="speaker-info avatar-form form-group row">
             <div class="col-md-3 col-form-label">
                 <img
                   class="avatar float-right"

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -50,6 +50,7 @@
                 {% bootstrap_field form.get_gravatar layout='event-inline' %}
                 <div class="user-avatar-display">
                     {% bootstrap_field form.avatar layout='inline' %}
+                    <small class="form-text text-muted d-block">{{ form.avatar.help_text }}</small>
                 </div>
             </div>
         </div>

--- a/src/pretalx/orga/templatetags/orga_edit_link.py
+++ b/src/pretalx/orga/templatetags/orga_edit_link.py
@@ -9,5 +9,5 @@ register = template.Library()
 def orga_edit_link(url, target=None):
     if target:
         url = f'{url}#{target}'
-    result = f'<a href="{url}" class="btn btn-xs btn-outline-primary orga-edit-link float-right" title="{_("Edit")}"><i class="fa fa-pencil"></i></a>'
+    result = f'<a href="{url}" class="btn btn-xs btn-outline-primary orga-edit-link ml-auto" title="{_("Edit")}"><i class="fa fa-pencil"></i></a>'
     return mark_safe(result)

--- a/src/pretalx/person/models/user.py
+++ b/src/pretalx/person/models/user.py
@@ -93,7 +93,8 @@ class User(PermissionsMixin, AbstractBaseUser):
         null=True,
         blank=True,
         verbose_name=_('Profile picture'),
-        help_text=_('Optional. Will be displayed publicly.'),
+        help_text=_('Optional. Will be displayed publicly. '
+                    'If possible, upload an image that is least 120 Pixels wide.'),
     )
     get_gravatar = models.BooleanField(
         default=False,

--- a/src/pretalx/static/agenda/scss/_speaker.scss
+++ b/src/pretalx/static/agenda/scss/_speaker.scss
@@ -90,6 +90,10 @@
     .speaker-avatar {
       width: 120px;
       margin-left: 8px;
+
+      > img {
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+      }
     }
   }
 

--- a/src/pretalx/static/agenda/scss/_speaker.scss
+++ b/src/pretalx/static/agenda/scss/_speaker.scss
@@ -84,14 +84,12 @@
     flex-direction: row;
 
     .speaker-bio {
-      min-width: 60%;
-      flex-grow: 1;
+      flex: 1;
     }
 
-    .speaker-info {
-      max-width: 320px;
-      display: flex;
-      flex-direction: column;
+    .speaker-avatar {
+      width: 120px;
+      margin-left: 8px;
     }
   }
 

--- a/src/pretalx/static/cfp/scss/_layout.scss
+++ b/src/pretalx/static/cfp/scss/_layout.scss
@@ -111,13 +111,7 @@ footer {
 .avatar-form {
   display: flex;
   align-items: flex-start;
-  margin-left: 20px;
-  padding-bottom: 8px;
 
-  .left-side {
-    margin-left: -20px;
-    margin-right: 20px;
-  }
   img.avatar {
     padding-right: 16px;
     margin-left: -16px;
@@ -129,13 +123,19 @@ footer {
     display: flex;
     flex-direction: column;
 
-    .user-avatar-display .bootstrap4-multi-input {
+    .bootstrap4-multi-input,
+    .bootstrap4-multi-input > .col-12 {
       margin: 0;
+      padding: 0;
     }
 
     .form-group {
       display: flex;
       flex-direction: column;
+    }
+
+    .user-avatar-display .form-group {
+      margin-bottom: 0;
     }
   }
 }

--- a/src/pretalx/static/orga/scss/_layout.scss
+++ b/src/pretalx/static/orga/scss/_layout.scss
@@ -313,7 +313,6 @@ footer {
 .avatar-form {
   display: flex;
   align-items: flex-start;
-  margin-left: 20px;
   padding-bottom: 8px;
 
   img.avatar {
@@ -325,13 +324,19 @@ footer {
     display: flex;
     flex-direction: column;
 
-    .user-avatar-display .bootstrap4-multi-input {
+    .bootstrap4-multi-input,
+    .bootstrap4-multi-input > .col-12 {
       margin: 0;
+      padding: 0;
     }
 
     .form-group {
       display: flex;
       flex-direction: column;
+    }
+
+    .user-avatar-display .form-group {
+      margin-bottom: 0;
     }
   }
 }


### PR DESCRIPTION
The current CSS implementation around the Speaker's avatar is currently slightly sub-optimal. The actual with of the avatar-image is dependent on the original image-with as well as on the bio-text and how it is flowing/wrapped.

This results in a suboptimal and inconsistent presentation for some speakers:
<img width="1175" alt="vorher-1" src="https://user-images.githubusercontent.com/142237/52348630-166e6180-2a25-11e9-83af-1b5ad45b916f.png">
<img width="1162" alt="vorher-2" src="https://user-images.githubusercontent.com/142237/52348631-166e6180-2a25-11e9-8fb4-06081d227334.png">

Furthermore there is no visual space between the speaker's avatar and the Ical-button above it.

This PR changes the CSS for this place, ensuring a consistent width of the avatar-Image, adjusting the bio-text as required.

## How Has This Been Tested?
Setting the Image- and Bio-Texts from the two problematic cases listed above ([Reda Chatar](https://talks.seibert-media.net/summit19/speaker/HHLAUY/) and [Bastian Schmitt](https://talks.seibert-media.net/summit19/speaker/T9RQ3Q/)) results in the presented Effect in Chrome.

## Screenshots (if appropriate):
With this PR applied, the visual representation is consistent across all images and bio-texts and acceptable for all devices:
<img width="1197" alt="bildschirmfoto 2019-02-06 um 15 27 42" src="https://user-images.githubusercontent.com/142237/52348910-b4622c00-2a25-11e9-84bb-3fe2aa4e2bcb.png">
<img width="376" alt="bildschirmfoto 2019-02-06 um 15 27 58" src="https://user-images.githubusercontent.com/142237/52348911-b4fac280-2a25-11e9-9f8c-3aba1f6b310e.png">
<img width="628" alt="bildschirmfoto 2019-02-06 um 15 28 02" src="https://user-images.githubusercontent.com/142237/52348912-b4fac280-2a25-11e9-86d1-8fea0ae79446.png">
<img width="563" alt="bildschirmfoto 2019-02-06 um 15 28 09" src="https://user-images.githubusercontent.com/142237/52348913-b4fac280-2a25-11e9-80e2-0cb969e4d441.png">
<img width="561" alt="bildschirmfoto 2019-02-06 um 15 28 53" src="https://user-images.githubusercontent.com/142237/52348914-b4fac280-2a25-11e9-99a9-f40b16e1a942.png">
<img width="608" alt="bildschirmfoto 2019-02-06 um 15 29 07" src="https://user-images.githubusercontent.com/142237/52348915-b5935900-2a25-11e9-93ce-e1936289007b.png">
<img width="314" alt="bildschirmfoto 2019-02-06 um 15 29 12" src="https://user-images.githubusercontent.com/142237/52348916-b5935900-2a25-11e9-97bf-506a997f4f34.png">
<img width="1174" alt="bildschirmfoto 2019-02-06 um 15 29 19" src="https://user-images.githubusercontent.com/142237/52348917-b5935900-2a25-11e9-931b-8e37c955b2b8.png">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My change is listed in the CHANGELOG.rst if appropriate.
