### PR TITLE
installation fails if configuration does not use sqlite

### DIFF
--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -108,21 +108,14 @@ Check out :ref:`configure` for details on the available configuration options.
 Step 5: Installation
 --------------------
 
-Now we will install pretalx itself. Please execute the following steps as the
-``pretalx`` user. This isolates the pretalx environment from your global Python
-versions and binaries::
+Please execute the following steps as the ``pretalx`` user. This isolates the
+pretalx environment from your global Python versions and binaries::
 
     $ pip install --user -U pip setuptools wheel gunicorn
-    $ pip install --user -U pretalx
 
-If you intend to run pretalx with asynchronous task runners or with redis as
-cache server, you can install ``pretalx[redis]`` instead, which will pull in
-the appropriate dependencies. Please note that you should also use
-``pretalx[redis]`` when you upgrade pretalx in this case.
-
-pretalx works your choice of database backends – we recommend using PostgreSQL,
-but MySQL and SQLite work as well. Use this command to install the database
-driver (unless you use SQLite, which has its driver built in):
+pretalx works with your choice of database backends – we recommend using
+PostgreSQL, but MySQL and SQLite work as well. Use this command to install the
+database driver (unless you use SQLite, which has its driver built in):
 
 +------------+-------------------------------------------+
 | Database   | pip package                               |
@@ -133,6 +126,15 @@ driver (unless you use SQLite, which has its driver built in):
 +------------+-------------------------------------------+
 | Oracle     | ``pip install --user -U cx_Oracle``       |
 +------------+-------------------------------------------+
+
+Now we will install pretalx itself::
+
+    $ pip install --user -U pretalx
+
+If you intend to run pretalx with asynchronous task runners or with redis as
+cache server, you can install ``pretalx[redis]`` instead, which will pull in
+the appropriate dependencies. Please note that you should also use
+``pretalx[redis]`` when you upgrade pretalx in this case.
 
 We also need to create a data directory::
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If the configuration in **Step 4** uses a non-sqlite DB, **Step 5** `pip install --user -U pretalx` (before installing the DB driver) will fail. Swap the order in the documentation.

Also add a missing "with" in "pretalx works your choice of database backends".

(TBH i am not a fan of `pip install --user` as it doesn't scale if the user in question runs multiple apps (whether that's a good/bad is another discussion), but i still prefer vanilla venvs dedicated only to the app.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
