### PR TITLE
docs: show runserver command for custom IP:port

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -96,6 +96,10 @@ To run the local development server, execute::
 Now point your browser to http://localhost:8000/orga/ – You should be able to log in and play
 around!
 
+Alternatively, use this for a development server on a custom IP:port::
+
+    tox -e dev -- -m pretalx runserver 10.10.10.10:8888
+
 .. _`checksandtests`:
 
 Code checks and unit tests


### PR DESCRIPTION
if you want to access pretalx development server not on localhost, but on another (LAN) IP, you need this.

due to tox being in between, it needs a special commandline that is not very intuitive, so we better have that in the docs than requiring everybody to find this out.
