### PR TITLE
fix redis port number in docs

### DIFF
--- a/doc/administrator/configure.rst
+++ b/doc/administrator/configure.rst
@@ -262,7 +262,7 @@ session storage to speed up operations. You will need to install ``django_redis`
 ~~~~~~~~~~~~
 
 - The location of redis, if you want to use it as a cache.
-  ``'redis://[:password]@127.0.0.1:6397/1'`` would be a sensible value, or
+  ``'redis://[:password]@127.0.0.1:6379/1'`` would be a sensible value, or
   ``unix://[:password]@/path/to/socket.sock?db=0`` if you prefer to use sockets.
 - **Environment variable:** ``PRETALX_REDIS``
 - **Default:** ``''``


### PR DESCRIPTION
I noticed that the port number in the config description is confusing as 6379 is the "normal" port number for redis

I'm also a bit confused by these lines:
https://github.com/pretalx/pretalx/blob/ce106b7b140c0e0f2178bf7387acbedc4c2c809a/doc/administrator/configure.rst#L270-L276

This setting seems to be a boolean, which would mean that a "sensible value" of a string doesn't make any sense.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
