### PR TITLE
Fix Link-Example

### DIFF
--- a/doc/user/markdown.rst
+++ b/doc/user/markdown.rst
@@ -36,7 +36,7 @@ on the right:
 | .. code-block:: md                       |                                      |
 |                                          | Look at https://pretalx.com.         |
 |     Look at https://pretalx.com.         |                                      |
-|     Look at [this](https://pretalx.com.) | Look at this_.                       |
+|     Look at [this](https://pretalx.com). | Look at this.                        |
 +------------------------------------------+--------------------------------------+
 | .. code-block:: md                       |                                      |
 |                                          |                                      |


### PR DESCRIPTION
Our users were adding dots to the End of their URLs, according to the examples, and they did not work.

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
