### PR TITLE
[orga] refactor average_score away

### DIFF
--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -80,7 +80,7 @@
                     });
                     });</script>
         {% endif %}
-        {% if form.instance.average_score != None %}
+        {% if submission.reviews.count %}
         <div class="form-group row">
             <label class="col-md-3 col-form-label">
                 {% trans "Review score" %}

--- a/src/pretalx/orga/templatetags/review_score.py
+++ b/src/pretalx/orga/templatetags/review_score.py
@@ -35,7 +35,7 @@ def _review_score_override(positive_overrides, negative_overrides):
 
 @register.simple_tag(takes_context=True)
 def review_score(context, submission):
-    score = submission.average_score
+    score = submission.avg_score
     positive_overrides = submission.reviews.filter(override_vote=True).count()
     negative_overrides = submission.reviews.filter(override_vote=False).count()
 

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -451,10 +451,6 @@ class Submission(LogMixin, models.Model):
             return template.render(context={'url': self.recording_url})
 
     @property
-    def average_score(self):
-        return self.reviews.all().aggregate(avg=models.Avg('score'))['avg']
-
-    @property
     def active_resources(self):
         return self.resources.filter(resource__isnull=False)
 

--- a/src/tests/unit/submission/test_review_model.py
+++ b/src/tests/unit/submission/test_review_model.py
@@ -4,24 +4,6 @@ from pretalx.submission.models import Review
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('scores,expected', (
-    ([], None),
-    ([None], None),
-    ([None, None], None),
-    ([1], 1),
-    ([1, None], 1),
-    ([1, 2], 1.5),
-    ([1, 2, None], 1.5),
-))
-def test_average_review_score(submission, scores, expected):
-    speaker = submission.speakers.first()
-    reviews = [Review(submission=submission, score=score, user=speaker) for score in scores]
-    Review.objects.bulk_create(reviews)
-    assert submission.average_score == expected
-    submission.reviews.all().delete()
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize('score,override,expected', (
     (0, None, '0'),
     (1, None, '1'),


### PR DESCRIPTION
The submission model has a property called `average_score`, but the queryset
for submissions also returns the average score with a property called `avg_score`.

Unify those two into a single `avg_score` property.

## How Has This Been Tested?

Checked on a local instance if:

 - the average score is still displayed in the reviews dashboard
 - the average score is displayed in the "content" page of a submssion, if there there are any scores

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
