### PR TITLE
Update installation.rst

### DIFF
--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -152,7 +152,11 @@ the appropriate dependencies. Please note that you should also use
 We also need to create a data directory::
 
     $ mkdir -p /var/pretalx/data/media
-
+   
+Then, create the folder for the static files::
+    
+    $ mkdir /var/pretalx/static
+ 
 We compile static files and translation data and create the database structure::
 
     $ python -m pretalx migrate


### PR DESCRIPTION
Added the option to create /var/pretalx/static from the pretalx user, if the folder is not created the static files by defect will end in /var/pretalx/.local/bin/...... (the python env), after creating the folder writable by the user the files are now dropped into that folder.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #XX. It does so by …

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
