### PR TITLE
cleanup & enhance avatar selection gui

### DIFF
--- a/src/pretalx/agenda/templates/agenda/speaker.html
+++ b/src/pretalx/agenda/templates/agenda/speaker.html
@@ -27,10 +27,15 @@
             {{ profile.biography|rich_text }}
         </div>
         <div class="speaker-avatar">
-            {% if profile.user.get_gravatar %}
-            <img width="100%" src="https://www.gravatar.com/avatar/{{ profile.user.gravatar_parameter }}" alt="{% trans "The speaker's profile picture" %}"/>
-            {% elif profile.user.avatar %}
-            <img width="100%" src="{{ profile.user.avatar.url }}" alt="{% trans "The speaker's profile picture" %}">
+            {% if profile.user.get_gravatar or profile.user.avatar %}
+            <img width="100%"
+                 {% if profile.user.get_gravatar %}
+                 src="https://www.gravatar.com/avatar/{{ profile.user.gravatar_parameter }}"
+                 {% elif profile.user.avatar %}
+                 src="{{ profile.user.avatar.url }}"
+                 {% endif %}
+                 alt="{% trans "The speaker's profile picture" %}"
+            >
             {% endif %}
         </div>
     </section>

--- a/src/pretalx/cfp/templates/cfp/event/submission_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_profile.html
@@ -17,28 +17,11 @@
         {{ text|rich_text }}
     </p>
 
-    {% if request.event.settings.cfp_request_avatar %}
     {% bootstrap_form_errors form %}
-    <div class="avatar-form form-group row">
-        <label class="col-md-3 col-form-label">
-            {% trans "Profile picture" %}
-            <br>
-            <img
-            class="avatar float-right"
-            data-gravatar="{{ gravatar_parameter }}"
-            data-avatar=""
-            alt="{% trans "Your avatar" %}"
-            />
-        </label>
-        <div class="avatar-form-fields col-md-9">
-            {% bootstrap_field form.get_gravatar layout='event-inline' %}
-            <div class="user-avatar-display">
-                {% bootstrap_field form.avatar layout='inline' %}
-                <small class="form-text text-muted d-block">{{ profile_form.avatar.help_text }}</small>
-            </div>
-        </div>
-    </div>
+    {% if request.event.settings.cfp_request_avatar %}
+        {% include "common/avatar.html" with user=user form=form %}
     {% endif %}
+
     {% bootstrap_field form.name layout='event' %}
     {% if form.biography %}{% bootstrap_field form.biography layout='event' %}{% endif %}
     {% if form.availabilities %}

--- a/src/pretalx/cfp/templates/cfp/event/user_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_profile.html
@@ -23,30 +23,7 @@
         {% csrf_token %}
         {% bootstrap_form_errors profile_form %}
         {% if request.event.settings.cfp_request_avatar %}
-        <div class="avatar-form form-group row">
-            <label class="col-md-3 col-form-label">
-            {% trans "Profile picture" %}
-            <br>
-            <img
-              class="avatar float-right"
-              data-gravatar="{{ request.user.gravatar_parameter }}"
-              data-avatar="{% if request.user.avatar %}{{ request.user.avatar.url }}{% endif %}"
-              alt="{% trans "Your avatar" %}"
-              {% if request.user.get_gravatar %}
-              src="https://www.gravatar.com/avatar/{{ request.user.gravatar_parameter }}"
-              {% elif request.user.avatar and request.user.avatar != 'False' %}
-              src="{{ request.user.avatar.url }}"
-              {% endif %}
-            />
-            </label>
-            <div class="avatar-form-fields col-md-9">
-                {% bootstrap_field profile_form.get_gravatar layout='event-inline' %}
-                <div class="user-avatar-display">
-                    {% bootstrap_field profile_form.avatar layout='inline' %}
-                    <small class="form-text text-muted d-block">{{ profile_form.avatar.help_text }}</small>
-                </div>
-            </div>
-        </div>
+            {% include "common/avatar.html" with user=request.user form=profile_form %}
         {% endif %}
         {% bootstrap_field profile_form.name layout='event' %}
         {% if profile_form.biography %}{% bootstrap_field profile_form.biography layout='event' %}{% endif %}

