### PR TITLE
Only show the secret public link if can_view_speakers

### DIFF
--- a/src/pretalx/orga/templates/orga/submission/base.html
+++ b/src/pretalx/orga/templates/orga/submission/base.html
@@ -78,7 +78,7 @@
             <summary class="btn btn-primary">{% trans "Links" %} <i class="fa fa-caret-down"></i></summary>
             <ul class="dropdown-content dropdown-content-sw">
                 {% if submission.state == "confirmed" %}<li><a href="{{ submission.urls.public.full }}" class="dropdown-item" target=_blank>{% trans "Public link" %}</a></li>{% endif %}
-                <li><a href="{{ submission.urls.review.full }}" class="dropdown-item" target=_blank>{% trans "Secret public link" %}</a></li>
+                {% if can_view_speakers %}<li><a href="{{ submission.urls.review.full }}" class="dropdown-item" target=_blank>{% trans "Secret public link" %}</a></li>{% endif %}
             </ul>
         </details>
     </ul>


### PR DESCRIPTION
Otherwise, during a anonymous review stage, this link appears, redirecting the reviewer to a page showing the speaker name.

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
