### PR TITLE
docs: make sure the pretalx-worker is properly installed

### DIFF
--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -154,7 +154,7 @@ named ``/etc/systemd/system/pretalx-web.service`` with the following content::
     [Install]
     WantedBy=multi-user.target
 
-For asynchronous execution of long-running tasks via Celery, such as outgoing mail),
+For asynchronous execution of long-running tasks via Celery (such as outgoing mail),
 you'll also need a second service ``/etc/systemd/system/pretalx-worker.service``
 with the following content::
 

--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -154,9 +154,9 @@ named ``/etc/systemd/system/pretalx-web.service`` with the following content::
     [Install]
     WantedBy=multi-user.target
 
-If you decide to use Celery (giving you asynchronous execution for long-running
-tasks), you'll also need a second service
-``/etc/systemd/system/pretalx-worker.service`` with the following content::
+For asynchronous execution of long-running tasks via Celery, such as outgoing mail),
+you'll also need a second service ``/etc/systemd/system/pretalx-worker.service``
+with the following content::
 
     [Unit]
     Description=pretalx background worker
@@ -235,8 +235,8 @@ You can make sure the web interface is up and look for any issues with::
 
     # journalctl -u pretalx-web
 
-If you use Celery, you can do the same for the worker processes (for example in
-case the emails are not sent)::
+For the Celery worker you can do the same for the worker processes (for example in
+case outgoing mails are not sent)::
 
     # journalctl -u pretalx-worker
 


### PR DESCRIPTION
This makes using Celery not an optional "if you decide to" but, as the installation is otherwise not working out of the box, a requirement.

If this is actually optional and advanced users can use pretalx without, I would recommend splitting optional things into a separate document for those users.

This PR references issue https://github.com/pretalx/pretalx/issues/680

## How Has This Been Tested?
Not tested from scratch. Based on my installation on Ubuntu 18.04 today.

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