--- a/src/pretalx/common/templates/common/avatar.html
+++ b/src/pretalx/common/templates/common/avatar.html
@@ -1,0 +1,28 @@
+{% load bootstrap4 %}
+{% load i18n %}
+
+<div class="avatar-form form-group row">
+    <label class="col-md-3 col-form-label">
+        {% trans "Profile picture" %}
+    </label>
+    <div class="avatar-form-fields col-md-9">
+        <img
+                class="avatar float-right {% if not user.avatar and not user.get_gravatar %}d-none{% endif %}"
+                data-gravatar="{{ user.gravatar_parameter }}"
+                data-avatar="{% if user.avatar %}{{ user.avatar.url }}{% endif %}"
+                alt="{% trans "Your avatar" %}"
+                {% if user.avatar %}
+                src="{{ user.avatar.url }}"
+                {% elif user.get_gravatar %}
+                src="https://www.gravatar.com/avatar/{{ user.gravatar_parameter }}?s=512"
+                {% endif %}
+        />
+
+        {% bootstrap_field form.get_gravatar layout='event-inline' %}
+
+        <div class="avatar-upload">
+            {% bootstrap_field form.avatar layout='inline' %}
+            <small class="form-text text-muted d-block">{{ profile_form.avatar.help_text }}</small>
+        </div>
+    </div>
+</div>

--- a/src/pretalx/common/templates/common/avatar.html
+++ b/src/pretalx/common/templates/common/avatar.html
@@ -6,19 +6,21 @@
         {% trans "Profile picture" %}
     </label>
     <div class="avatar-form-fields col-md-9">
-        <img
-                class="avatar float-right {% if not user.avatar and not user.get_gravatar %}d-none{% endif %}"
-                data-gravatar="{{ user.gravatar_parameter }}"
-                data-avatar="{% if user.avatar %}{{ user.avatar.url }}{% endif %}"
-                alt="{% trans "Your avatar" %}"
-                {% if user.avatar %}
-                src="{{ user.avatar.url }}"
-                {% elif user.get_gravatar %}
-                src="https://www.gravatar.com/avatar/{{ user.gravatar_parameter }}?s=512"
-                {% endif %}
-        />
+        <div class="d-flex align-items-start">
+            <img
+                    class="avatar {% if not user.avatar and not user.get_gravatar %}d-none{% endif %} order-1"
+                    data-gravatar="{{ user.gravatar_parameter }}"
+                    data-avatar="{% if user.avatar %}{{ user.avatar.url }}{% endif %}"
+                    alt="{% trans "Your avatar" %}"
+                    {% if user.avatar %}
+                    src="{{ user.avatar.url }}"
+                    {% elif user.get_gravatar %}
+                    src="https://www.gravatar.com/avatar/{{ user.gravatar_parameter }}?s=512"
+                    {% endif %}
+            />
 
