### PR TITLE
Speaker ical export fails on missing room

### DIFF
--- a/src/pretalx/schedule/models/slot.py
+++ b/src/pretalx/schedule/models/slot.py
@@ -135,7 +135,8 @@ class TalkSlot(LogMixin, models.Model):
             'summary'
         ).value = f'{self.submission.title} - {self.submission.display_speaker_names}'
         vevent.add('dtstamp').value = creation_time
-        vevent.add('location').value = str(self.room.name)
+        if self.room:
+            vevent.add('location').value = str(self.room.name)
         vevent.add('uid').value = 'pretalx-{}-{}@{}'.format(
             self.submission.event.slug, self.submission.code, netloc
         )


### PR DESCRIPTION
If a slot is not assigned to a room, this problem is going to occur.
Recognized because an exception was thrown in production. Excerpt:

> Internal Server Error: /glt19/speaker/VXNRDD/talks.ics
>
> AttributeError at /glt19/speaker/VXNRDD/talks.ics
> 'NoneType' object has no attribute 'name'
>
> Request Method: GET
> Request URL: http://pretalx.linuxtage.at/glt19/speaker/VXNRDD/talks.ics
> Django Version: 2.1.4
> Python Executable: /usr/bin/python3
> Python Version: 3.7.3
>
> […]
>
> File "/var/pretalx/.local/lib/python3.7/site-packages/pretalx/agenda/views/speaker.py" in get
>   58.             slot.build_ical(cal)
>
> File "/var/pretalx/.local/lib/python3.7/site-packages/pretalx/schedule/models/slot.py" in build_ical
>   136.         vevent.add('location').value = str(self.room.name)
>
> Exception Type: AttributeError at /glt19/speaker/VXNRDD/talks.ics
> Exception Value: 'NoneType' object has no attribute 'name'

## How Has This Been Tested?
Untested. Sorry, I don't have a non-production pretalx running at this point. Not reproducible at production (because slot was spacially assigned)

## Checklist

- [ ] My code follows the code style of this project (but pylint does not complain).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
