### PR TITLE
[orga] Allow hiding of notes to organiser

### DIFF
--- a/src/pretalx/event/forms.py
+++ b/src/pretalx/event/forms.py
@@ -242,6 +242,7 @@ class ReviewPhaseForm(I18nModelForm):
         fields = [
             'name', 'start', 'end',
             'can_review',
+            'can_see_notes_to_organiser',
             'can_see_speaker_names',
             'can_change_submission_state',
             'can_see_other_reviews',

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -385,6 +385,7 @@ class Event(LogMixin, models.Model):
                 position=0,
                 can_review=True,
                 can_see_other_reviews='after_review',
+                can_see_notes_to_organiser=False,
                 can_see_speaker_names=True,
                 can_change_submission_state=False,
             )
@@ -395,6 +396,7 @@ class Event(LogMixin, models.Model):
                 position=1,
                 can_review=False,
                 can_see_other_reviews='always',
+                can_see_notes_to_organiser=True,
                 can_see_speaker_names=True,
                 can_change_submission_state=True,
             )
@@ -519,6 +521,7 @@ class Event(LogMixin, models.Model):
 
                 can_review=True,
                 can_see_other_reviews='after_review',
+                can_see_notes_to_organiser=False,
                 can_see_speaker_names=True,
                 can_change_submission_state=False,
             )

--- a/src/pretalx/orga/permissions.py
+++ b/src/pretalx/orga/permissions.py
@@ -86,6 +86,12 @@ def is_event_over(user, obj):
 
 
 @rules.predicate
+def can_view_notes_to_organiser(user, obj):
+    event = obj.event
+    return event.active_review_phase and event.active_review_phase.can_see_notes_to_organiser
+
+
+@rules.predicate
 def can_view_speaker_names(user, obj):
     event = obj.event
     return event.active_review_phase and event.active_review_phase.can_see_speaker_names
@@ -125,6 +131,7 @@ rules.add_perm('orga.edit_schedule', can_change_submissions)
 rules.add_perm('orga.schedule_talk', can_change_submissions)
 rules.add_perm('orga.view_room', can_change_submissions)
 rules.add_perm('orga.edit_room', can_change_submissions)
+rules.add_perm('orga.view_notes', can_change_submissions | (is_reviewer & can_view_notes_to_organiser))
 rules.add_perm('orga.view_speakers', can_change_submissions | (is_reviewer & can_view_speaker_names))
 rules.add_perm('orga.view_speaker', can_change_submissions | (is_reviewer & can_view_speaker_names))
 rules.add_perm('orga.change_speaker', can_change_submissions)

--- a/src/pretalx/orga/templates/orga/submission/review.html
+++ b/src/pretalx/orga/templates/orga/submission/review.html
@@ -5,6 +5,7 @@
 {% load rules %}
 
 {% block submission_content %}
+{% has_perm 'orga.view_notes' request.user request.event as can_view_notes_to_organiser %}
 {% has_perm 'orga.view_speakers' request.user request.event as can_view_speakers %}
 {% has_perm 'orga.view_reviews' request.user submission as can_view_other_reviews %}
 {% if request.user in submission.speakers.all %}
@@ -69,7 +70,7 @@
         </div>
     </div>
     {% endif %}
-    {% if request.event.settings.cfp_request_notes %}
+    {% if can_view_notes_to_organiser and request.event.settings.cfp_request_notes %}
     <div class="form-group row">
         <label class="col-md-3 col-form-label" for="id_text">{% trans "Notes" %}</label>
         <div class="col-md-9 mt-1">

--- a/src/pretalx/submission/models/review.py
+++ b/src/pretalx/submission/models/review.py
@@ -93,6 +93,10 @@ class ReviewPhase(models.Model):
         verbose_name=_('Reviewers can see speaker names'),
         default=True,
     )
+    can_see_notes_to_organiser = models.BooleanField(
+        verbose_name=_('Reviewers can see notes to organiser'),
+        default=False,
+    )
     can_change_submission_state = models.BooleanField(
         verbose_name=_('Reviewers can accept and reject submissions'),
         default=False,


### PR DESCRIPTION
It's now possible to hide the notes to organiser in the review phases.
Those comments might uncover details that are meant for the organiser
and not for the reviewer.

## How Has This Been Tested?

Tested manually within the dev environment. Checked if a user with "is reviewer" permissions can see/cannot see the notes.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
