### PR TITLE
📚 Update section for email in development setup

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -144,16 +144,17 @@ afterwards to format that file.
 Working with mails
 ^^^^^^^^^^^^^^^^^^
 
-If you want to test emails in your development setup, we recommend starting
-Python's debugging SMTP server in a separate shell and configuring pretalx to
-use it. The debugging SMTP server will print every email to its stdout.
+When running in development mode, Pretalx uses Django's console email backend.
+This means the development server will print any emails to its stdout, instead
+of sending them via SMTP.
 
-Add this to your ``src/pretalx.cfg``::
+If you want to test sending event emails via a custom SMTP server, we recommend
+starting Python's debugging SMTP server in a separate shell::
 
-    [mail]
-    port = 1025
+    python -m smtpd -n -c DebuggingServer localhost:1025
 
-Then execute ``python -m smtpd -n -c DebuggingServer localhost:1025``.
+You can use this server by specifying host ``localhost`` and port ``1025`` in
+the event email settings.
 
 Working with translations
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
When running in development mode, the server is using Django's console
email backend and prints mails to stdout instead of sending them via
SMTP.

The mail configuration is also not loaded by `settings.py` leading to the
proposed port setting of 1025 to be ignored, and default settings
showing up in the admin information, which was a bit confusing to me.

Python's debugging SMTP server was still news to me, so I think it is
useful to keep that information around, in case somebody needs to test
interactions via SMTP.