### PR TITLE
📚 Fix code example for adding sidebar view

### DIFF
--- a/doc/developer/plugins/customview.rst
+++ b/doc/developer/plugins/customview.rst
@@ -59,8 +59,8 @@ your views::
 There is also a signal that allows you to add the view to the event sidebar navigation like this::
 
 
-    from django.core.urlresolvers import resolve, reverse
     from django.dispatch import receiver
+    from django.urls import resolve, reverse
     from django.utils.translation import ugettext_lazy as _
     from pretalx.orga.signals import nav_event
 


### PR DESCRIPTION
The example of adding a view to the event sidebar navigation used
an outdated django import.

`django.core.urlresolvers` was renamed to `django.urls`.