-        {% bootstrap_field form.get_gravatar layout='event-inline' %}
+            {% bootstrap_field form.get_gravatar layout='event-inline' %}
+        </div>
 
         <div class="avatar-upload">
             {% bootstrap_field form.avatar layout='inline' %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -48,34 +48,8 @@
     <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {% bootstrap_form_errors form %}
-        <div class="speaker-info avatar-form form-group row">
-            <div class="col-md-3 col-form-label">
-                {% if form.instance.user.has_avatar %}
-                    <img
-                      class="avatar float-right"
-                      data-gravatar="{{ form.instance.user.gravatar_parameter }}"
-                      data-avatar="{% if form.instance.user.avatar %}{{ form.instance.user.avatar.url }}{% endif %}"
-                      alt="{% trans "The speaker's profile picture" %}"
-                      {% if form.instance.user.get_gravatar %}
-                      src="https://www.gravatar.com/avatar/{{ form.instance.user.gravatar_parameter }}"
-                      {% elif form.instance.user.has_local_avatar %}
-                      src="{{ form.instance.user.avatar.url }}"
-                      {% endif %}
-                    />
-                {% endif %}
-            </div>
-            {% if request.event.settings.cfp_request_avatar or form.instance.user.has_avatar %}
-            <div class="avatar-form-fields col-md-9">
-                {% if form.get_gravatar %}{% bootstrap_field form.get_gravatar layout='event-inline' %}{% endif %}
-                {% if form.avatar %}
-                <div class="user-avatar-display">
-                    {% bootstrap_field form.avatar layout='inline' %}
-                    <small class="form-text text-muted d-block">{{ form.avatar.help_text }}</small>
-                </div>
-                {% endif %}
-            </div>
-            {% endif %}
-        </div>
+
+        {% include "common/avatar.html" with user=form.instance.user form=form %}
         {% bootstrap_field form.name layout='event' %}
         {% bootstrap_field form.email layout='event' %}
         <div class="d-flex mb-4">

--- a/src/pretalx/person/forms.py
+++ b/src/pretalx/person/forms.py
@@ -169,6 +169,10 @@ class SpeakerProfileForm(
 
     def clean_avatar(self):
         avatar = self.cleaned_data.get("avatar")
+
+        if not avatar:
+            avatar = None
+
         if avatar:
             size = getattr(avatar, "_size", None)
             if avatar.file and size and size > 10 * 1024 * 1024:

--- a/src/pretalx/static/cfp/js/profile.js
+++ b/src/pretalx/static/cfp/js/profile.js
@@ -1,33 +1,66 @@
-document.addEventListener("DOMContentLoaded", function() {
-  const avatarImage = document.querySelector(".avatar-form img")
-  const avatarInput = document.querySelector(".user-avatar-display")
-  if (!avatarImage || !avatarInput)
-    return
-  for (const selector of ["#id_get_gravatar", "#id_profile-get_gravatar"]) {
-    let element = document.querySelector(selector)
-    if (element) {
-      element.addEventListener("click", () => {
-        if (element.checked) {
-          avatarImage.style.display = "block"
-          avatarImage.src =
-            "https://www.gravatar.com/avatar/" + avatarImage.dataset.gravatar
-          avatarInput.style.display = "none"
+$(function () {
+    const $image = $(".avatar-form img");
+    const $fileInput = $(".avatar-form .avatar-upload input[type=file]");
+    const $resetCheckbox = $(".avatar-form .avatar-upload input[type=checkbox]");
+    const $useGravatar = $('.avatar-form #id_get_gravatar');
+
+    $fileInput.on('change', function () {
+        let imageSelected = $fileInput.val() !== '';
+
+        if (imageSelected) {
+            $useGravatar.prop('checked', false);
+
+            let files = $fileInput.prop('files');
+            if (files) {
+                const reader = new FileReader();
+                reader.onload = function (e) {
+                    $image.attr('src', e.target.result);
+                    $image.removeClass('d-none');
+                };
+                reader.readAsDataURL(files[0]);
+                $resetCheckbox.prop('checked', false);
+            } else if ($image.data('avatar')) {
+                $image.attr('src', $image.data('avatar'));
+                $resetCheckbox.prop('checked', false);
+            } else {
+                $image.addClass('d-none');
+            }
+        } else if ($image.data('avatar')) {
+            $image.attr('src', $image.data('avatar'));
+            $image.removeClass('d-none');
+            $resetCheckbox.prop('checked', false);
         } else {
-          avatarInput.style.display = "block"
-          if (avatarImage.dataset.avatar) {
-            avatarImage.style.display = "block"
-            avatarImage.src = avatarImage.dataset.avatar
-          } else {
-            avatarImage.style.display = "none"
-          }
+            $image.addClass('d-none');
         }
-      })
-    }
-  }
-  const gravatarInput = document.querySelector("#id_get_gravatar")
-  if (gravatarInput && gravatarInput.checked) {
-    avatarInput.style.display = "none"
-    avatarImage.src =
-      "https://www.gravatar.com/avatar/" + avatarImage.dataset.gravatar
-  }
-})
+    });
+
+    $useGravatar.on('change', function () {
+        let gravatarSelected = $useGravatar.prop('checked');
+
+        if (gravatarSelected) {
+            $fileInput.val('');
+            $image.removeClass('d-none');
+            $image.attr('src', "https://www.gravatar.com/avatar/" + $image.data('gravatar') + '?s=512');
+            $resetCheckbox.prop('checked', true);
+        } else if ($image.data('avatar')) {
+            $image.attr('src', $image.data('avatar'));
+            $image.removeClass('d-none');
+            $resetCheckbox.prop('checked', false);
+        } else {
+            $image.addClass('d-none');
+        }
+    });
+
+    $resetCheckbox.on('change', function () {
+        let isResetSelected = $resetCheckbox.prop('checked');
+        if (isResetSelected) {
+            $fileInput.val('');
+            $image.addClass('d-none');
+        } else if ($image.data('avatar')) {
+            $image.attr('src', $image.data('avatar'));
+            $image.removeClass('d-none');
+        } else {
+            $image.addClass('d-none');
+        }
+    })
+});

--- a/src/pretalx/static/cfp/scss/_layout.scss
+++ b/src/pretalx/static/cfp/scss/_layout.scss
@@ -127,38 +127,6 @@ footer {
   margin: auto;
 }
 
-.avatar-form {
-  display: flex;
-  align-items: flex-start;
-
-  img.avatar {
-    padding-right: 16px;
-    margin-left: -16px;
-    max-width: 100%;
-    height: auto;
-  }
-
-  .avatar-form-fields {
-    display: flex;
-    flex-direction: column;
-
-    .bootstrap4-multi-input,
-    .bootstrap4-multi-input > .col-12 {
-      margin: 0;
-      padding: 0;
-    }
-
-    .form-group {
-      display: flex;
-      flex-direction: column;
-    }
-
-    .user-avatar-display .form-group {
-      margin-bottom: 0;
-    }
-  }
-}
-
 .add-speaker .input-group {
   padding-left: 8px;
 }

--- a/src/pretalx/static/cfp/scss/main.scss
+++ b/src/pretalx/static/cfp/scss/main.scss
@@ -6,5 +6,6 @@
 @import "../../common/scss/_forms";
 @import "../../common/scss/_dashboard";
 @import "../../common/scss/_stages";
+@import "../../common/scss/_avatar";
 @import "../../common/scss/pretalx";
 @import "_layout";

--- a/src/pretalx/static/common/scss/_avatar.scss
+++ b/src/pretalx/static/common/scss/_avatar.scss
@@ -1,0 +1,47 @@
+.avatar-form {
+  display: flex;
+  align-items: flex-start;
+
+  img.avatar {
+    width: 100px;
+    height: auto;
+
+    position: absolute;
+    right: 10px;
+  }
+
+  .avatar-form-fields {
+    display: flex;
+    flex-direction: column;
+
+    .bootstrap4-multi-input,
+    .bootstrap4-multi-input > .col-12 {
+      margin: 0;
+      padding: 0;
+    }
+
+    .form-group {
+      display: flex;
+      flex-direction: column;
+      margin-right: 110px;
+    }
+
+    .user-avatar-display .form-group {
+      margin-bottom: 0;
+    }
+  }
+
+  .avatar-upload .form-group {
+    display: block;
+
+    input[type=checkbox] {
+      margin: 0 2px 0 12px;
+    }
+
+    input[type=file] {
+      display: inline-block;
+      width: auto;
+      margin-left: 2px;
+    }
+  }
+}

--- a/src/pretalx/static/common/scss/_avatar.scss
+++ b/src/pretalx/static/common/scss/_avatar.scss
@@ -5,9 +5,6 @@
   img.avatar {
     width: 100px;
     height: auto;
-
-    position: absolute;
-    right: 10px;
   }
 
   .avatar-form-fields {
@@ -23,7 +20,6 @@
     .form-group {
       display: flex;
       flex-direction: column;
-      margin-right: 110px;
     }
 
     .user-avatar-display .form-group {

--- a/src/pretalx/static/orga/scss/_layout.scss
+++ b/src/pretalx/static/orga/scss/_layout.scss
@@ -337,37 +337,6 @@ footer {
   padding: 0 0.75rem;
 }
 
-.avatar-form {
-  display: flex;
-  align-items: flex-start;
-  padding-bottom: 8px;
-
-  img.avatar {
-    max-width: 100%;
-    height: auto;
-  }
-
-  .avatar-form-fields {
-    display: flex;
-    flex-direction: column;
-
-    .bootstrap4-multi-input,
-    .bootstrap4-multi-input > .col-12 {
-      margin: 0;
-      padding: 0;
-    }
-
-    .form-group {
-      display: flex;
-      flex-direction: column;
-    }
-
-    .user-avatar-display .form-group {
-      margin-bottom: 0;
-    }
-  }
-}
-
 .event-logo-field {
   img.event-logo-display {
     margin-left: 12px;

--- a/src/pretalx/static/orga/scss/main.scss
+++ b/src/pretalx/static/orga/scss/main.scss
@@ -6,6 +6,7 @@
 @import "../../common/scss/_availabilities";
 @import "../../common/scss/_dashboard";
 @import "../../common/scss/_stages";
+@import "../../common/scss/_avatar";
 @import "../../vendored/forkawesome/scss/fork-awesome";
 @import "../../vendored/datetimepicker/_bootstrap-datetimepicker";
 @import "../../common/scss/pretalx";


### PR DESCRIPTION
This PR cleans up code and UI around the avatar/gravatar selection. In the current master, the code for avatar-selection and -editing exists three times: in `cfp/…/submission_profile.html`, in `cfp/…/user_profile.html` and in `orga/…/speaker/form.html`. The HTML in these three places is slightly different. There is different CSS for this widget for Frontend and Backend.

This PR moves the relevant HTML and CSS into a central snippet unter `commons/…` and includes this from all three places.

Furthermore this PR enhances the user interaction between the avatar- and the gravatar-selection. Especially it
 - hides the "broken image" icon when nothing is selected
 - renders a local preview of an selected image
 - removes an selected image when gravatar is chosen
 - removes gravatar when an image is uploaded

## How Has This Been Tested?
The HTML, CSS and JS-Changes were tested on Chrome on MacOS.

## Screenshots (if appropriate):
### Before
<img width="1169" alt="Bildschirmfoto 2020-01-16 um 21 10 43" src="https://user-images.githubusercontent.com/142237/72559852-06ead000-38a6-11ea-9e1b-78651a28e023.png">
<img width="1156" alt="Bildschirmfoto 2020-01-16 um 21 10 55" src="https://user-images.githubusercontent.com/142237/72559853-06ead000-38a6-11ea-8d65-6f8c2f66f897.png">
<img width="393" alt="Bildschirmfoto 2020-01-16 um 21 11 09" src="https://user-images.githubusercontent.com/142237/72559855-06ead000-38a6-11ea-90fc-8f773d8f0244.png">
<img width="407" alt="Bildschirmfoto 2020-01-16 um 21 12 21" src="https://user-images.githubusercontent.com/142237/72559870-0fdba180-38a6-11ea-90cf-58a016aff75c.png">

### After
<img width="405" alt="Bildschirmfoto 2020-01-16 um 21 11 53" src="https://user-images.githubusercontent.com/142237/72559874-15d18280-38a6-11ea-9a14-98ee43ec6461.png">
<img width="409" alt="Bildschirmfoto 2020-01-16 um 21 12 43" src="https://user-images.githubusercontent.com/142237/72559878-19650980-38a6-11ea-9d46-5660a01784c3.png">
<img width="1170" alt="Bildschirmfoto 2020-01-16 um 21 12 59" src="https://user-images.githubusercontent.com/142237/72559883-1c5ffa00-38a6-11ea-895f-f74bee42e5d2.png">


## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
