### PR TITLE
[mail] Fix migration

### DIFF
--- a/src/pretalx/mail/migrations/0006_populate_mail_users.py
+++ b/src/pretalx/mail/migrations/0006_populate_mail_users.py
@@ -14,8 +14,7 @@ def populate_to_users(apps, schema_editor):
     for mail in QueuedMail.objects.all():
         addresses = (mail.to or '').split(',')
         for address in addresses:
-            address = address.strip().lower()
-            if not address:
+            if not address.strip():
                 continue
             user = user_lookup.get(address.strip().lower())
             if user:


### PR DESCRIPTION
The migration might fail if an email address is not all lowercase.

The problem is that the address gets lowercasesed first and if there
is a user with this email address, then it is removed from the list
of addresses. But that removal expects the original address and not
the lowecases one.

## How Has This Been Tested?

I've run it locally on an instance where the migration was failing and now it passes.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
