### PR TITLE
Enable flex-wrap: wrap for search forms and fix margin of submit button

### DIFF
--- a/src/pretalx/static/orga/scss/_layout.scss
+++ b/src/pretalx/static/orga/scss/_layout.scss
@@ -260,6 +260,7 @@ footer {
 
 .search-form {
   display: flex;
+  flex-wrap: wrap;
   margin-bottom: 1rem;
   align-content: center;
 
@@ -280,6 +281,7 @@ footer {
   .btn {
     align-self: flex-start;
     margin-top: 8px;
+    margin-left: 8px;
   }
 }
 


### PR DESCRIPTION
On small screens (my notebook 1366x768 px), the search form of the submission and review list is too wide. The form is a flexbox but without `flex-wrap: wrap`. It looks like this:

![master](https://user-images.githubusercontent.com/3611273/53698622-98149d80-3ddf-11e9-9869-10a41ab42ebe.png)

This pull request enables `flex-wrap: wrap` and sets `margin-left` of the submit button on same value as the form fields.

The changes affect the following templates:

```sh
[michael@michael-probook pretalx]$ grep -n search-form `find -type f -name "*.html"`
./src/pretalx/orga/templates/orga/submission/list.html:49:        <form class="search-form">
./src/pretalx/orga/templates/orga/review/dashboard.html:80:    <form class="search-form">
./src/pretalx/orga/templates/orga/speaker/list.html:17:        <form class="search-form">
./src/pretalx/common/templates/common/search_form.html:4:<form class="search-form">
./doc/_themes/pretalx_theme/searchbox.html:3:  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">

[michael@michael-probook pretalx]$ grep -rn search_form `find -type f -name "*.html"`
./.env/lib/python3.7/site-packages/django/contrib/admin/templates/admin/change_list.html:56:      {% block search %}{% search_form cl %}{% endblock %}
./src/pretalx/orga/templates/orga/mails/sent_list.html:11:    {% include "common/search_form.html" %}
./src/pretalx/orga/templates/orga/mails/outbox_list.html:18:            {% include "common/search_form.html" %}
./src/pretalx/orga/templates/orga/submission/list.html:50:            {% bootstrap_form search_form %}
./src/pretalx/orga/templates/orga/review/dashboard.html:81:        {% bootstrap_form search_form %}
./src/pretalx/orga/templates/orga/speaker/list.html:18:            {% bootstrap_form search_form %}
./src/pretalx/common/templates/common/search_form.html:5:    {% bootstrap_form search_form %}
```

Submission, review and speakers list will benefit from this change. The list views for sent emails and the outbox will slightly change. The padding between the input field and the search button increases by a few pixels.

After change:

![search-form-wrap](https://user-images.githubusercontent.com/3611273/53698730-fee68680-3de0-11e9-819b-09f882321823.png)



- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
