### PR TITLE
Fixing api submissions endpoint lacking biography

### DIFF
--- a/src/pretalx/api/serializers/submission.py
+++ b/src/pretalx/api/serializers/submission.py
@@ -38,7 +38,7 @@ class SubmissionSerializer(I18nAwareModelSerializer):
             'orga.view_speakers', request.event
         )
         if has_slots or has_permission:
-            return SubmitterSerializer(obj.speakers.all(), many=True).data
+            return SubmitterSerializer(obj.speakers.all(), many=True, context=self.context).data
         return []
 
     class Meta:


### PR DESCRIPTION
Binding the context of the SubmissionSerializer to the nested SubmitterSerializer allows access to the biography of submitters


## How Has This Been Tested?
Tested in local deployment.


## Checklist

- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
