### PR TITLE
Speed up tests by 50% by not compiling SCSS and caching templates

### DIFF
--- a/src/pretalx/common/settings/test_settings.py
+++ b/src/pretalx/common/settings/test_settings.py
@@ -30,6 +30,12 @@ MAIL_FROM = 'orga@orga.org'
 COMPRESS_ENABLED = COMPRESS_OFFLINE = False
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
+COMPRESS_PRECOMPILERS_ORIGINAL = COMPRESS_PRECOMPILERS  # NOQA
+COMPRESS_PRECOMPILERS = ()  # NOQA
+TEMPLATES[0]['OPTIONS']['loaders'] = (  # NOQA
+    ('django.template.loaders.cached.Loader', template_loaders),  # NOQA
+)
+
 DEBUG = True
 DEBUG_PROPAGATE_EXCEPTIONS = True
 

--- a/src/tests/common/test_common_css.py
+++ b/src/tests/common/test_common_css.py
@@ -1,5 +1,7 @@
 import pytest
+from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 
 from pretalx.common.css import validate_css
 from pretalx.event.models import Event
@@ -58,6 +60,7 @@ def test_invalid_css(invalid_css):
 
 
 @pytest.mark.django_db
+@override_settings(COMPRESS_PRECOMPILERS=settings.COMPRESS_PRECOMPILERS_ORIGINAL)
 def test_regenerate_css(event):
     from pretalx.common.tasks import regenerate_css
 


### PR DESCRIPTION
When working on pretix, I found this speed-up opportunity and thought you might like it too :) On my machine, it gets the pretalx test suite down from around 100 seconds to around 45 seconds, which I think is quite impressive.

The two optimizations are:

* Cache templates in memory during a test run
* Do not compile SCSS during testing

The second is the major speed gain, but of course has the downside of, well, SCSS not being compiled. It would be easily possible to implement caching instead of just disabling it during tests, but I don't think its worth it, since any compilation errors in the SCSS codebase will be found by the ``rebuild`` command that is already run on CI.

## How Has This Been Tested?
With the test suite.
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
