### PR TITLE
Mention in API docs that slot does not show up til release

### DIFF
--- a/doc/api/resources/submissions.rst
+++ b/doc/api/resources/submissions.rst
@@ -25,7 +25,7 @@ duration                              number                     The talk's dura
 do_not_record                         boolean                    Indicates if the speaker consent to recordings of their talk
 is_featured                           boolean                    Indicates if the talk is show in the schedule preview / sneak peek
 content_locale                        string                     The language the submission is in, e.g. "en" or "de"
-slot                                  object                     An object with the scheduling details, e.g. ``{"start": …, "end": …, "room": "R101"}`` if they exist.
+slot                                  object                     An object with the scheduling details, e.g. ``{"start": …, "end": …, "room": "R101"}`` if they exist. This will not be present til after the schedule is released.
 slot_count                            number                     How often this submission may be scheduled.
 image                                 string                     The submission image URL
 answers                               list                       The question answers given by the speakers. Available if the requesting user has organiser permissions.


### PR DESCRIPTION
I was not clear as to when the slot field would appear, and now i now I know

## How Has This Been Tested?
I have not. But it is just a docs change,
## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
