### PR TITLE
🎀 show sessions in full-width too

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -5,7 +5,7 @@
 
 {% block body_tag %}{% if not request.event.settings.schedule_display or request.event.settings.schedule_display == "proportional" %} class="body-schedule"{% endif %}{% endblock %}
 
-{% block container_width %}{% if not show_talk_list %} main-schedule{% endif %}{% endblock %}
+{% block container_width %}{% if not show_talk_list %} main-schedule {% else %} main-sessions {% endif %}{% endblock %}
 
 {% block agenda_custom_header %}
     {% compress js %}

--- a/src/pretalx/agenda/templates/agenda/schedule.html
+++ b/src/pretalx/agenda/templates/agenda/schedule.html
@@ -5,7 +5,7 @@
 
 {% block body_tag %}{% if not request.event.settings.schedule_display or request.event.settings.schedule_display == "proportional" %} class="body-schedule"{% endif %}{% endblock %}
 
-{% block container_width %}{% if not show_talk_list %} main-schedule {% else %} main-sessions {% endif %}{% endblock %}
+{% block container_width %}{% if not show_talk_list %} main-schedule{% else %} main-sessions{% endif %}{% endblock %}
 
 {% block agenda_custom_header %}
     {% compress js %}

--- a/src/pretalx/static/agenda/scss/_agenda.scss
+++ b/src/pretalx/static/agenda/scss/_agenda.scss
@@ -1,3 +1,6 @@
+#main-container.main-sessions {
+  max-width: calc(100vw);
+}
 #main-container.main-schedule {
   min-width: min-content;
   max-width: calc(100vw);


### PR DESCRIPTION
If running an event with more than 3 days the session screen is fixed width and not full-width as the schedule.

An example of the problem is accessible under https://fahrplan.privacyweek.at/pw21/talk/#

## How Has This Been Tested?
local tests in multiple browsers. 

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
