### PR TITLE
Make dropdown-content z-index very large

### DIFF
--- a/src/pretalx/static/common/scss/_dropdown.scss
+++ b/src/pretalx/static/common/scss/_dropdown.scss
@@ -12,7 +12,7 @@ details.dropdown {
   .dropdown-content {
     position: absolute;
     top: 100%;
-    z-index: 100;
+    z-index: 9999;
     min-width: 160px;
     max-width: 400px;
     padding: 4px 0;


### PR DESCRIPTION
This PR closes issue https://github.com/pretalx/pretalx/issues/973

It does so by making the z-index of the dropdown very large.
I guess 100 is just not that much when for the agenda page which has thousands of items

## How Has This Been Tested?
I made the corresponding change via developer tools in firefox.
I don't know how to compile SCSS or host pretalx locally


## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/5127634/88236091-23602e80-cc74-11ea-99a6-c9788d6e85c5.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
