### PR TITLE
Adding tool to monitor feedback. #794

### DIFF
--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -292,6 +292,7 @@ class Event(LogMixin, models.Model):
         plugins = '{settings}plugins'
         information = '{base}info/'
         new_information = '{base}info/new'
+        feedbacks = '{base}submissions/feedbacks/'
 
     class api_urls(EventUrls):
         base = '/api/events/{self.slug}/'

--- a/src/pretalx/event/models/event.py
+++ b/src/pretalx/event/models/event.py
@@ -271,6 +271,7 @@ class Event(LogMixin, models.Model):
         stats = '{base}submissions/statistics/'
         submission_feed = '{base}submissions/feed/'
         new_submission = '{submissions}new'
+        feedback = '{submissions}feedback/'
         speakers = '{base}speakers/'
         settings = edit_settings = '{base}settings/'
         review_settings = '{settings}review/'
@@ -292,7 +293,6 @@ class Event(LogMixin, models.Model):
         plugins = '{settings}plugins'
         information = '{base}info/'
         new_information = '{base}info/new'
-        feedbacks = '{base}submissions/feedbacks/'
 
     class api_urls(EventUrls):
         base = '/api/events/{self.slug}/'

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -244,13 +244,13 @@
                         </a>
                     </span>
                     <div class="collapse in{% if "submissions." in url_name|slice:":13" %} show{% endif %}" aria-expand="true" id="collapseSubmissions">
-                        <a href="{{ request.event.orga_urls.submissions }}" class="nav-link nav-link-second-level{% if "submissions." in url_name and "submissions.statistics" not in url_name  and "submissions.feedbacks" not in url_name %} active{% endif %}">
+                        <a href="{{ request.event.orga_urls.submissions }}" class="nav-link nav-link-second-level{% if "submissions." in url_name and "submissions.statistics" not in url_name  and "submissions.feedback" not in url_name %} active{% endif %}">
                             <span>{% trans "Submissions" %}</span>
                         </a>
                         <a href="{{ request.event.orga_urls.stats }}" class="nav-link nav-link-second-level{% if "submissions.statistics" in url_name %} active{% endif %}">
                             <span>{% trans "Statistics" %}</span>
                         </a>
-                        <a href="{{ request.event.orga_urls.feedbacks }}" class="nav-link nav-link-second-level{% if "submissions.feedbacks" in url_name %} active{% endif %}">
+                        <a href="{{ request.event.orga_urls.feedback }}" class="nav-link nav-link-second-level{% if "submissions.feedback" in url_name %} active{% endif %}">
                             <span>{% trans "Feedback" %}</span>
                         </a>
                     </div>

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -244,11 +244,14 @@
                         </a>
                     </span>
                     <div class="collapse in{% if "submissions." in url_name|slice:":13" %} show{% endif %}" aria-expand="true" id="collapseSubmissions">
-                        <a href="{{ request.event.orga_urls.submissions }}" class="nav-link nav-link-second-level{% if "submissions." in url_name and "submissions.statistics" not in url_name %} active{% endif %}">
+                        <a href="{{ request.event.orga_urls.submissions }}" class="nav-link nav-link-second-level{% if "submissions." in url_name and "submissions.statistics" not in url_name  and "submissions.feedbacks" not in url_name %} active{% endif %}">
                             <span>{% trans "Submissions" %}</span>
                         </a>
                         <a href="{{ request.event.orga_urls.stats }}" class="nav-link nav-link-second-level{% if "submissions.statistics" in url_name %} active{% endif %}">
                             <span>{% trans "Statistics" %}</span>
+                        </a>
+                        <a href="{{ request.event.orga_urls.feedbacks }}" class="nav-link nav-link-second-level{% if "submissions.feedbacks" in url_name %} active{% endif %}">
+                            <span>{% trans "Feedback" %}</span>
                         </a>
                     </div>
                 </div>

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -4,13 +4,13 @@
 
 {% block content %}
     <h2 class="d-flex w-100 justify-content-between align-items-start">
-        {% trans "Event feedback" %}
+        {% trans "Attendee feedback" %}
     </h2>
 
     {% regroup feedback|dictsort:"talk.title" by talk.title as feedbacks_list %}
 
     {% for submission in feedbacks_list %}
-        <h4>{% trans "Feedback for submission" %} <a href="{{ submission.list.1.talk.orga_urls.base }}">{{ submission.grouper }}</a></h4>
+        <h4>{% trans "Feedback for" %} {{ quotation_open }}<a href="{{ submission.list.1.talk.orga_urls.base }}">{{ submission.grouper }}</a>{{ quotation_close }}</h4>
         
         {% for entry in submission.list %}
         <div class="card feedback-card">

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -6,18 +6,22 @@
     <h2 class="d-flex w-100 justify-content-between align-items-start">
         {% trans "Event feedback" %}
     </h2>
-    {% for entry in feedback %}
-    <div class="card feedback-card">
-        <div class="card-body">
-            {% trans "Submission" %}: <a href="{{ entry.talk.orga_urls.base }}">{{ entry.talk.title }}</a>
-            <br><br>
 
-            {{ entry.review|rich_text }}
+    {% regroup feedback|dictsort:"talk.title" by talk.title as feedbacks_list %}
+
+    {% for submission in feedbacks_list %}
+        <h4>{% trans "Feedback for submission" %} <a href="{{ submission.list.1.talk.orga_urls.base }}">{{ submission.grouper }}</a></h4>
+        
+        {% for entry in submission.list %}
+        <div class="card feedback-card">
+            <div class="card-body">
+                {{ entry.review|rich_text }}
+            </div>
         </div>
-    </div>
-    {% empty %}
-        {% trans "There has been no feedback for this event yet." %}
+        {% empty %}
+            {% trans "There has been no feedback for this event yet." %}
+        {% endfor %}
+        <br><br>
     {% endfor %}
