### PR TITLE
Fix help texts and logo's scaling

### DIFF
--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -37,19 +37,19 @@ class EventForm(ReadOnlyFlag, I18nModelForm):
     )
     logo = ImageField(
         required=False,
-        label=_("Header image"),
+        label="",
         help_text=_(
-            "If you provide a header image, it will be displayed instead of your event's color and/or header pattern "
-            "on top of all event pages. It will be center-aligned, so when the window shrinks, the center parts will "
-            "continue to be displayed, and not stretched."
+            "If you provide a logo image, we will by default not show your event's name and date in the page header. "
+            "We will show your logo in its full size if possible, scaled down to the full header width."
         ),
     )
     header_image = ImageField(
         required=False,
-        label=_("Header image"),
+        label="",
         help_text=_(
-            "If you provide a logo image, we will by default not show your event's name and date in the page header. "
-            "We will show your logo in its full size if possible, scaled down to the full header width otherwise."
+            "If you provide a header image, it will be displayed instead of your event's color and/or header pattern "
+            "on top of all event pages. It will be center-aligned, so when the window shrinks, the center parts will "
+            "continue to be displayed, and not stretched."
         ),
     )
     custom_css_text = forms.CharField(

--- a/src/pretalx/orga/templates/orga/settings/form.html
+++ b/src/pretalx/orga/templates/orga/settings/form.html
@@ -76,7 +76,7 @@
                 />
                 {% endif %}
                 <br>
-                {% bootstrap_field form.logo layout='inline' %}
+                {% bootstrap_field form.logo %}
             </div>
         </div>
         <div class="event-logo-field form-group row">
@@ -89,7 +89,7 @@
                 />
                 {% endif %}
                 <br>
-                {% bootstrap_field form.header_image layout='inline' %}
+                {% bootstrap_field form.header_image %}
             </div>
         </div>
         <div {% if request.event.primary_color %}style="--color: {{ request.event.primary_color }}"{% endif %} class="colorpicker-update">

--- a/src/pretalx/static/cfp/scss/_layout.scss
+++ b/src/pretalx/static/cfp/scss/_layout.scss
@@ -58,8 +58,7 @@ header {
 }
 
 #event-logo {
-  height: auto;
-  width: 100%;
+  max-height: 200px;
   margin-top: -50px;
   margin-bottom: 8px;
 }


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes issues #1082 & #1084. It does so by fixing help texts for logo and header images in event's settings. Also, we changed  #event-logo height rule to max-height and deleted width rule.

## Screenshots:

![Screenshot (279)](https://user-images.githubusercontent.com/56487775/114321746-0383da00-9b25-11eb-9f8b-6a2a4ee81d4f.png)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All existing tests passed.
