### PR TITLE
🐛  fixed gather your team link

### DIFF
--- a/src/pretalx/event/stages.py
+++ b/src/pretalx/event/stages.py
@@ -43,7 +43,7 @@ STAGES = {
         'icon': 'paper-plane',
         'links': [
             {'title': _('Configure the event'), 'url': ['orga_urls', 'settings']},
-            {'title': _('Gather your team'), 'url': ['orga_urls', 'team_settings']},
+            {'title': _('Gather your team'), 'url': ['organiser', 'orga_urls', 'base']},
             {'title': _('Write a CfP'), 'url': ['cfp', 'urls', 'edit_text']},
             {
                 'title': _('Customize mail templates'),


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Gather your team link returns 404. Looks like the link changed. I am not sure though. Maybe it is intentional? 

