### PR TITLE
Restructure code

### DIFF
--- a/src/pretalx/event/actions.py
+++ b/src/pretalx/event/actions.py
@@ -1,0 +1,65 @@
+from dateutil.relativedelta import relativedelta
+from django.db import transaction
+from django.utils.timezone import now
+from django.utils.translation import ugettext_lazy as _
+
+from pretalx.event.models import Event
+from pretalx.mail.default_templates import (
+    ACCEPT_TEXT, ACK_TEXT, GENERIC_SUBJECT, QUESTION_SUBJECT,
+    QUESTION_TEXT, REJECT_TEXT, UPDATE_SUBJECT, UPDATE_TEXT,
+)
+from pretalx.mail.models import MailTemplate
+from pretalx.schedule.models import Schedule
+from pretalx.submission.models import CfP, ReviewPhase, SubmissionType
+
+
+@transaction.atomic
+def build_initial_data(event: Event):
+    """Builds all required related data for an event.
+
+    Generates mail templates, CfP, review phases, and a default submission
+    type."""
+    if not hasattr(event, "cfp"):
+        sub_type = SubmissionType.objects.filter(event=event).first()
+        if not sub_type:
+            sub_type = SubmissionType.objects.create(event=event, name="Talk")
+        CfP.objects.create(event=event, default_type=sub_type)
+
+    Schedule.objects.get_or_create(event=event, version=None)
+    event.accept_template = event.accept_template or MailTemplate.objects.create(
+        event=event, subject=GENERIC_SUBJECT, text=ACCEPT_TEXT
+    )
+    event.ack_template = event.ack_template or MailTemplate.objects.create(
+        event=event, subject=GENERIC_SUBJECT, text=ACK_TEXT
+    )
+    event.reject_template = event.reject_template or MailTemplate.objects.create(
+        event=event, subject=GENERIC_SUBJECT, text=REJECT_TEXT
+    )
+    event.update_template = event.update_template or MailTemplate.objects.create(
+        event=event, subject=UPDATE_SUBJECT, text=UPDATE_TEXT
+    )
+    event.question_template = event.question_template or MailTemplate.objects.create(
+        event=event, subject=QUESTION_SUBJECT, text=QUESTION_TEXT
+    )
+
+    if not event.review_phases.all().exists():
+        cfp_deadline = event.cfp.deadline
+        r = ReviewPhase.objects.create(
+            event=event,
+            name=_("Review"),
+            start=cfp_deadline,
+            end=event.datetime_from - relativedelta(months=-3),
+            is_active=bool(not cfp_deadline or cfp_deadline < now()),
+            position=0,
+        )
+        ReviewPhase.objects.create(
+            event=event,
+            name=_("Selection"),
+            start=r.end,
+            is_active=False,
+            position=1,
+            can_review=False,
+            can_see_other_reviews="always",
+            can_change_submission_state=True,
+        )
+    event.save()

--- a/src/pretalx/event/actions.py
+++ b/src/pretalx/event/actions.py
@@ -4,7 +4,7 @@ from django.utils.timezone import now
 from django.utils.translation import ugettext_lazy as _
 
 from pretalx.common.models import ActivityLog
