### PR TITLE
no quotation signs in config file

### DIFF
--- a/doc/administrator/configure.rst
+++ b/doc/administrator/configure.rst
@@ -25,7 +25,7 @@ file looks like this:
 The configuration format is the INI file format as understood by `Python`_.
 It's worth mentioning that you can use any of 'yes'/'no', 'on'/'off',
 'true'/'false' and '1'/'0' to set boolean settings. You can add add comments by
-starting a line with ';' or '#'.
+starting a line with ';' or '#'. Also strings don't need to be quoted as every value is already a string.
 
 The filesystem section
 ----------------------
@@ -240,7 +240,7 @@ cycle.
 ~~~~~~~~~~~
 
 - The celery backend. If you use a standard redis-based setup,
-  ``'redis://127.0.0.1/1'`` would be a sensible value.
+  ``redis://127.0.0.1/1`` would be a sensible value.
 - **Environment variable:** ``PRETALX_CELERY_BACKEND``
 - **Default:** ``''``
 
@@ -248,7 +248,7 @@ cycle.
 ~~~~~~~~~~~
 
 - The celery broker. If you use a standard redis-based setup,
-  ``'redis://127.0.0.1/2'`` would be a sensible value.
+  ``redis://127.0.0.1/2`` would be a sensible value.
 - **Environment variable:** ``PRETALX_CELERY_BROKER``
 - **Default:** ``''``
 
@@ -262,7 +262,7 @@ session storage to speed up operations. You will need to install ``django_redis`
 ~~~~~~~~~~~~
 
 - The location of redis, if you want to use it as a cache.
-  ``'redis://[:password]@127.0.0.1:6379/1'`` would be a sensible value, or
+  ``redis://[:password]@127.0.0.1:6379/1`` would be a sensible value, or
   ``unix://[:password]@/path/to/socket.sock?db=0`` if you prefer to use sockets.
 - **Environment variable:** ``PRETALX_REDIS``
 - **Default:** ``''``
@@ -271,7 +271,6 @@ session storage to speed up operations. You will need to install ``django_redis`
 ~~~~~~~~~~~
 
 - If you want to use redis as your session storage, set this to ``True``.
-  ``'redis://127.0.0.1/2'`` would be a sensible value.
 - **Environment variable:** ``PRETALX_REDIS_SESSIONS``
 - **Default:** ``False``
 
@@ -290,7 +289,7 @@ The logging section
 
 - The log level to start sending emails at. Any of ``[DEBUG, INFO, WARNING, ERROR, CRITICAL]``.
 - **Environment variable:** ``PRETALX_LOGGING_EMAIL_LEVEL``
-- **Default:** ``'ERROR'``
+- **Default:** ``ERROR``
 
 The locale section
 ------------------
@@ -300,14 +299,14 @@ The locale section
 
 - The system's default locale.
 - **Environment variable:** ``PRETALX_LANGUAGE_CODE``
-- **Default:** ``'en'``
+- **Default:** ``en``
 
 ``time_zone``
 ~~~~~~~~~~~~~
 
 - The system's default time zone as a ``pytz`` name.
 - **Environment variable:** ``PRETALX_TIME_ZONE``
-- **Default:** ``'UTC'``
+- **Default:** ``UTC``
 
 
 .. _Python: https://docs.python.org/3/library/configparser.html


### PR DESCRIPTION
related to #1136

When I tried to set up Pretalx yesterday I got stuck for quite some time getting mysterious errors like `ValueError: Redis URL must specify one of the following schemes (redis://, rediss://, unix://)` or `ValueError: Incorrect timezone setting: "Europe/Berlin"`. 
After missing the forest for the trees for some time, I finally noticed that I was always entering `backend = 'redis://127.0.0.1/1'` and similar values in the config file, but python ini files don't need any quotes and in fact then use the quotes as part of the string which makes the error messages really confusing.

So I think this should be made a bit more clear in the docs in case someone else is coming across the same issue.

 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
