### PR TITLE
✨ keep the browser scroll from jumping when editing review phases

### DIFF
--- a/src/pretalx/orga/templates/orga/settings/review.html
+++ b/src/pretalx/orga/templates/orga/settings/review.html
@@ -57,24 +57,24 @@
                         {% if action != 'view' %}
                         {% if not form.instance.is_active %}
                             <a href="{{ form.instance.urls.activate }}"
-                               class="btn btn-outline-warning ml-auto mr-2"
+                               class="btn btn-outline-warning ml-auto mr-2 keep-scroll-position"
                                title="{% trans "Activate phase" %}">
                                 <i class="fa fa-star"></i>
                             </a>
                         {% else %}
                             <a href=""
-                               class="btn btn-warning ml-auto mr-2"
+                               class="btn btn-warning ml-auto mr-2 keep-scroll-position"
                                title="{% trans "Phase is active" %}">
                                 <i class="fa fa-star"></i>
                             </a>
                         {% endif %}
                         <a href="{{ form.instance.urls.down }}"
-                           class="btn btn-outline-info mr-2"
+                           class="btn btn-outline-info mr-2 keep-scroll-position"
                            title="{% trans "Move phase down" %}">
                             <i class="fa fa-arrow-down"></i>
                         </a>
                         <a href="{{ form.instance.urls.up }}"
-                           class="btn btn-outline-info mr-2"
+                           class="btn btn-outline-info mr-2 keep-scroll-position"
                            title="{% trans "Move phase up" %}">
                             <i class="fa fa-arrow-up"></i>
                         </a>

--- a/src/pretalx/static/orga/js/main.js
+++ b/src/pretalx/static/orga/js/main.js
@@ -74,6 +74,12 @@ document.addEventListener("DOMContentLoaded", function() {
     }
   })
 
+  $(".keep-scroll-position").click(ev => {
+    sessionStorage.setItem('scroll-position', window.scrollY);
+  });
+
+  restore_scroll_position();
+
   document.querySelectorAll(".checkbox-multi-select").forEach(element => {
     update_multi_select_caption(element)
   })
@@ -82,6 +88,15 @@ document.addEventListener("DOMContentLoaded", function() {
   })
   update_review_override_votes()
 })
+
+function restore_scroll_position() {
+    var oldScrollY = sessionStorage.getItem('scroll-position');
+
+    if (oldScrollY) {
+        window.scroll(window.scrollX, Math.max(oldScrollY, window.innerHeight));
+        sessionStorage.removeItem('scroll-position');
+    }
+}
 
 function update_review_override_votes() {
   const review = document.querySelector("#id_is_reviewer")


### PR DESCRIPTION
When you edit review phases (move them up/down, delete, ...) the browser scroll jumps to the very top after each action because of the form submit. This remembers the scroll position using JS and resets it. Does nothing without JS.

## How Has This Been Tested?
manually

## Screenshots (if appropriate):
show me how to make nice gifs on linux and I'll provide one ;)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] I have updated the documentation accordingly.~~
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
