### PR TITLE
Add submission_type to email template

### DIFF
--- a/src/pretalx/mail/context.py
+++ b/src/pretalx/mail/context.py
@@ -26,6 +26,10 @@ def get_context_explanation():
             ),
         },
         {
+            "name": "submission_type",
+            "explanation": _("The type of the submission including the duration."),
+        },
+        {
             "name": "speakers",
             "explanation": _("The name(s) of all speakers in this submission."),
         },
@@ -50,6 +54,7 @@ def template_context_from_submission(submission):
             "confirmation_link": submission.urls.confirm.full(),
             "submission_title": submission.title,
             "submission_url": submission.urls.user_base.full(),
+            "submission_type": submission.submission_type,
             "speakers": submission.display_speaker_names,
             "orga_url": submission.orga_urls.base.full(),
             "track_name": str(submission.track.name) if submission.track else None,


### PR DESCRIPTION
This does not only contain the submission type itself, but also its duration.
This is useful information for the speaker, hence I dare to have it included.

If speaker submitted several types, it's useful as a reminder which one it was.

## How Has This Been Tested?

I've use the democon data and edited the "Accept Mail" template to include `{submission_type}` in the subject as well as the body. It then showed up correctly in the email queue when I was accepting an email.

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.

Not all tests passed, but the tests that failed also failed on current HEAD.