### PR TITLE
📚 Fix development setup instructions

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -58,7 +58,7 @@ First up, check that ``tox`` is installed and working as expected::
 Then, create the local database::
 
     tox -e dev manage.py migrate
-    tox -e dev manage.py collectstatic --noinput
+    tox -e dev -- manage.py collectstatic --noinput
 
 To be able to log in, you should also create an admin user, organiser and team by running::
 


### PR DESCRIPTION
--noinput is a flag for collectstatic.
Without "--" it is recognized as a flag for tox.

## How Has This Been Tested?
Running the former command yielded the following results on my machine:
```
$ tox -e dev manage.py collectstatic --noinput
usage: tox [--version] [-h] [--help-ini] [-v] [-q] [--showconfig] [-l] [-a] [-c CONFIGFILE] [-e envlist] [--devenv ENVDIR] [--notest] [--sdistonly] [-p VAL] [-o] [--parallel--safe-build]
           [--installpkg PATH] [--develop] [-i URL] [--pre] [-r] [--result-json PATH] [--hashseed SEED] [--force-dep REQ] [--sitepackages] [--alwayscopy] [-s [val]] [--workdir PATH]
           [args [args ...]]
tox: error: unrecognized arguments: --noinput
```