### PR TITLE
[common] do not pass a ['list'] to mail server for reply-to

### DIFF
--- a/src/pretalx/common/mail.py
+++ b/src/pretalx/common/mail.py
@@ -92,14 +92,14 @@ def mail_send_task(
     headers: dict = None,
 ):
     headers = headers or dict()
+    if reply_to and isinstance(reply_to, str):
+        reply_to = reply_to.split(',')
     if event:
         event = Event.objects.filter(id=event).first()
     if event:
         sender = event.settings.get('mail_from')
         if sender == 'noreply@example.org' or not sender:
             sender = settings.MAIL_FROM
-        if reply_to:
-            headers['reply-to'] = reply_to.split(',') if isinstance(reply_to, str) else reply_to
         backend = event.get_mail_backend()
         sender = formataddr((str(event.name), sender))
     else:
@@ -107,7 +107,7 @@ def mail_send_task(
         backend = get_connection(fail_silently=False)
 
     email = EmailMultiAlternatives(
-        subject, body, sender, to=to, cc=cc, bcc=bcc, headers=headers
+        subject, body, sender, to=to, cc=cc, bcc=bcc, headers=headers, reply_to=reply_to
     )
 
     if html is not None:

--- a/src/pretalx/common/mail.py
+++ b/src/pretalx/common/mail.py
@@ -99,7 +99,7 @@ def mail_send_task(
     if event:
         sender = event.settings.get('mail_from')
         if sender == 'noreply@example.org' or not sender:
-            sender = settings.MAIL_FROM
+            sender = event.email
         backend = event.get_mail_backend()
         sender = formataddr((str(event.name), sender))
     else:


### PR DESCRIPTION
values passed to headers['reply-to'] are not processed in any way and
thus end up in the actual headers just as they are. in the end the
client ends up with a header like:
```
reply-to: ['orga@event.com']
```
which confuses it.

using the reply_to parameter of djangos mail class correctly joins the
python list into a parsable list:

```
Reply-To: orga@event.com, someone@else.com
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
