### PR TITLE
Add confirmation to single mail deletion

### DIFF
--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -266,7 +266,7 @@ urlpatterns = [
                             ),
                             re_path(
                                 "^(?P<pk>[0-9]+)/delete$",
-                                mails.OutboxPurge.as_view(),
+                                mails.MailDelete.as_view(),
                                 name="mails.outbox.mail.delete",
                             ),
                             re_path(

--- a/src/tests/orga/views/test_orga_views_mail.py
+++ b/src/tests/orga/views/test_orga_views_mail.py
@@ -186,10 +186,18 @@ def test_orga_can_discard_all_mails(orga_client, event, mail, other_mail, sent_m
 
 
 @pytest.mark.django_db
+def test_orga_can_view_discard_mail_confirm(orga_client, event, mail):
+    with scope(event=event):
+        assert QueuedMail.objects.count() == 1
+    response = orga_client.get(mail.urls.delete, follow=True)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
 def test_orga_can_discard_single_mail(orga_client, event, mail, other_mail):
     with scope(event=event):
         assert QueuedMail.objects.count() == 2
-    response = orga_client.get(mail.urls.delete, follow=True)
+    response = orga_client.post(mail.urls.delete, follow=True)
     assert response.status_code == 200
     with scope(event=event):
         assert QueuedMail.objects.count() == 1


### PR DESCRIPTION
This PR closes/references issue #967. It does so by adding a confirmation dialog before deleting a single email

## How Has This Been Tested?
Unit tests added
Deleting single emails from http://localhost:8000/orga/event/democon/mails/outbox/
Deleting all emails from http://localhost:8000/orga/event/democon/mails/outbox/

Tested on mac

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. - failing on master for other reasons, not included in this PR 
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
