### PR TITLE
API Endpoints /submission and /talks: Return URL, not Internal Storage Path for Resources

### DIFF
--- a/doc/api/resources/submissions.rst
+++ b/doc/api/resources/submissions.rst
@@ -31,7 +31,7 @@ image                                 string                     The submission 
 answers                               list                       The question answers given by the speakers. Available if the requesting user has organiser permissions.
 notes                                 string                     Notes the speaker left for the organisers. Available if the requesting user has organiser permissions.
 internal_notes                        string                     Notes the organisers left on the submission. Available if the requesting user has organiser permissions.
-resources                             object                     Files the speaker has uploaded for this submission. ``{"resource": "/path/to/file", "description": "Slides"}``
+resources                             object                     Files the speaker has uploaded for this submission. ``{"resource": "https://hostname.tld/path/to/file", "description": "Slides"}``
 ===================================== ========================== =======================================================
 
 .. versionadded:: 1.1.0

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`788` Return URL, not internal storage path for resources of talks.
 - :feature:`-` Plugin authors will now have access to all configuration sections starting with ``[plugin:*]``, to ease the integration of system level settings.
 - :feature:`787` Provide the file uploads a speaker added to their submission via the ``/talks`` and ``/submissions`` API endpoint.
 - :feature:`-` Show speakers how many feedback notes have been left (if any) in their personal submission list view.

--- a/src/pretalx/api/serializers/submission.py
+++ b/src/pretalx/api/serializers/submission.py
@@ -18,7 +18,7 @@ class FileField(Field):
     source = '*'
 
     def to_representation(self, value):
-        return value.path
+        return value.url
 
 
 class ResourceSerializer(ModelSerializer):

--- a/src/tests/api/test_api_serializers.py
+++ b/src/tests/api/test_api_serializers.py
@@ -139,7 +139,7 @@ def test_submission_serializer_for_organiser(submission, orga_user, resource):
         assert data['slot'] is None
         assert data['created'] == submission.created.astimezone(submission.event.tz).isoformat()
         assert data['resources'] == [{
-            'resource': resource.resource.path,
+            'resource': resource.resource.url,
             'description': resource.description,
         }]
 
@@ -171,7 +171,7 @@ def test_submission_serializer(submission, resource):
         assert data['submission_type'] == str(submission.submission_type.name)
         assert data['slot'] is None
         assert data['resources'] == [{
-            'resource': resource.resource.path,
+            'resource': resource.resource.url,
             'description': resource.description,
         }]
 


### PR DESCRIPTION
Use `FileField.url`, not `FileField.path`. See also https://docs.djangoproject.com/en/2.2/ref/models/fields/#django.db.models.FileField.storage

While the frontend (`/orga/event/{event_slug}/submissions/{code}`) uses the `url` attribute, the API serialiser used `path` which returns the path on the disk. The unit tests did not point out this mistake because the compared the result against `path` as well.

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] ~I have updated the documentation accordingly.~ not necessary
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (except those which fail on current master branch as well)
- [x] My change is listed in the CHANGELOG.rst if appropriate.