### PR TITLE
Clarify column names in speakers page, add accepted(/confirmed) column

### DIFF
--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -27,7 +27,7 @@
             <tr>
                 <th>{% trans "Name" %}</th>
                 <th>{% trans "Scheduled Talks" %}</th>
-                <th>{% trans "Confirmed Submissions" %}</th>
+                <th>{% trans "Accepted Submissions" %}</th>
                 <th>{% trans "Submissions" %}</th>
                 {% if can_mark_speaker or can_see_speaker_status %}<th></th>{% endif %}
             </tr>
@@ -37,7 +37,7 @@
                 <tr>
                     <td><a href="{{ profile.orga_urls.base }}">{{ profile.user.get_display_name }}</a></td>
                     <td>{{ profile.talks.count }}</td>
-                    <td>{{ profile.confirmed_submissions.count }}</td>
+                    <td>{{ profile.accepted_confirmed_submissions.count }}</td>
                     <td>{{ profile.submissions.count }}</td>
                     {% if can_mark_speaker or can_see_speaker_status %}
                         <td class="action-column">

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -26,7 +26,8 @@
         <thead>
             <tr>
                 <th>{% trans "Name" %}</th>
-                <th>{% trans "Talks" %}</th>
+                <th>{% trans "Scheduled Talks" %}</th>
+                <th>{% trans "Confirmed Submissions" %}</th>
                 <th>{% trans "Submissions" %}</th>
                 {% if can_mark_speaker or can_see_speaker_status %}<th></th>{% endif %}
             </tr>
@@ -36,6 +37,7 @@
                 <tr>
                     <td><a href="{{ profile.orga_urls.base }}">{{ profile.user.get_display_name }}</a></td>
                     <td>{{ profile.talks.count }}</td>
+                    <td>{{ profile.confirmed_submissions.count }}</td>
                     <td>{{ profile.submissions.count }}</td>
                     {% if can_mark_speaker or can_see_speaker_status %}
                         <td class="action-column">

--- a/src/pretalx/person/models/profile.py
+++ b/src/pretalx/person/models/profile.py
@@ -60,9 +60,9 @@ class SpeakerProfile(LogMixin, models.Model):
         return self.user.submissions.filter(event=self.event)
 
     @cached_property
-    def confirmed_submissions(self):
-        """All non-deleted :class:`~pretalx.submission.models.submission.Submission` objects by this user that have been confirmed on this event."""
-        return self.user.submissions.filter(event=self.event, state='confirmed')
+    def accepted_confirmed_submissions(self):
+        """All non-deleted :class:`~pretalx.submission.models.submission.Submission` objects by this user that have been accepted or confirmed on this event."""
+        return self.user.submissions.filter(event=self.event, state__in=['confirmed', 'accepted'])
 
     @cached_property
     def talks(self):

--- a/src/pretalx/person/models/profile.py
+++ b/src/pretalx/person/models/profile.py
@@ -60,6 +60,11 @@ class SpeakerProfile(LogMixin, models.Model):
         return self.user.submissions.filter(event=self.event)
 
     @cached_property
+    def confirmed_submissions(self):
+        """All non-deleted :class:`~pretalx.submission.models.submission.Submission` objects by this user that have been confirmed on this event."""
+        return self.user.submissions.filter(event=self.event, state='confirmed')
+
+    @cached_property
     def talks(self):
         """A queryset of :class:`~pretalx.submission.models.submission.Submission` objects.
 


### PR DESCRIPTION
This clarifies some of the language used in columns and (hopefully) removes ambiguity around "talks" on the speakers page.

Related to #757 

## How Has This Been Tested?

Only looking at the table in the browser

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/15880420/65042872-b7c17c80-d951-11e9-8587-99f33ba4a2b8.png)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
