### PR TITLE
Fix incorrect HTTP header name

### DIFF
--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -234,7 +234,7 @@ The following snippet is an example on how to configure an nginx proxy for preta
         ssl_certificate /path/to/cert.chain.pem;
         ssl_certificate_key /path/to/key.pem;
 
-        add_header Referrer-Options same-origin;
+        add_header Referrer-Policy same-origin;
         add_header X-Content-Type-Options nosniff;
 
         location / {


### PR DESCRIPTION
`Referrer-Options` should be changed to `Referrer-Policy` (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)