### PR TITLE
[common] allow users/orga to upload SVGs

### DIFF
--- a/src/pretalx/common/forms/fields.py
+++ b/src/pretalx/common/forms/fields.py
@@ -8,7 +8,7 @@ from pretalx.common.forms.widgets import (
     ClearableBasenameFileInput, PasswordConfirmationInput, PasswordStrengthInput,
 )
 
-IMAGE_EXTENSIONS = (".png", ".jpg", ".gif", ".jpeg")
+IMAGE_EXTENSIONS = (".png", ".jpg", ".gif", ".jpeg", ".svg")
 
 
 class GlobalValidator:


### PR DESCRIPTION
pretalx allowed SVGs as Event header image in the past, but currently doesn't. I'm not sure if this change was intentional, so you're now reading this PR instead of a commit in master :)

## How Has This Been Tested?

in production :)

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
