### PR TITLE
Do not consider empty strings in core module configuration

### DIFF
--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -82,7 +82,8 @@ for entry_point in iter_entry_points(group='pretalx.plugin', name=None):
     PLUGINS.append(entry_point.module_name)
     INSTALLED_APPS.append(entry_point.module_name)
 
-CORE_MODULES = LOCAL_APPS + config.get('site', 'core_modules').split(',')
+CORE_MODULES = LOCAL_APPS + [module for module in config.get('site', 'core_modules').split(',') if module]
+
 
 ## URL SETTINGS
 SITE_URL = config.get('site', 'url', fallback='http://localhost')

--- a/src/tests/common/test_common_signals.py
+++ b/src/tests/common/test_common_signals.py
@@ -1,15 +1,9 @@
-import os
-
 import pytest
 from tests.dummy_signals import footer_link, footer_link_test
 
 from pretalx.common.signals import EventPluginSignal, _populate_app_cache
 
 
-@pytest.mark.skipif(
-    ("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true") or ("CI" in os.environ and os.environ["CI"] == "true"),
-    reason="Skipping this test on Travis CI, as it breaks for unexplainable reasons."
-)
 @pytest.mark.django_db
 def test_is_plugin_active(event):
     _populate_app_cache()


### PR DESCRIPTION
While working on a different patch, I had a local test failure on a test that is already skipped on Travis. I found the root cause and fixed it :)

## How Has This Been Tested?
A test that previously failed now passes.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
