### PR TITLE
[orga] send emails to speakers, who answered a question

### DIFF
--- a/src/pretalx/orga/forms/mails.py
+++ b/src/pretalx/orga/forms/mails.py
@@ -6,6 +6,7 @@ from pretalx.common.mixins.forms import ReadOnlyFlag
 from pretalx.mail.context import get_context_explanation
 from pretalx.mail.models import MailTemplate, QueuedMail
 from pretalx.person.models import User
+from pretalx.submission.models import QuestionTarget, QuestionVariant
 
 
 class MailTemplateForm(ReadOnlyFlag, I18nModelForm):
@@ -98,6 +99,7 @@ class WriteMailForm(forms.ModelForm):
         required=False,
     )
     tracks = forms.MultipleChoiceField(label=_('All submissions in these tracks'), required=False)
+    boolean_questions = forms.MultipleChoiceField(label=_('Answered one of these questions with "yes"'), required=False)
     submission_types = forms.MultipleChoiceField(label=_('All submissions of these types'), required=False)
     submissions = forms.MultipleChoiceField(required=False)
     additional_recipients = forms.CharField(
@@ -120,6 +122,13 @@ class WriteMailForm(forms.ModelForm):
             del self.fields['tracks']
         self.fields['submission_types'].choices = [
             (submission_type.pk, submission_type.name) for submission_type in event.submission_types.all()
+        ]
+        self.fields['boolean_questions'].choices = [
+            (question.pk, question.question)
+            for question in event.questions.filter(
+                variant=QuestionVariant.BOOLEAN,
+                target=QuestionTarget.SPEAKER,
+            )
         ]
         self.fields['text'].help_text = _(
             'Please note: Placeholders will not be substituted, this is an upcoming feature. '

--- a/src/pretalx/orga/templates/orga/mails/send_form.html
+++ b/src/pretalx/orga/templates/orga/mails/send_form.html
@@ -11,6 +11,7 @@
         {% if form.tracks %}{% bootstrap_field form.tracks layout='event' %}{% endif %}
         {% bootstrap_field form.submission_types layout='event' %}
         {% bootstrap_field form.submissions layout='event' %}
+        {% bootstrap_field form.boolean_questions layout='event' %}
         {% bootstrap_field form.additional_recipients layout='event' %}
         {% bootstrap_field form.reply_to layout='event' %}
         {% bootstrap_field form.cc layout='event' %}

--- a/src/pretalx/orga/views/mails.py
+++ b/src/pretalx/orga/views/mails.py
@@ -265,6 +265,14 @@ class ComposeMail(EventPermissionRequired, FormView):
                 submission_type_id__in=submission_types
             ))
             user_set.update(users)
+        boolean_questions = form.cleaned_data.get('boolean_questions')
+        if boolean_questions:
+            users = User.objects.filter(
+                submissions__in=self.request.event.submissions.all(),
+                answers__question__pk__in=boolean_questions,
+                answers__answer='True',
+            )
+            user_set.update(users)
 
         for recipient in form.cleaned_data.get('recipients'):
             if recipient == 'reviewers':

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -210,6 +210,27 @@ def speaker_boolean_question(event):
 
 
 @pytest.fixture
+def speaker_boolean_answer(event, speaker, speaker_boolean_question):
+    return Answer.objects.create(answer='True', person=speaker, question=speaker_boolean_question)
+
+
+@pytest.fixture
+def other_speaker_boolean_question(event):
+    return Question.objects.create(
+        event=event,
+        question='Do you like red?',
+        variant=QuestionVariant.BOOLEAN,
+        target='speaker',
+        required=False,
+    )
+
+
+@pytest.fixture
+def other_speaker_boolean_answer(event, speaker, other_speaker_boolean_question):
+    return Answer.objects.create(answer='True', person=speaker, question=other_speaker_boolean_question)
+
+
+@pytest.fixture
 def speaker_file_question(event):
     return Question.objects.create(
         event=event,

--- a/src/tests/orga/views/test_orga_views_mail.py
+++ b/src/tests/orga/views/test_orga_views_mail.py
@@ -255,6 +255,36 @@ def test_orga_can_compose_mail_for_track(orga_client, event, submission, track):
 
 
 @pytest.mark.django_db
+def test_orga_can_compose_mail_for_boolean_questions_no_answer(orga_client, event, submission, speaker_boolean_question, other_speaker_boolean_answer):
+    response = orga_client.get(
+        event.orga_urls.compose_mails, follow=True,
+    )
+    assert response.status_code == 200
+    assert QueuedMail.objects.filter(sent__isnull=True).count() == 0
+    response = orga_client.post(
+        event.orga_urls.compose_mails, follow=True,
+        data={'bcc': '', 'cc': '', 'reply_to': '', 'subject': 'foo', 'text': 'bar', 'boolean_questions': [speaker_boolean_question.pk]}
+    )
+    assert response.status_code == 200
+    assert QueuedMail.objects.filter(sent__isnull=True).count() == 0
+
+
+@pytest.mark.django_db
+def test_orga_can_compose_mail_for_boolean_questions_answer(orga_client, event, submission, speaker_boolean_answer, other_speaker_boolean_question):
+    response = orga_client.get(
+        event.orga_urls.compose_mails, follow=True,
+    )
+    assert response.status_code == 200
+    assert QueuedMail.objects.filter(sent__isnull=True).count() == 0
+    response = orga_client.post(
+        event.orga_urls.compose_mails, follow=True,
+        data={'bcc': '', 'cc': '', 'reply_to': '', 'subject': 'foo', 'text': 'bar', 'boolean_questions': [speaker_boolean_answer.question.pk]}
+    )
+    assert response.status_code == 200
+    assert QueuedMail.objects.filter(sent__isnull=True).count() == 1
+
+
+@pytest.mark.django_db
 def test_orga_can_compose_mail_for_submission_type(orga_client, event, submission):
     response = orga_client.get(
         event.orga_urls.compose_mails, follow=True,


### PR DESCRIPTION
Send emails to speakers, who answered a yes/no question with "yes", e.g. they opted in to information emails after the event.

## How Has This Been Tested?

Manually and using supplied tests.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/2158203/58660278-600cf000-8325-11e9-806d-d3b72f14289d.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
