### PR TITLE
Fix 'session_block' for abstracts containing links

### DIFF
--- a/src/pretalx/agenda/templates/agenda/session_block.html
+++ b/src/pretalx/agenda/templates/agenda/session_block.html
@@ -42,7 +42,7 @@
         {% endif %}
         {% if session.submission and session.submission.abstract %}
             <div class="abstract">
-                {{ session.submission.abstract|rich_text }}
+                {{ session.submission.abstract|rich_text_without_links }}
             </div>
         {% endif %}
         <div class="bottom-info">


### PR DESCRIPTION
This PR fixes an issue with the `agenda/session_block.html` template when the abstract contains links. The issue arises due to the browser (tested in Firefox and Chromium) trying to fix things up when `<a>` tags contain other `<a>` tags.
Links will now be stripped, which is fine since `session_block` is only used in two other templates (`agenda/schedule_nojs.html` and `agenda/speaker.html`) where it acts as a link to the actual talk page.

## How Has This Been Tested?

The fix has been verified both by looking at the rendered page (see screenshots) and the markup (before, the surrounding `<a>` tag has spawned multiple `<a>` elements at different levels of the hierarchy - now, there is only one surrounding `<a>` element). Using `grep -r session_block *` I have searched for uses of the template and only found those mentioned above.

## Screenshots

### Before

![A screenshot of the issue: The left part of the `session_block` displaying the time and duration is considerably shorter than the right part containing the title and abstract.](https://user-images.githubusercontent.com/31102854/146091755-90c6b17b-8bba-4542-82cb-e2b1ab1dd357.png)

### After

![A screenshot with the patch applied and the `session_block` looking as expected: The left and right parts of it are now the same height.](https://user-images.githubusercontent.com/31102854/146093517-8f6ea036-acd6-41e7-a5b6-40861d19490c.png)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
