### PR TITLE
be more python3.x agnostic

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setupdir = src
 
 
 [testenv]
-basepython = python3.7
+basepython = python3
 usedevelop = True
 envdir = {toxinidir}/.env
 recreate = false


### PR DESCRIPTION
Most packages and `venv` symlink python3 to whatever they have installed. This will cover all 3.6+ versions.  The minimal python requirement is clear from the docs and `setup.py` checks for 3.6 so i don't see any risk here... It just makes the dev's life easier...

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
