### PR TITLE
Improvements to public talk/speaker page

### DIFF
--- a/src/pretalx/agenda/templates/agenda/speaker.html
+++ b/src/pretalx/agenda/templates/agenda/speaker.html
@@ -30,7 +30,7 @@
             {% if profile.user.get_gravatar or profile.user.avatar %}
             <img width="100%"
                  {% if profile.user.get_gravatar %}
-                 src="https://www.gravatar.com/avatar/{{ profile.user.gravatar_parameter }}"
+                 src="https://www.gravatar.com/avatar/{{ profile.user.gravatar_parameter }}?s=200"
                  {% elif profile.user.avatar %}
                  src="{{ profile.user.avatar.url }}"
                  {% endif %}

--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -135,6 +135,7 @@
                             </div>
                         </a>
                         <div class="info">
+                            {{ speaker.talk_profile.biography|rich_text }}
                             {% if speaker.other_submissions.count > 1 %}
                                 {{ phrases.agenda.speaker_other_talks }}
                                 <ul class="speaker-talks">


### PR DESCRIPTION
A Pull Request in two parts: 


### Talk page: Add speaker bio

Much consideration was taken to this page, but given the existing translations and layout of the click-through speaker page, the minimal default profile information, just the bio has been added to the talk page.

<img width="425" alt="Bio before" src="https://user-images.githubusercontent.com/813732/89093060-559f2800-d3fa-11ea-8d9a-5aaa63ea534a.png"> <img width="449" alt="Bio after" src="https://user-images.githubusercontent.com/813732/89093062-58018200-d3fa-11ea-9167-7f5d8bf619b7.png">


### Improve resolution of retrieved gravatar

Previously: the retrieved gravatar was the default 80x80 size, in a `.speaker-avatar` div of width 180

Now: retrieved avatar is 200x200, which is larger than the display size, but is still a useful size for clearer display.
<img width="406" alt="Avatar before" src="https://user-images.githubusercontent.com/813732/89093065-59cb4580-d3fa-11ea-8f5f-efafe0541526.png">
<img width="325" alt="Avatar after" src="https://user-images.githubusercontent.com/813732/89093063-5932af00-d3fa-11ea-802e-ea61a3eaabf1.png"> 




## How Has This Been Tested?

Testing in local instance

## Screenshots (if appropriate):

See above

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
