### PR TITLE
Tests for PR #1123

### DIFF
--- a/src/pretalx/submission/models/question.py
+++ b/src/pretalx/submission/models/question.py
@@ -221,7 +221,7 @@ class Question(LogMixin, models.Model):
         _now = now()
         # Question should become optional in order to be frozen
         if self.read_only:
-            return True
+            return False
         if self.question_required == QuestionRequired.REQUIRED:
             return True
         if self.question_required == QuestionRequired.AFTER_DEADLINE:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -197,6 +197,154 @@ def question(event):
 
 
 @pytest.fixture
+def question_required_always(event):
+    with scope(event=event):
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            question_required=QuestionRequired.REQUIRED,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_required_after_option_before_deadline(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_deadline = dt.datetime.now().replace(tzinfo=utc) + dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            deadline=date_of_deadline,
+            question_required=QuestionRequired.AFTER_DEADLINE,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_freeze_after_option_before_deadline_question_required_optional(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_freeze = dt.datetime.now().replace(tzinfo=utc) + dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            freeze_after=date_of_freeze,
+            question_required=QuestionRequired.OPTIONAL,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_freeze_after_option_after_deadline_question_required_optional(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_freeze = dt.datetime.now().replace(tzinfo=utc) - dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            freeze_after=date_of_freeze,
+            question_required=QuestionRequired.OPTIONAL,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_freeze_after_option_before_deadline_question_required_required(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_freeze = dt.datetime.now().replace(tzinfo=utc) + dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            freeze_after=date_of_freeze,
+            question_required=QuestionRequired.REQUIRED,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_freeze_after_option_after_deadline_question_required_required(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_freeze = dt.datetime.now().replace(tzinfo=utc) - dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            freeze_after=date_of_freeze,
+            question_required=QuestionRequired.REQUIRED,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_freeze_after_option_after_deadline(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_freeze = dt.datetime.now().replace(tzinfo=utc) - dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            freeze_after=date_of_freeze,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_freeze_after_option_before_deadline(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_freeze = dt.datetime.now().replace(tzinfo=utc) + dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            freeze_after=date_of_freeze,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
+def question_required_after_option_after_deadline(event):
+    with scope(event=event):
+        utc = pytz.timezone(event.timezone)
+        date_of_deadline = dt.datetime.now().replace(tzinfo=utc) - dt.timedelta(weeks=4)
+        return Question.objects.create(
+            event=event,
+            question="How much do you like green, on a scale from 1-10?",
+            variant=QuestionVariant.NUMBER,
+            target="submission",
+            deadline=date_of_deadline,
+            question_required=QuestionRequired.AFTER_DEADLINE,
+            contains_personal_data=False,
+            position=1,
+        )
+
+
+@pytest.fixture
 def inactive_question(event):
     with scope(event=event):
         return Question.objects.create(

--- a/src/tests/submission/test_question_model.py
+++ b/src/tests/submission/test_question_model.py
@@ -27,6 +27,84 @@ def test_missing_answers_submission_question(submission, target, question):
 
 
 @pytest.mark.django_db
+def test_question_required_property_optional_questions(question):
+    assert question.required is False
+
+
+@pytest.mark.django_db
+def test_question_required_property_always_required_questions(question_required_always):
+    assert question_required_always.required is True
+
+
+@pytest.mark.django_db
+def test_question_required_property_required_after_option_before_deadline(
+    question_required_after_option_before_deadline,
+):
+    assert question_required_after_option_before_deadline.required is False
+
+
+@pytest.mark.django_db
+def test_question_required_property_required_after_option_after_deadline(
+    question_required_after_option_after_deadline,
+):
+    assert question_required_after_option_after_deadline.required is True
+
+
+@pytest.mark.django_db
+def test_question_required_property_freeze_after_option_before_deadline_question_required_optional(
+    question_freeze_after_option_before_deadline_question_required_optional,
+):
+    assert (
+        question_freeze_after_option_before_deadline_question_required_optional.required
+        is False
+    )
+
+
+@pytest.mark.django_db
+def test_question_required_property_freeze_after_option_after_deadline_question_required_optional(
+    question_freeze_after_option_after_deadline_question_required_optional,
+):
+    assert (
+        question_freeze_after_option_after_deadline_question_required_optional.required
+        is False
+    )
+
+
+@pytest.mark.django_db
+def test_question_required_property_freeze_after_option_after_deadline_question_required(
+    question_freeze_after_option_after_deadline_question_required_required,
+):
+    assert (
+        question_freeze_after_option_after_deadline_question_required_required.required
+        is False
+    )
+
+
+@pytest.mark.django_db
+def test_question_required_property_freeze_after_option_before_deadline_question_required(
+    question_freeze_after_option_before_deadline_question_required_required,
+):
+    assert (
+        question_freeze_after_option_before_deadline_question_required_required.required
+        is True
+    )
+
+
+@pytest.mark.django_db
+def test_question_property_freeze_after_option_after_deadline(
+    question_freeze_after_option_after_deadline,
+):
+    assert question_freeze_after_option_after_deadline.read_only is True
+
+
+@pytest.mark.django_db
+def test_question_property_freeze_after_option_before_deadline(
+    question_freeze_after_option_before_deadline,
+):
+    assert question_freeze_after_option_before_deadline.read_only is False
+
+
+@pytest.mark.django_db
 def test_question_base_properties(submission, question):
     a = Answer.objects.create(answer="True", submission=submission, question=question)
     assert a.event == question.event


### PR DESCRIPTION
This PR is linked to PR #1123 and adds tests on issue #1069 from discussions . Based on codecov reports of the previous PR, we added tests in ```test_orga_views_cfp.py``` and ```test_question_model.py```. Also, we noticed that the ```required``` property in ```Question``` model returns True if the question is ```read_only```, which we also fixed.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
