### PR TITLE
Remove placeholder address

### DIFF
--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -288,7 +288,6 @@ class MailSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):
         super().__init__(*args, **kwargs)
         event = kwargs.get('obj')
         if event:
-            self.fields['mail_from'].widget.attrs['placeholder'] = event.email
             self.fields['mail_from'].help_text += ' ' + _(
                 'Leave empty to use the default address: {}'
             ).format(settings.MAIL_FROM)


### PR DESCRIPTION
Remove the placeholder address in the Email Settings view. 

**Why?**

Previously, if you had no value in this field, the help text would tell you:

> Sender address for outgoing emails. Leave empty to use the default address: noreply@pretalx.com

However, the placeholder for that input field defaults to be your event email. 

<img width="471" alt="two fields" src="https://user-images.githubusercontent.com/813732/58744423-0ec84200-8486-11e9-9dcd-01267273a863.png">


The contrast difference in the form and entered value means that it *looks* like you have set a value, but it's actually empty, using the default. (In this example, the first field has no value, only placeholder; the second field has a value)

By removing the placeholder, administrators won't confuse a value for a lack of value. Also, the helptext will be more accurate ("Leave empty" actually has an empty field, with no placeholder)

Mock up of result: 
<img width="506" alt="Mock up of result" src="https://user-images.githubusercontent.com/813732/58744433-4d5dfc80-8486-11e9-8e1f-d5389097e772.png">