-from pretalx.event.models import Event
+from pretalx.event.models import Event, Organiser
 from pretalx.mail.default_templates import (
     ACCEPT_TEXT, ACK_TEXT, GENERIC_SUBJECT, QUESTION_SUBJECT,
     QUESTION_TEXT, REJECT_TEXT, UPDATE_SUBJECT, UPDATE_TEXT,
@@ -146,3 +146,12 @@ def shred_event(event: Event):
     delete_mail_templates(event)
     for entry in deletion_order:
         entry.delete()
+
+
+@transaction.atomic
+def shred_organiser(organiser: Organiser):
+    """Irrevocably deletes the organiser and all related events and their data."""
+    for event in organiser.events.all():
+        shred_event(event)
+    organiser.logged_actions().delete()
+    organiser.delete()

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -321,7 +321,7 @@ class Event(LogMixin, models.Model):
     @cached_property
     def named_locales(self) -> list:
         """Is a list of tuples of locale codes and natural names for this event."""
-        enabled = set(self.locale_array.split(","))
+        enabled = set(self.locales)
         return [a for a in settings.LANGUAGES_NATURAL_NAMES if a[0] in enabled]
 
     @cached_property
@@ -565,16 +565,6 @@ class Event(LogMixin, models.Model):
         E.g. as long as the event takes place within the same month, the month
         is only named once."""
         return daterange(self.date_from, self.date_to)
-
-    def release_schedule(self, name: str, user=None, notify_speakers: bool=False):
-        """Releases a new :class:`~pretalx.schedule.models.schedule.Schedule` by finalizing the current WIP schedule.
-
-        :param name: The new version name
-        :param user: The :class:`~pretalx.person.models.user.User` executing the release
-        :param notify_speakers: Generate emails for all speakers with changed slots.
-        :type user: :class:`~pretalx.person.models.user.User`
-        """
-        self.wip_schedule.freeze(name=name, user=user, notify_speakers=notify_speakers)
 
     def send_orga_mail(self, text, stats=False):
         from django.utils.translation import override

--- a/src/pretalx/event/models/organiser.py
+++ b/src/pretalx/event/models/organiser.py
@@ -49,8 +49,9 @@ class Organiser(LogMixin, models.Model):
     @transaction.atomic
     def shred(self):
         """Irrevocably deletes the organiser and all related events and their data."""
+        from pretalx.event.actions import shred_event
         for event in self.events.all():
-            event.shred()
+            shred_event(event)
         self.logged_actions().delete()
         self.delete()
 

--- a/src/pretalx/event/models/organiser.py
+++ b/src/pretalx/event/models/organiser.py
@@ -1,7 +1,7 @@
 import string
 
 from django.core.validators import RegexValidator
-from django.db import models, transaction
+from django.db import models
 from django.utils.crypto import get_random_string
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
@@ -45,15 +45,6 @@ class Organiser(LogMixin, models.Model):
         delete = '{base}delete'
         teams = '{base}teams/'
         new_team = '{teams}new'
-
-    @transaction.atomic
-    def shred(self):
-        """Irrevocably deletes the organiser and all related events and their data."""
-        from pretalx.event.actions import shred_event
-        for event in self.events.all():
-            shred_event(event)
-        self.logged_actions().delete()
-        self.delete()
 
 
 class Team(LogMixin, models.Model):

--- a/src/pretalx/event/services.py
+++ b/src/pretalx/event/services.py
@@ -5,6 +5,7 @@ from django.utils.timezone import now
 
 from pretalx.celery_app import app
 from pretalx.common.signals import periodic_task
+from pretalx.event.actions import build_initial_data
 from pretalx.event.models import Event
 
 
@@ -19,7 +20,7 @@ def task_periodic_event_services(event_slug):
     if not event:
         return
 
-    event.build_initial_data()  # Make sure the required mail templates are there
+    build_initial_data(event)  # Make sure the required mail templates are there
     if not event.settings.sent_mail_event_created:
         if (
             timedelta(0)

--- a/src/pretalx/orga/views/cfp.py
+++ b/src/pretalx/orga/views/cfp.py
@@ -351,7 +351,8 @@ class CfPQuestionRemind(EventPermissionRequired, TemplateView):
             messages.error(request, _('Could not send mails, error in configuration.'))
             return redirect(request.path)
         if not getattr(request.event, 'question_template', None):
-            request.event.build_initial_data()
+            from pretalx.event.actions import build_initial_data
+            build_initial_data(request.event)
         if self.filter_form.cleaned_data['role'] == 'true':
             people = set(request.event.speakers)
             submissions = request.event.talks

--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -27,7 +27,7 @@ from pretalx.common.mixins.views import (
 )
 from pretalx.common.tasks import regenerate_css
 from pretalx.common.views import is_form_bound
-from pretalx.event.actions import build_initial_data
+from pretalx.event.actions import build_initial_data, copy_data_from
 from pretalx.event.forms import (
     EventWizardBasicsForm, EventWizardCopyForm, EventWizardDisplayForm,
     EventWizardInitialForm, EventWizardTimelineForm, ReviewPhaseForm,
@@ -554,6 +554,7 @@ class EventWizard(PermissionRequired, SensibleBackWizardMixin, SessionWizardView
             date_from=steps['timeline']['date_from'],
             date_to=steps['timeline']['date_to'],
         )
+        build_initial_data(event)
         deadline = steps['timeline'].get('deadline')
         if deadline:
             zone = timezone(event.timezone)
@@ -588,9 +589,7 @@ class EventWizard(PermissionRequired, SensibleBackWizardMixin, SessionWizardView
         )
 
         if steps['copy'] and steps['copy']['copy_from_event']:
-            event.copy_data_from(steps['copy']['copy_from_event'])
-
-        build_initial_data(event)
+            copy_data_from(steps['copy']['copy_from_event'], event)
         return redirect(event.orga_urls.base + '?congratulations')
 
 

--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -27,7 +27,7 @@ from pretalx.common.mixins.views import (
 )
 from pretalx.common.tasks import regenerate_css
 from pretalx.common.views import is_form_bound
-from pretalx.event.actions import build_initial_data, copy_data_from
+from pretalx.event.actions import build_initial_data, copy_data_from, shred_event
 from pretalx.event.forms import (
     EventWizardBasicsForm, EventWizardCopyForm, EventWizardDisplayForm,
     EventWizardInitialForm, EventWizardTimelineForm, ReviewPhaseForm,
@@ -604,7 +604,7 @@ class EventDelete(PermissionRequired, DeleteView):
     def delete(self, request, *args, **kwargs):
         event = self.get_object()
         if event:
-            event.shred()
+            shred_event(event)
         return redirect('/orga/')
 
 

--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -27,6 +27,7 @@ from pretalx.common.mixins.views import (
 )
 from pretalx.common.tasks import regenerate_css
 from pretalx.common.views import is_form_bound
+from pretalx.event.actions import build_initial_data
 from pretalx.event.forms import (
     EventWizardBasicsForm, EventWizardCopyForm, EventWizardDisplayForm,
     EventWizardInitialForm, EventWizardTimelineForm, ReviewPhaseForm,
@@ -589,6 +590,7 @@ class EventWizard(PermissionRequired, SensibleBackWizardMixin, SessionWizardView
         if steps['copy'] and steps['copy']['copy_from_event']:
             event.copy_data_from(steps['copy']['copy_from_event'])
 
+        build_initial_data(event)
         return redirect(event.orga_urls.base + '?congratulations')
 
 

--- a/src/pretalx/orga/views/organiser.py
+++ b/src/pretalx/orga/views/organiser.py
@@ -9,6 +9,7 @@ from django_context_decorator import context
 from pretalx.common.mail import SendMailException
 from pretalx.common.mixins.views import PermissionRequired
 from pretalx.common.views import CreateOrUpdateView
+from pretalx.event.actions import shred_organiser
 from pretalx.event.forms import OrganiserForm, TeamForm, TeamInviteForm, TeamTrackForm
 from pretalx.event.models import Organiser, Team, TeamInvite
 
@@ -198,5 +199,5 @@ class OrganiserDelete(PermissionRequired, DeleteView):
     def delete(self, request, *args, **kwargs):
         organiser = self.get_object()
         if organiser:
-            organiser.shred()
+            shred_organiser(organiser)
         return HttpResponseRedirect('/orga/')

--- a/src/pretalx/orga/views/schedule.py
+++ b/src/pretalx/orga/views/schedule.py
@@ -128,7 +128,7 @@ class ScheduleReleaseView(EventPermissionRequired, FormView):
         return redirect(self.request.event.orga_urls.release_schedule)
 
     def form_valid(self, form):
-        self.request.event.release_schedule(
+        self.request.event.wip_schedule.freeze(
             form.cleaned_data['version'],
             user=self.request.user,
             notify_speakers=form.cleaned_data['notify_speakers'],

--- a/src/tests/agenda/test_agenda_permissions.py
+++ b/src/tests/agenda/test_agenda_permissions.py
@@ -17,7 +17,7 @@ def test_agenda_permission_is_agenda_visible(is_public, show_schedule, has_sched
     event.is_public = is_public
     event.settings.show_schedule = show_schedule
     if has_schedule:
-        event.release_schedule('42')
+        event.wip_schedule.freeze('42')
     assert is_agenda_visible(None, event) is result
 
 

--- a/src/tests/agenda/views/test_agenda_schedule.py
+++ b/src/tests/agenda/views/test_agenda_schedule.py
@@ -66,7 +66,7 @@ def test_schedule_page(
 def test_versioned_schedule_page(
     client, django_assert_num_queries, event, speaker, slot, schedule, other_slot
 ):
-    event.release_schedule('new schedule')
+    event.wip_schedule.freeze('new schedule')
     event.current_schedule.talks.update(is_visible=False)
 
     url = event.urls.schedule

--- a/src/tests/agenda/views/test_agenda_sneek_peak.py
+++ b/src/tests/agenda/views/test_agenda_sneek_peak.py
@@ -13,7 +13,7 @@ def test_sneak_peek_invisible_because_schedule(
     client, django_assert_num_queries, event
 ):
     event.settings.show_sneak_peek = True
-    event.release_schedule("42")
+    event.wip_schedule.freeze("42")
     with django_assert_num_queries(27):
         response = client.get(event.urls.sneakpeek, follow=True)
 
@@ -39,7 +39,7 @@ def test_sneak_peek_visible(client, django_assert_num_queries, event):
 def test_sneak_peek_visible_despite_schedule(client, django_assert_num_queries, event):
     event.settings.show_sneak_peek = True
     event.settings.show_schedule = False
-    event.release_schedule("42")
+    event.wip_schedule.freeze("42")
     with django_assert_num_queries(17):
         response = client.get(event.urls.sneakpeek, follow=True)
     assert response.status_code == 200

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -5,6 +5,7 @@ import pytz
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.timezone import now
 
+from pretalx.event.actions import build_initial_data
 from pretalx.event.models import Event, Organiser, Team, TeamInvite
 from pretalx.mail.models import MailTemplate
 from pretalx.person.models import SpeakerInformation, SpeakerProfile, User
@@ -88,6 +89,7 @@ def event(organiser):
         date_to=today + datetime.timedelta(days=3),
         organiser=organiser,
     )
+    build_initial_data(event)
     # exporting takes quite some time, so this speeds up our tests
     event.settings.export_html_on_schedule_release = False
     for team in organiser.teams.all():
@@ -106,6 +108,7 @@ def other_event(other_organiser):
         date_to=datetime.date.today() + datetime.timedelta(days=1),
         organiser=other_organiser,
     )
+    build_initial_data(event)
     event.settings.export_html_on_schedule_release = False
     for team in other_organiser.teams.all():
         team.limit_events.add(event)
@@ -125,6 +128,7 @@ def multilingual_event(organiser):
         locale_array='en,de',
         organiser=organiser,
     )
+    build_initial_data(event)
     event.settings.export_html_on_schedule_release = False
     for team in organiser.teams.all():
         team.limit_events.add(event)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -647,7 +647,7 @@ def availability(event):
 
 @pytest.fixture
 def schedule(event):
-    event.release_schedule('🍪 Version')
+    event.wip_schedule.freeze('🍪 Version')
     return event.current_schedule
 
 

--- a/src/tests/event/test_event_actions.py
+++ b/src/tests/event/test_event_actions.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from pretalx.event.actions import build_initial_data
+from pretalx.event.actions import build_initial_data, copy_data_from
 from pretalx.event.models import Event
 
 
@@ -40,3 +40,26 @@ def test_initial_data(event):
     assert event.schedules.count()
     assert event.wip_schedule
     assert event.mail_templates.all().count() == template_count
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('with_url', (True, False))
+def test_event_copy_settings(event, submission_type, with_url):
+    if with_url:
+        event.settings.custom_domain = 'https://testeventcopysettings.example.org'
+    build_initial_data(event)
+    event.settings.random_value = 'testcopysettings'
+    event.accept_template.text = 'testtemplate'
+    event.accept_template.save()
+    new_event = Event.objects.create(
+        organiser=event.organiser, locale_array='de,en',
+        name='Teh Name', slug='tn', timezone='Europe/Berlin',
+        email='tehname@example.org', locale='de',
+        date_from=datetime.date.today(), date_to=datetime.date.today()
+    )
+    copy_data_from(event, new_event)
+    assert new_event.submission_types.count() == event.submission_types.count()
+    assert new_event.accept_template
+    assert new_event.accept_template.text == 'testtemplate'
+    assert new_event.settings.random_value == 'testcopysettings'
+    assert not new_event.settings.custom_domain

--- a/src/tests/event/test_event_actions.py
+++ b/src/tests/event/test_event_actions.py
@@ -1,0 +1,42 @@
+import datetime
+
+import pytest
+
+from pretalx.event.actions import build_initial_data
+from pretalx.event.models import Event
+
+
+@pytest.fixture
+def event():
+    return Event.objects.create(
+        name='Event', slug='event', is_public=True,
+        email='orga@orga.org', locale_array='en,de', locale='en',
+        date_from=datetime.date.today(), date_to=datetime.date.today()
+    )
+
+
+@pytest.mark.django_db
+def test_initial_data(event):
+    assert not hasattr(event, 'cfp')
+
+    build_initial_data(event)
+
+    assert event.cfp.default_type
+    assert event.accept_template
+    assert event.ack_template
+    assert event.reject_template
+    assert event.schedules.count()
+    assert event.wip_schedule
+    template_count = event.mail_templates.all().count()
+
+    event.cfp.delete()
+    build_initial_data(event)
+
+    assert event.cfp
+    assert event.cfp.default_type
+    assert event.accept_template
+    assert event.ack_template
+    assert event.reject_template
+    assert event.schedules.count()
+    assert event.wip_schedule
+    assert event.mail_templates.all().count() == template_count

--- a/src/tests/event/test_event_actions.py
+++ b/src/tests/event/test_event_actions.py
@@ -2,21 +2,27 @@ import datetime
 
 import pytest
 
-from pretalx.event.actions import build_initial_data, copy_data_from
+from pretalx.event.actions import build_initial_data, copy_data_from, shred_organiser
 from pretalx.event.models import Event
 
 
 @pytest.fixture
-def event():
+def raw_event():
     return Event.objects.create(
-        name='Event', slug='event', is_public=True,
-        email='orga@orga.org', locale_array='en,de', locale='en',
-        date_from=datetime.date.today(), date_to=datetime.date.today()
+        name='Event',
+        slug='event',
+        is_public=True,
+        email='orga@orga.org',
+        locale_array='en,de',
+        locale='en',
+        date_from=datetime.date.today(),
+        date_to=datetime.date.today(),
     )
 
 
 @pytest.mark.django_db
-def test_initial_data(event):
+def test_initial_data(raw_event):
+    event = raw_event
     assert not hasattr(event, 'cfp')
 
     build_initial_data(event)
@@ -44,7 +50,8 @@ def test_initial_data(event):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('with_url', (True, False))
-def test_event_copy_settings(event, submission_type, with_url):
+def test_event_copy_settings(raw_event, submission_type, with_url):
+    event = raw_event
     if with_url:
         event.settings.custom_domain = 'https://testeventcopysettings.example.org'
     build_initial_data(event)
@@ -52,10 +59,15 @@ def test_event_copy_settings(event, submission_type, with_url):
     event.accept_template.text = 'testtemplate'
     event.accept_template.save()
     new_event = Event.objects.create(
-        organiser=event.organiser, locale_array='de,en',
-        name='Teh Name', slug='tn', timezone='Europe/Berlin',
-        email='tehname@example.org', locale='de',
-        date_from=datetime.date.today(), date_to=datetime.date.today()
+        organiser=event.organiser,
+        locale_array='de,en',
+        name='Teh Name',
+        slug='tn',
+        timezone='Europe/Berlin',
+        email='tehname@example.org',
+        locale='de',
+        date_from=datetime.date.today(),
+        date_to=datetime.date.today(),
     )
     copy_data_from(event, new_event)
     assert new_event.submission_types.count() == event.submission_types.count()
@@ -63,3 +75,27 @@ def test_event_copy_settings(event, submission_type, with_url):
     assert new_event.accept_template.text == 'testtemplate'
     assert new_event.settings.random_value == 'testcopysettings'
     assert not new_event.settings.custom_domain
+
+
+@pytest.mark.django_db
+def test_shred_used_event(
+    resource,
+    answered_choice_question,
+    personal_answer,
+    rejected_submission,
+    deleted_submission,
+    mail,
+    sent_mail,
+    room_availability,
+    slot,
+    unreleased_slot,
+    past_slot,
+    feedback,
+    canceled_talk,
+    review,
+    information,
+    other_event,
+):
+    assert Event.objects.count() == 2
+    shred_organiser(rejected_submission.event.organiser)
+    assert Event.objects.count() == 1

--- a/src/tests/event/test_event_model.py
+++ b/src/tests/event/test_event_model.py
@@ -77,10 +77,3 @@ def test_event_model_talks(slot, other_slot, accepted_submission, submission, re
     other_slot.submission.speakers.add(slot.submission.speakers.first())
     assert len(event.talks.all()) == len(set(event.talks.all()))
     assert len(event.speakers.all()) == len(set(event.speakers.all()))
-
-
-@pytest.mark.django_db
-def test_shred_used_event(resource, answered_choice_question, personal_answer, rejected_submission, deleted_submission, mail, sent_mail, room_availability, slot, unreleased_slot, past_slot, feedback, canceled_talk, review, information, other_event):
-    assert Event.objects.count() == 2
-    rejected_submission.event.organiser.shred()
-    assert Event.objects.count() == 1

--- a/src/tests/event/test_event_model.py
+++ b/src/tests/event/test_event_model.py
@@ -63,28 +63,6 @@ def test_event_model_slug_uniqueness():
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('with_url', (True, False))
-def test_event_copy_settings(event, submission_type, with_url):
-    if with_url:
-        event.settings.custom_domain = 'https://testeventcopysettings.example.org'
-    event.settings.random_value = 'testcopysettings'
-    event.accept_template.text = 'testtemplate'
-    event.accept_template.save()
-    new_event = Event.objects.create(
-        organiser=event.organiser, locale_array='de,en',
-        name='Teh Name', slug='tn', timezone='Europe/Berlin',
-        email='tehname@example.org', locale='de',
-        date_from=datetime.date.today(), date_to=datetime.date.today()
-    )
-    new_event.copy_data_from(event)
-    assert new_event.submission_types.count() == event.submission_types.count()
-    assert new_event.accept_template
-    assert new_event.accept_template.text == 'testtemplate'
-    assert new_event.settings.random_value == 'testcopysettings'
-    assert not new_event.settings.custom_domain
-
-
-@pytest.mark.django_db
 def test_event_urls_custom(event):
     custom = 'https://foo.bar.com'
     assert custom not in event.urls.submit.full()

--- a/src/tests/schedule/test_schedule_model.py
+++ b/src/tests/schedule/test_schedule_model.py
@@ -133,8 +133,8 @@ def test_scheduled_talks(slot, room):
 
 @pytest.mark.django_db
 def test_is_archived(event):
-    event.release_schedule(name='v1')
-    event.release_schedule(name='v2')
+    event.wip_schedule.freeze(name='v1')
+    event.wip_schedule.freeze(name='v2')
 
     v1_schedule = Schedule.objects.get(version='v1')
     v2_schedule = Schedule.objects.get(version='v2')

--- a/src/tests/schedule/test_schedule_utils.py
+++ b/src/tests/schedule/test_schedule_utils.py
@@ -17,5 +17,5 @@ from pretalx.schedule.utils import guess_schedule_version
 ))
 def test_schedule_version_guessing(event, previous, suggestion):
     if previous:
-        event.release_schedule(previous)
+        event.wip_schedule.freeze(previous)
     assert guess_schedule_version(event) == suggestion


### PR DESCRIPTION
This PR slowly-but-surely pulls the business logic away from the models into local `actions.py` files.

Later, we may also move complex lookups (such as `Event.talks`) to `selectors.py`, but that's not a priority right now.

Models to be done:

- `common`
    - [x] ActivityLog
- `event`
    - [x] Event
    - [x] Organiser
    - [x] Team
    - [x] TeamInvite
- `mail`
    - [ ] QueuedMail
    - [ ] MailTemplate
- `person`
    - [x] SpeakerInformation
    - [x] SpeakerProfile
    - [ ] User
- `schedule`
    - [x] Availability
    - [ ] Schedule
    - [x] Room
    - [ ] TalkSlot
- `submission`
    - [ ] Submission
    - [x] Question
    - [x] Answer
    - [x] AnswerOption
    - [x] Resource
    - [x] Review
    - [ ] ReviewPhase
    - [x] Track
    - [x] Feedback
    - [ ]  SubmissionType
    - [x] CfP