### PR TITLE
fix missing "haben" in release msgstr

### DIFF
--- a/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
@@ -3559,7 +3559,7 @@ msgstr "Vortragende über Änderungen informieren"
 
 #: pretalx/orga/forms/schedule.py:24
 msgid "We released a new schedule version!"
-msgstr "Wir eine neue Programmversion veröffentlicht!"
+msgstr "Wir haben eine neue Programmversion veröffentlicht!"
 
 #: pretalx/orga/forms/schedule.py:31
 msgid "This schedule version was used already, please choose a different one."

--- a/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
@@ -3568,7 +3568,7 @@ msgstr "Vortragende über Änderungen informieren"
 
 #: pretalx/orga/forms/schedule.py:24
 msgid "We released a new schedule version!"
-msgstr "Wir eine neue Programmversion veröffentlicht!"
+msgstr "Wir haben eine neue Programmversion veröffentlicht!"
 
 #: pretalx/orga/forms/schedule.py:31
 msgid "This schedule version was used already, please choose a different one."


### PR DESCRIPTION
This PR fixes a grammar issue in two strings. The german translation (both formal and non-formal) of the information about a new release is missing a "haben".
## Checklist

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
