### PR TITLE
Correct empty featured list message

### DIFF
--- a/src/pretalx/agenda/templates/agenda/featured.html
+++ b/src/pretalx/agenda/templates/agenda/featured.html
@@ -6,8 +6,8 @@
 
 {% block agenda_content %}
 <p>
-    <b>{% trans "Welcome to our list of featured talks!" %}</b><br><br>
     {% if talks %}
+    <b>{% trans "Welcome to our list of featured talks!" %}</b><br><br>
     {% blocktrans trimmed %}
     We prepared a list of exciting talks, so you can get a feel for our
     conference. Please keep in mind that this is not our full schedule.

--- a/src/pretalx/agenda/views/schedule.py
+++ b/src/pretalx/agenda/views/schedule.py
@@ -429,7 +429,7 @@ class ScheduleView(ScheduleDataView):
             messages.success(
                 request,
                 _(
-                    "Our schedule is not live yet, but we have this list of featured talks available!"
+                    "Our schedule is not live yet"
                 ),
             )
             return HttpResponseRedirect(self.request.event.urls.featured)


### PR DESCRIPTION
If someone ends up in the featured talks page when there are no featured talks, the messaging should be consistent.

The "Welcome!" now only appears if there are talks, and the success banner no longer assumes state of the list.

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
