### PR TITLE
Update times when timezone is changed for an event (WIP)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,7 +2,7 @@
 
 Release Notes
 =============
-
+- :bug:`781` When the timezone is changed for an event, the talk slots and availability times get shifted to the new time so that it doesn't break on the schedule.
 - :feature:`-` Answers to boolean questions are not displayed as "yes", "no", and "maybe" in public display, instead of "true" or "false".
 - :bug:`775` When a speaker withdrew their already-accepted talk, the talk slot was not removed from the schedule editor. It did work when setting the state via the organiser interface.
 - :bug:`774` The API endpoint for events always returned a 404 on the detail view, even when event was visible in the list view.

--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -50,7 +50,7 @@ class EventSettingsPermission(EventPermissionRequired):
 
 
 class EventDetail(ActionFromUrl, EventSettingsPermission, UpdateView):
-    momdel = Event
+    model = Event
     form_class = EventForm
     permission_required = 'orga.change_settings'
     template_name = 'orga/settings/form.html'


### PR DESCRIPTION
When the timezone is changed after a number of talks have been scheduled, the difference in timezone shifts the time it is scheduled for (e.g., a 10am talk will be moved to 11am in the schedule if changing from Europe/London to Europe/Paris time)

This PR closes/references issue https://github.com/pretalx/pretalx/issues/766. It does so by changing all the talk slots and availability times when the timezone is changed on the settings form.  It only attempts to do any checks/changes if the timezone has been changed so it won't impact performance.

## How Has This Been Tested?
Not yet, still a work in progress... (things that are currently broken are commented in the code)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
