### PR TITLE
Expose room guid in schedule.json

### DIFF
--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -161,6 +161,15 @@ class FrabJsonExporter(ScheduleData):
                 "end": self.event.date_to.strftime("%Y-%m-%d"),
                 "daysCount": self.event.duration,
                 "timeslot_duration": "00:05",
+                "rooms": [
+                    {
+                        "name": str(room.name),
+                        "guid": room.guid,
+                        "description": str(room.description) or None,
+                        "capacity": room.capacity,
+                    }
+                    for room in self.event.rooms.all()
+                ],
                 "days": [
                     {
                         "index": day["index"],

--- a/src/tests/agenda/test_agenda_schedule_export.py
+++ b/src/tests/agenda/test_agenda_schedule_export.py
@@ -106,7 +106,7 @@ def test_schedule_frab_json_export(
     django_assert_max_num_queries,
     orga_user,
 ):
-    with django_assert_max_num_queries(25):
+    with django_assert_max_num_queries(26):
         regular_response = client.get(
             reverse(
                 "agenda:export.schedule.json",
@@ -115,7 +115,7 @@ def test_schedule_frab_json_export(
             follow=True,
         )
     client.force_login(orga_user)
-    with django_assert_max_num_queries(25):
+    with django_assert_max_num_queries(26):
         orga_response = client.get(
             reverse(
                 "agenda:export.schedule.json",


### PR DESCRIPTION
Followup PR for #1211:

This reverts commit 953ebe8fd3ed315758f889e8ec5b658976ac319a, as the same changes got merged to frab/main today:

https://github.com/frab/frab/pull/871/files#diff-72d3c524a4fe722765a30e6c4c5f2dd184823971a9e83da56521042136893947R18-R22

This PR closes issue #1118

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
