### PR TITLE
✨ make contents of sent mails selectable. Closes #827

### DIFF
--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -1,6 +1,7 @@
 {% extends "orga/mails/base.html" %}
 {% load bootstrap4 %}
 {% load i18n %}
+{% load rich_text %}
 
 {% block mail_content %}
     {% if form.instance.sent %}
@@ -14,13 +15,92 @@
         {% csrf_token %}
         <h2>{% trans "Mail Editor" %}</h2>
         {% bootstrap_form_errors form %}
-        {% bootstrap_field form.to layout='event' %}
-        {% if form.to_users %}{% bootstrap_field form.to_users layout='event' %}{% endif %}
-        {% bootstrap_field form.reply_to layout='event' %}
-        {% bootstrap_field form.cc layout='event' %}
-        {% bootstrap_field form.bcc layout='event' %}
-        {% bootstrap_field form.subject layout='event' %}
-        {% bootstrap_field form.text layout='event' %}
+
+        {% if not form.read_only %}
+          {% bootstrap_field form.to layout='event' %}
+          {% if form.to_users %}{% bootstrap_field form.to_users layout='event' %}{% endif %}
+          {% bootstrap_field form.reply_to layout='event' %}
+          {% bootstrap_field form.cc layout='event' %}
+          {% bootstrap_field form.bcc layout='event' %}
+          {% bootstrap_field form.subject layout='event' %}
+          {% bootstrap_field form.text layout='event' %}
+        {% else %}
+          <div class="container">
+            <div class="row mb-3">
+              <div class="col col-md-3 text-right font-weight-bold">
+                <label>To</label>
+              </div>
+              <div class="col col-md-9">
+                {{ form.instance.to|default:"-" }}
+              </div>
+            </div>
+
+            {% if form.to_users %}
+              <div class="row mb-3">
+                <div class="col col-md-3 text-right font-weight-bold">
+                  <label>To Users</label>
+                </div>
+                <div class="col col-md-9">
+                  {% for user in form.instance.to_users.all %}
+                    {% if user in request.event.submitters %}
+                        <a href="{% url "orga:speakers.view" event=request.event.slug pk=user.pk %}">
+                            {{ user }}
+                        </a>
+                    {% else %}
+                      {{ user }}{% endif %}{% if not forloop.last %},
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+            {% endif %}
+
+            <div class="row mb-3">
+              <div class="col col-md-3 text-right font-weight-bold">
+                <label>Reply-To</label>
+              </div>
+              <div class="col col-md-9">
+                {{ form.instance.reply_to|default:"-" }}
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col col-md-3 text-right font-weight-bold">
+                <label>CC</label>
+              </div>
+              <div class="col col-md-9">
+                {{ form.instance.cc|default:"-" }}
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col col-md-3 text-right font-weight-bold">
+                <label>BCC</label>
+              </div>
+              <div class="col col-md-9">
+                {{ form.instance.bcc|default:"-" }}
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col col-md-3 text-right font-weight-bold">
+                <label>Subject</label>
+              </div>
+              <div class="col col-md-9">
+                {{ form.instance.subject }}
+              </div>
+            </div>
+
+            <div class="row mb-3">
+              <div class="col col-md-3 text-right font-weight-bold">
+                <label>Text</label>
+              </div>
+              <div class="col col-md-9">
+                {{ form.instance.text|rich_text }}
+              </div>
+            </div>
+          </div>
+        {% endif %}
+
         <div class="submit-group">
             <span></span>
             <span>


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #827 . It does so by making the contents of mails selectable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. Sent an email.
2. Chose `Sent Emails` and then one of the emails there.
3. Tried to copy and paste the content.

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/9026972/71782153-5217ff80-2fd7-11ea-9feb-59354761bf22.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
