### PR TITLE
Filter by track

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`609` Filter submissions and reviews by track.
 - :bug:`-` Changing the order of rooms made the schedule break.
 - :feature:`433` Organisers can now view all reviews, except for their own submissions.
 - :feature:`589` Before setting a new custom domain for an event, pretalx now checks if the domain has any nameserver records.

--- a/src/pretalx/orga/templates/orga/review/dashboard.html
+++ b/src/pretalx/orga/templates/orga/review/dashboard.html
@@ -81,6 +81,9 @@
         {% bootstrap_form search_form %}
         {% bootstrap_field filter_form.submission_type %}
         {% bootstrap_field filter_form.state layout='inline' %}
+        {% if request.event.settings.use_tracks %}
+            {% bootstrap_field filter_form.track %}
+        {% endif %}
         <button class="btn btn-success" type="submit">{% trans "Search" %}</button>
     </form>
 </div>

--- a/src/pretalx/orga/templates/orga/submission/list.html
+++ b/src/pretalx/orga/templates/orga/submission/list.html
@@ -50,6 +50,9 @@
             {% bootstrap_form search_form %}
             {% bootstrap_field filter_form.submission_type %}
             {% bootstrap_field filter_form.state layout='inline' %}
+            {% if request.event.settings.use_tracks %}
+                {% bootstrap_field filter_form.track %}
+            {% endif %}
             <button class="btn btn-success" type="submit">{% trans "Search" %}</button>
         </form>
         {% if can_create_submission %}

--- a/src/pretalx/orga/views/review.py
+++ b/src/pretalx/orga/views/review.py
@@ -27,7 +27,7 @@ class ReviewDashboard(EventPermissionRequired, Filterable, ListView):
         'speakers__name__icontains',
         'title__icontains',
     )
-    filter_fields = ('submission_type', 'state')
+    filter_fields = ('submission_type', 'state', 'track')
 
     def get_filter_form(self):
         return SubmissionFilterForm(

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -403,7 +403,7 @@ class SubmissionList(EventPermissionRequired, Sortable, Filterable, ListView):
     context_object_name = 'submissions'
     template_name = 'orga/submission/list.html'
     default_filters = {'code__icontains', 'title__icontains'}
-    filter_fields = ('submission_type', 'state')
+    filter_fields = ('submission_type', 'state', 'track')
     filter_form_class = SubmissionFilterForm
     sortable_fields = ('code', 'title', 'state', 'is_featured')
     permission_required = 'orga.view_submissions'

--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -126,6 +126,9 @@ class SubmissionFilterForm(forms.Form):
     submission_type = forms.MultipleChoiceField(
         required=False, widget=CheckboxMultiDropdown
     )
+    track = forms.MultipleChoiceField(
+        required=False, widget=CheckboxMultiDropdown
+    )
 
     def __init__(self, event, *args, **kwargs):
         self.event = event
@@ -137,6 +140,11 @@ class SubmissionFilterForm(forms.Form):
         type_count = (
             lambda x: event.submissions(manager='all_objects')
             .filter(submission_type=x)  # noqa
+            .count()
+        )
+        track_count = (
+            lambda x: event.submissions(manager='all_objects')
+            .filter(track=x) #noqa
             .count()
         )
         self.fields['submission_type'].choices = [
@@ -157,3 +165,8 @@ class SubmissionFilterForm(forms.Form):
             for choice in usable_states
         ]
         self.fields['state'].widget.attrs['title'] = _('Submission states')
+        self.fields['track'].choices = [
+            (track.pk, f'{track.name} ({track_count(track.pk)})')
+            for track in event.tracks.all()
+        ]
+        self.fields['track'].widget.attrs['title'] = _('Tracks')


### PR DESCRIPTION
This pull request enables organisers to filter submissions by track – both in the submission and the review list view. It is a good idea to merge #608 or apply a similar fix to because this pull request increases the width of the form.

I know that review teams can be configured to only see their tracks but why not add another filter in the frontend?

## How Has This Been Tested?

Python 3.7, Firefox 65

## Screenshots (if appropriate):
![filter-by-open](https://user-images.githubusercontent.com/3611273/53698813-f6db1680-3de1-11e9-90ab-08e8383f628d.png)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change is listed in the CHANGELOG.rst if appropriate.
