### PR TITLE
fix typo in referrer content

### DIFF
--- a/src/pretalx/common/templates/common/base.html
+++ b/src/pretalx/common/templates/common/base.html
@@ -12,7 +12,7 @@
     <meta name="application-name" content="pretalx">
     <meta name="generator" content="pretalx">
     <meta name="keywords" content="{% if request.event %}{{ request.event.name }}, {{ request.event.slug }}, {% if request.event.date_from %}{{ request.event.date_from.year }}, {% endif %}{% endif %}schedule, talks, cfp, call for papers, conference, submissions, organizer">
-    <meta name="referrer" content="strict-origin-when-crossorigin">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
     {{ html_head|safe }}
     {% if request.event and request.event.settings.meta_noindex %}<meta name="robots" content="noindex, nofollow">{% else %}<meta name="robots" content="index, follow">{% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -12,7 +12,7 @@
     <meta name="application-name" content="pretalx">
     <meta name="generator" content="pretalx">
     <meta name="keywords" content="{% if request.event %}{{ request.event.name }}, {{ request.event.slug }}, {% if request.event.date_from %}{{ request.event.date_from.year }}, {% endif %}{% endif %}schedule, talks, cfp, call for papers, conference, submissions, organizer">
-    <meta name="referrer" content="strict-origin-when-crossorigin">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
     <meta name="robots" content="nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#3aa57c">


### PR DESCRIPTION
https://lists.w3.org/Archives/Public/public-webappsec/2015May/0064.html

error from chromium console log:

Failed to set referrer policy:
The value 'strict-origin-when-crossorigin' is not one of 'always', ..., 'strict-origin-when-cross-origin', or 'unsafe-url'.
The referrer policy has been left unchanged.