### PR TITLE
🎀 Add placeholder to email settings password field

### DIFF
--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -19,6 +19,7 @@ from pretalx.common.phrases import phrases
 from pretalx.event.models.event import Event, Event_SettingsStore
 from pretalx.orga.forms.widgets import HeaderSelect, MultipleLanguagesWidget
 
+ENCRYPTED_PASSWORD_PLACEHOLDER = "*******"
 
 class EventForm(ReadOnlyFlag, I18nModelForm):
     locales = forms.MultipleChoiceField(
@@ -362,9 +363,11 @@ class MailSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):
             self.fields["mail_from"].help_text += " " + _(
                 "Leave empty to use the default address: {}"
             ).format(settings.MAIL_FROM)
-        # TODO: Refactor into its own method
+        self.set_encrypted_password_placeholder()
+        
+    def set_encrypted_password_placeholder(self):
         if self.initial["smtp_password"]:
-            self.fields["smtp_password"].widget.attrs["placeholder"] = "*******"
+            self.fields["smtp_password"].widget.attrs["placeholder"] = ENCRYPTED_PASSWORD_PLACEHOLDER
 
     def clean(self):
         data = self.cleaned_data

--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -21,6 +21,7 @@ from pretalx.orga.forms.widgets import HeaderSelect, MultipleLanguagesWidget
 
 ENCRYPTED_PASSWORD_PLACEHOLDER = "*******"
 
+
 class EventForm(ReadOnlyFlag, I18nModelForm):
     locales = forms.MultipleChoiceField(
         label=_("Active languages"),
@@ -364,10 +365,12 @@ class MailSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):
                 "Leave empty to use the default address: {}"
             ).format(settings.MAIL_FROM)
         self.set_encrypted_password_placeholder()
-        
+
     def set_encrypted_password_placeholder(self):
         if self.initial["smtp_password"]:
-            self.fields["smtp_password"].widget.attrs["placeholder"] = ENCRYPTED_PASSWORD_PLACEHOLDER
+            self.fields["smtp_password"].widget.attrs[
+                "placeholder"
+            ] = ENCRYPTED_PASSWORD_PLACEHOLDER
 
     def clean(self):
         data = self.cleaned_data

--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -362,6 +362,9 @@ class MailSettingsForm(ReadOnlyFlag, I18nFormMixin, HierarkeyForm):
             self.fields["mail_from"].help_text += " " + _(
                 "Leave empty to use the default address: {}"
             ).format(settings.MAIL_FROM)
+        # TODO: Refactor into its own method
+        if self.initial["smtp_password"]:
+            self.fields["smtp_password"].widget.attrs["placeholder"] = "*******"
 
     def clean(self):
         data = self.cleaned_data


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
When inheriting an event, it was unclear if this event already had a password set up.  Now if there is no password, the password's placeholder will be "Password". If there is a password, the placeholder will be "********" (8 asterisks) these eight asterisks are stored as a global constant for convenient changing

<!--- If it fixes an open issue, please link to the issue here. -->
This PR closes/references issue #994. It does so by completing functionality discussed above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
User testing.  I created new events and changed the passwords.  I also inherited events that both did and did not have existing passwords.

<!--- Include details of your testing environment, and the tests you ran to -->
Mac OSX and venv

<!--- see how your change affects other areas of the code, etc. -->
I did not notice any other changes in flexibility

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X] My code follows the code style of this project. (I believe so)
- [X] My change requires a change to the documentation. (This would be up to maintainer's discretion)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed. (Only failing tests seem to be environment driven rather than code driven)
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
