### PR TITLE
🎀 do not use two-column layout on mobile

### DIFF
--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -5,9 +5,9 @@
 
 {% bootstrap_form_errors form %}
 {% if no_form %}
-<div id="auth-form" class="password-input-form">
+<div id="auth-form" class="password-input-form d-md-flex flex-row">
 {% else %}
-<form id="auth-form" class="password-input-form" method="post" autocomplete="off">
+<form id="auth-form" class="password-input-form d-md-flex flex-row" method="post" autocomplete="off">
 {% endif %}
     {% csrf_token %}
     {% compress js %}

--- a/src/pretalx/static/common/scss/_forms.scss
+++ b/src/pretalx/static/common/scss/_forms.scss
@@ -57,9 +57,6 @@ form .form-control:disabled,
 }
 
 #auth-form {
-  display: flex;
-  flex-direction: row;
-
   .auth-form-block {
     flex-grow: 1;
     margin: 12px;


### PR DESCRIPTION
This PR disables the Two-Column-Layout for the Register/Login-Screen

## How Has This Been Tested?
Testen in Chrome and Firefox on MacOS.

## Screenshots (if appropriate):
Before:
<img width="300" alt="before" src="https://user-images.githubusercontent.com/142237/72524262-cbc6ad80-3861-11ea-8eea-e76fcd0f5227.png">
After:
<img width="300" alt="after" src="https://user-images.githubusercontent.com/142237/72524261-cbc6ad80-3861-11ea-8cc4-b8fbf2db3cf0.png">

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
