### PR TITLE
STATIC_URL and MEDIA_URL are now customizable

### DIFF
--- a/src/pretalx/common/tasks.py
+++ b/src/pretalx/common/tasks.py
@@ -108,5 +108,5 @@ def regenerate_css(event_id: int):
 
         if event.settings.get(f'{local_app}_css_checksum', '') != checksum:
             newname = default_storage.save(fname, ContentFile(css))
-            event.settings.set(f'{local_app}_css_file', f'/media/{newname}')
+            event.settings.set(f'{local_app}_css_file', f'/{settings.MEDIA_URL}{newname}')
             event.settings.set(f'{local_app}_css_checksum', checksum)

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -106,8 +106,8 @@ ALLOWED_HOSTS = [
 ]  # We have our own security middleware to allow for custom event URLs
 
 ROOT_URLCONF = 'pretalx.urls'
-STATIC_URL = '/static/'
-MEDIA_URL = '/media/'
+STATIC_URL = config.get('urls', 'static', fallback='/static/')
+MEDIA_URL = config.get('urls', 'media', fallback='/media/')
 FILE_UPLOAD_DIRECTORY_PERMISSIONS = 0o755
 
 


### PR DESCRIPTION
this url customization is taken from pretix. This allow for a customization of the static and media urls. This is handy when using a reverse proxy from the same vhost for multiple Django app.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on a personal instance. The css for the event has to be regenerated by performing some change in the settings. 

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
