### PR TITLE
Remove superfluous slashes from Exporter URLs

### DIFF
--- a/src/pretalx/common/exporter.py
+++ b/src/pretalx/common/exporter.py
@@ -69,7 +69,7 @@ class BaseExporter:
         Use ``exporter.urls.base.full()`` for the complete URL, taking into
         account the configured event URL, or HTML export URL.
         """
-        base = '/{self.event.urls.export}/{self.quoted_identifier}'
+        base = '{self.event.urls.export}{self.quoted_identifier}'
 
     def get_qrcode(self):
         image = qrcode.make(self.urls.base.full(), image_factory=qrcode.image.svg.SvgImage)


### PR DESCRIPTION
This fixes a bug introduced by commit 497e81c5aa710432a43c26f27c7e74d721997e85.

The first slash is unnecessary because self.event.urls.export starts with a slash. The second slash is unnecessary there is one already. Django fails to route requests with a double slash inside the path (/sotm2019/schedule/export/speakers.csv works but /sotm2019/schedule/export//speakers.csv fails).

The orga/schedule/export view currently contains defect links to the exports.

Current state (rendered HTML):

```html
<h3>Daten-Export</h3>

<ul>
    
    <li>
        <a href="//fossgis2019/schedule/export//speakers.csv">
            
                <i class="fa fa-users"></i>
            
            Vortragenden-CSV
            
        </a>
    </li>
    
    <li>
        <a href="//fossgis2019/schedule/export//schedule.ics">
            
                <i class="fa fa-calendar"></i>
```

With this fix:

```html
<h3>Data Export</h3>

<div class="alert alert-warning">
    You haven't released a schedule yet – many of these data exporters only work on a released schedule.
</div>

<ul>
    
    <li>
        <a href="/sotm2019/schedule/export/speakers.csv">
            
                <i class="fa fa-users"></i>
            
            Speaker CSV
            
        </a>
    </li>
    
    <li>
        <a href="/sotm2019/schedule/export/schedule.ics">
```

This pull request removes the leading slash (only one slash at the beginning remains) and removes one slash after "export" because Django fails to route URLs with a doubled slash as directory separator.

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (see above)
- [ ] My change is listed in the CHANGELOG.rst if appropriate. (I think that this is not necessary)