### PR TITLE
add check for speaker clashes

### DIFF
--- a/src/pretalx/schedule/models/slot.py
+++ b/src/pretalx/schedule/models/slot.py
@@ -125,6 +125,25 @@ class TalkSlot(LogMixin, models.Model):
                         ),
                     }
                 )
+            overlaps = TalkSlot.objects.filter(
+                    schedule=self.schedule, submission__speakers__in=[speaker]
+                ).filter(
+                        models.Q(start__lt=self.start, end__gt=self.start)
+                        | models.Q(start__lt=self.end, end__gt=self.end)).exists()
+            if overlaps:
+                warnings.append(
+                        {
+                            'type': 'speaker',
+                            'speaker': {
+                                'name': speaker.get_display_name(),
+                                'id': speaker.pk,
+                            },
+                            'message': _(
+                                'A speaker is giving another talk at the scheduled time.'
+                            ),
+                        }
+                    )
+
         return warnings
 
     def copy_to_schedule(self, new_schedule, save=True):


### PR DESCRIPTION
This PR closes/references issue #777 . It does so by checking for clashing talks from the same speaker whenever we check a talk for warnings

This has been tested manually.

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