-
     {% include "orga/pagination.html" %}
 {% endblock %}

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -1,0 +1,23 @@
+{% extends "orga/cfp/base.html" %}
+{% load i18n %}
+{% load rich_text %}
+
+{% block content %}
+    <h2 class="d-flex w-100 justify-content-between align-items-start">
+        {% trans "Event feedback" %}
+    </h2>
+    {% for entry in feedback %}
+    <div class="card feedback-card">
+        <div class="card-body">
+            {% trans "Submission" %}: <a href="{{ entry.talk.orga_urls.base }}">{{ entry.talk.title }}</a>
+            <br><br>
+
+            {{ entry.review|rich_text }}
+        </div>
+    </div>
+    {% empty %}
+        {% trans "There has been no feedback for this event yet." %}
+    {% endfor %}
+
+    {% include "orga/pagination.html" %}
+{% endblock %}

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -92,7 +92,7 @@ urlpatterns = [
         url('^submissions/cards/$', cards.SubmissionCards.as_view(), name='submissions.cards'),
         url('^submissions/feed/$', submission.SubmissionFeed(), name='submissions.feed'),
         url('^submissions/statistics/$', submission.SubmissionStats.as_view(), name='submissions.statistics'),
-        url('^submissions/feedbacks/$', submission.AllFeedbacksList.as_view(), name='submissions.feedbacks'),
+        url('^submissions/feedback/$', submission.AllFeedbacksList.as_view(), name='submissions.feedback'),
         url(r'^submissions/(?P<code>[\w-]+)/', include([
             url('^$', submission.SubmissionContent.as_view(), name='submissions.content.view'),
             url('^submit$', submission.SubmissionStateChange.as_view(), name='submissions.submit'),

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -92,6 +92,7 @@ urlpatterns = [
         url('^submissions/cards/$', cards.SubmissionCards.as_view(), name='submissions.cards'),
         url('^submissions/feed/$', submission.SubmissionFeed(), name='submissions.feed'),
         url('^submissions/statistics/$', submission.SubmissionStats.as_view(), name='submissions.statistics'),
+        url('^submissions/feedbacks/$', submission.AllFeedbacksList.as_view(), name='submissions.feedbacks'),
         url(r'^submissions/(?P<code>[\w-]+)/', include([
             url('^$', submission.SubmissionContent.as_view(), name='submissions.content.view'),
             url('^submit$', submission.SubmissionStateChange.as_view(), name='submissions.submit'),

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -590,12 +590,12 @@ class AllFeedbacksList(EventPermissionRequired, ListView):
     template_name = 'orga/submission/feedbacks_list.html'
 
     permission_required = 'submission.view_feedback'
-    paginate_by = 25
+    paginate_by = 5
 
     def get_queryset(self):
         qs = (
             Feedback.objects
-            .order_by('-pk', 'talk_id')
+            .order_by('-pk')
             .select_related('talk')
             .filter(talk__event=self.request.event)
         )

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -585,7 +585,7 @@ class SubmissionStats(PermissionRequired, TemplateView):
 
 
 class AllFeedbacksList(EventPermissionRequired, ListView):
-    model = Submission
+    model = Feedback
     context_object_name = 'feedback'
     template_name = 'orga/submission/feedbacks_list.html'
 

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -590,7 +590,7 @@ class AllFeedbacksList(EventPermissionRequired, ListView):
     template_name = 'orga/submission/feedbacks_list.html'
 
     permission_required = 'submission.view_feedback'
-    paginate_by = 5
+    paginate_by = 25
 
     def get_queryset(self):
         qs = (

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -31,7 +31,7 @@ from pretalx.person.forms import OrgaSpeakerForm
 from pretalx.person.models import SpeakerProfile, User
 from pretalx.submission.forms import QuestionsForm, ResourceForm, SubmissionFilterForm
 from pretalx.submission.models import (
-    Resource, Submission, SubmissionError, SubmissionStates,
+    Feedback, Resource, Submission, SubmissionError, SubmissionStates,
 )
 
 
@@ -582,3 +582,21 @@ class SubmissionStats(PermissionRequired, TemplateView):
             counter = Counter(str(submission.track) for submission in self.request.event.submissions.filter(state__in=[SubmissionStates.ACCEPTED, SubmissionStates.CONFIRMED]))
             return json.dumps(sorted(list({'label': label, 'value': value} for label, value in counter.items()), key=itemgetter('label')))
         return ''
+
+
+class AllFeedbacksList(EventPermissionRequired, ListView):
+    model = Submission
+    context_object_name = 'feedback'
+    template_name = 'orga/submission/feedbacks_list.html'
+
+    permission_required = 'submission.view_feedback'
+    paginate_by = 25
+
+    def get_queryset(self):
+        qs = (
+            Feedback.objects
+            .order_by('talk_id', '-pk')
+            .select_related('talk')
+            .filter(talk__event=self.request.event)
+        )
+        return qs

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -595,7 +595,7 @@ class AllFeedbacksList(EventPermissionRequired, ListView):
     def get_queryset(self):
         qs = (
             Feedback.objects
-            .order_by('talk_id', '-pk')
+            .order_by('-pk', 'talk_id')
             .select_related('talk')
             .filter(talk__event=self.request.event)
         )


### PR DESCRIPTION
This PR references issue #794. It does so by adding a feedback page, where all event related submissions feedbacks are showed and grouped by submission.

## How Has This Been Tested?
Tested by adding a feedbacks to talks and displaying them on the feedback page (see screenshot).

## Screenshots (if appropriate):
![ESS](https://user-images.githubusercontent.com/32014467/67396169-67b88400-f5a7-11e9-8058-891d9337c91b.png)


## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
