### PR TITLE
schedule/ascii: Ensure newline in !talk.submission

### DIFF
--- a/src/pretalx/schedule/ascii.py
+++ b/src/pretalx/schedule/ascii.py
@@ -26,7 +26,7 @@ def draw_schedule_list(data):
                         talk.room.name,
                     )
                     if talk.submission
-                    else "{} in {}".format(talk.description, talk.room.name)
+                    else "{} in {}\n".format(talk.description, talk.room.name)
                 )
                 for talk in talk_list
             )


### PR DESCRIPTION
Seems like breaks and non-submissions does not get a newline when being
printed.

    $ curl "https://pretalx.com/arch-conf-online-2020/talk/?format=list"

    # [snip]

    * 14:00 Break - DJ Set in Arch Conf* 15:00 Protecting secrets and se...
    * 16:00 Custom Kernels on Edge Devices in 2020, Angad Sharma (en); i...

Signed-off-by: Morten Linderud <morten@linderud.pw>