### PR TITLE
Fix display of date on talk page

### DIFF
--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -42,7 +42,7 @@
         </div>
         <small>
             {% if talk_slots|length == 1 %}
-                {{ talk_slots.0.start.date|date:"c" }}, {{ talk_slots.0.start|date:"H:i" }}–{{ talk_slots.0.end|date:"H:i" }}, {{ talk_slots.0.room.name }}
+                {{ talk_slots.0.start|date:"Y-m-d" }}, {{ talk_slots.0.start|date:"H:i" }}–{{ talk_slots.0.end|date:"H:i" }}, {{ talk_slots.0.room.name }}
             {% endif %}
             {% if request.event.is_multilingual %}
             <div class="speakers">
@@ -64,7 +64,7 @@
             <ul class="talk-slots">
                 {% for talk in talk_slots %}
                 <li class="talk-slot">
-                    {{ talk.start.date|date:"c" }}, {{ talk.start|date:"H:i" }}–{{ talk.end|date:"H:i" }}, {{ talk.room.name }}
+                    {{ talk.start|date:"Y-m-d" }}, {{ talk.start|date:"H:i" }}–{{ talk.end|date:"H:i" }}, {{ talk.room.name }}
                 </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->

When the date stored in the database for a talk (eg in UTC time) is the day before (eg 1 December 2020), but the talk will actually take place on 2 December 2020 due to the timezone difference, the talk page will display the date of 1 December 2020 instead of 2 December 2020.

This change makes sure the date object doesn't lose it's timezone component by being converted to a simple date object and instead uses a "Y-m-d" formatter to display it.

This fix is only for the talk template: I suggest looking over the template code for places where this is used:

.date|date:"c"

and replace it with:

|date:"Y-m-d"


## How Has This Been Tested?

Code updated on local copy of site and results appear to match expected date display

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
