### PR TITLE
Add option to send e-mail to confirmed speakers without any slides.

### DIFF
--- a/src/pretalx/orga/forms/mails.py
+++ b/src/pretalx/orga/forms/mails.py
@@ -93,6 +93,7 @@ class WriteMailForm(forms.ModelForm):
             ('confirmed', _('All confirmed speakers')),
             ('rejected', _('All rejected speakers')),
             ('reviewers', _('All reviewers in your team')),
+            ('no_slides', _('All confirmed speakers who have not uploaded slides')),
         ),
         widget=forms.CheckboxSelectMultiple,
         required=False,

--- a/src/pretalx/orga/views/mails.py
+++ b/src/pretalx/orga/views/mails.py
@@ -274,6 +274,9 @@ class ComposeMail(EventPermissionRequired, FormView):
                     )
                     .distinct()
                 )
+            elif recipient == 'no_slides':
+                users = User.objects.filter(submissions__in=self.request.event.submissions.filter(
+                    resources__isnull=True, state='confirmed'))
             else:
                 submission_filter = {'state': recipient}  # e.g. "submitted"
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR should fix issue #432 to add an option to send an e-mail to all confirmed speakers without any uploaded slides/resources.
Please double check the filter I used in views/mail.py, I set it to also match `state='confirmed'` as otherwise rejected submissions would get e-mailed too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests still pass, except two which failed before I made my changes. No additional tests have been added.
Manually tested this by creating a test event with submissions, etc. in the dev environment.

## Screenshots (if appropriate):

n/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
