### PR TITLE
🎀 fix login width regression introduced in #856

### DIFF
--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -15,7 +15,7 @@
         <script defer src="{% static 'common/js/password_strength.js' %}"></script>
     {% endcompress %}
 {% if not hide_login %}
-    <div class="auth-form-block">
+    <div class="auth-form-block flex-grow-1">
         {% if not hide_login and not hide_register %}
         <h4 class="text-center">{% trans "I already have an account" %}</h4>
         {% endif %}
@@ -34,8 +34,7 @@
     </div>
 {% endif %}
 {% if not hide_register %}
-
-    <div class="auth-form-block">
+    <div class="auth-form-block flex-grow-1">
         {% if not hide_login and not hide_register %}
         <h4 class="text-center">{% trans "I need a new account" %}</h4>
         {% endif %}

--- a/src/pretalx/static/common/scss/_forms.scss
+++ b/src/pretalx/static/common/scss/_forms.scss
@@ -58,7 +58,6 @@ form .form-control:disabled,
 
 #auth-form {
   .auth-form-block {
-    flex-grow: 1;
     margin: 12px;
   }
 }


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes a ui regression with the orga login introduced in #856

## Screenshots (if appropriate):

## Checklist
before
![Bildschirmfoto 2020-01-16 um 16 05 37](https://user-images.githubusercontent.com/142237/72536671-f83af380-387a-11ea-9b1a-b4a54a4df913.png)

after
<img width="472" alt="Bildschirmfoto 2020-01-16 um 16 12 38" src="https://user-images.githubusercontent.com/142237/72536700-0852d300-387b-11ea-8b68-a68994c70f40.png">

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
