### PR TITLE
Allow organisers to configure CfP field titles

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`-` Organisers can now configure not just field help texts, but also field titles/labels.
 - :feature:`-` The custom CSV and JSON exports are now the new default on the export pages, since they're more useful to the average user.
 - :bug:`1281` Fixed a rare race condition, where on schedule release, two new WIP schedules were created, leading to persistent errors on some event pages.
 - :bug:`1278` Deleting a proposal from its detail view would lead to a 404 page (because pretalx tried to redirect you back to the original page, which was now unavailable).

--- a/src/pretalx/cfp/flow.py
+++ b/src/pretalx/cfp/flow.py
@@ -629,11 +629,11 @@ class CfPFlow:
         step_config["fields"] = []
         for config_field in data.get("fields", []):
             field = {}
-            for key in ("help_text", "request", "required", "key"):
+            for key in ("help_text", "request", "required", "key", "label"):
                 if key in config_field:
                     field[key] = (
                         i18n_string(config_field[key], locales)
-                        if key == "help_text"
+                        if key in ("help_text", "label")
                         else config_field[key]
                     )
             step_config["fields"].append(field)

--- a/src/pretalx/cfp/forms/cfp.py
+++ b/src/pretalx/cfp/forms/cfp.py
@@ -9,7 +9,7 @@ class CfPFormMixin:
     before all other forms changing help_text behaviour.
     """
 
-    def _update_cfp_help_text(self, field_name):
+    def _update_cfp_texts(self, field_name):
         field = self.fields.get(field_name)
         if not field or not self.field_configuration:
             return
@@ -21,6 +21,8 @@ class CfPFormMixin:
                 + " "
                 + str(getattr(field, "added_help_text", ""))
             )
+        if field_data.get("label"):
+            field.label = field_data["label"]
 
     def __init__(self, *args, field_configuration=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -31,4 +33,4 @@ class CfPFormMixin:
             }
             for field_data in self.field_configuration:
                 if field_data in self.fields:
-                    self._update_cfp_help_text(field_data)
+                    self._update_cfp_texts(field_data)

--- a/src/pretalx/person/forms.py
+++ b/src/pretalx/person/forms.py
@@ -159,7 +159,7 @@ class SpeakerProfileForm(
             self.fields[field] = field_class(
                 initial=initial.get(field), disabled=read_only
             )
-            self._update_cfp_help_text(field)
+            self._update_cfp_texts(field)
 
         if not self.event.cfp.request_avatar:
             self.fields.pop("avatar", None)

--- a/src/pretalx/static/orga/js/cfp_flow.js
+++ b/src/pretalx/static/orga/js/cfp_flow.js
@@ -125,12 +125,19 @@ function areEqual () {
 Vue.component("field", {
   template: `
     <div>
-      <h2 v-if="isModal">Change field text<br></h2>
+      <h2 v-if="isModal" class="mb-4">Change input field</h2>
       <div :class="['form-group', 'row', field.field_source].concat(isModal ? '' : 'editable')" v-bind:style="style" @click.stop="makeModal" v-if="!(isModal && isQuestion)">
-      <label class="col-md-3 col-form-label">
+      <label class="col-md-3 col-form-label pt-0">
         <template v-if="field.widget !== 'CheckboxInput'">
-          {{ field.label[currentLanguage] }}
-          <br>
+          <template v-if="isModal">
+            <div class="i18n-form-group mb-2 title-input" @click.stop="">
+              <input type="text" class="form-control" :title="locale" :lang="locale" v-model="field.label[locale]" v-for="locale in locales">
+            </div>
+          </template>
+          <template v-else>
+            {{ field.label[currentLanguage] }}
+            <br>
+          </template>
           <template v-if="isModal && editRequirement">
             <span v-if="!field.required & !field.hard_required" :class="[editable ? 'editable' : '', 'optional']" @click.stop="field.required=true">Optional</span>
             <span v-else-if="!field.hard_required" :class="[editable ? 'editable' : '', 'optional']" @click.stop="field.required=false"><strong>Required</strong></span>

--- a/src/pretalx/static/orga/scss/_flow.scss
+++ b/src/pretalx/static/orga/scss/_flow.scss
@@ -123,3 +123,7 @@
     margin-top: 8px;
   }
 }
+.title-input input {
+  text-align: right;
+  font-weight: bold;
+}

--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -46,7 +46,6 @@ class InfoForm(CfPFormMixin, RequestRequire, PublicContent, forms.ModelForm):
 
         super().__init__(initial=initial, **kwargs)
 
-        self.fields["title"].label = _("Proposal title")
         if "abstract" in self.fields:
             self.fields["abstract"].widget.attrs["rows"] = 2
         if instance and instance.pk:

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -118,7 +118,7 @@ class Submission(LogMixin, GenerateCode, FileCleanupMixin, models.Model):
     event = models.ForeignKey(
         to="event.Event", on_delete=models.PROTECT, related_name="submissions"
     )
-    title = models.CharField(max_length=200, verbose_name=_("Title"))
+    title = models.CharField(max_length=200, verbose_name=_("Proposal title"))
     submission_type = models.ForeignKey(  # Reasonable default must be set in form/view
         to="submission.SubmissionType",
         related_name="submissions",

--- a/src/tests/orga/views/test_orga_views_schedule.py
+++ b/src/tests/orga/views/test_orga_views_schedule.py
@@ -712,7 +712,7 @@ def test_orga_can_export_answers_csv(
     assert response.status_code == 200
     assert (
         response.content.decode()
-        == f"ID,Title,Speaker IDs,{answered_choice_question.question}\r\n{submission.code},{submission.title},{speaker.code},{answer}\r\n"
+        == f"ID,Proposal title,Speaker IDs,{answered_choice_question.question}\r\n{submission.code},{submission.title},{speaker.code},{answer}\r\n"
     )
 
 
@@ -738,7 +738,7 @@ def test_orga_can_export_answers_json(
     assert json.loads(response.content.decode()) == [
         {
             "ID": submission.code,
-            "Title": submission.title,
+            "Proposal title": submission.title,
             answered_choice_question.question: answer,
             "Speaker IDs": [speaker.code],
         }

--- a/src/tests/submission/test_submission_model.py
+++ b/src/tests/submission/test_submission_model.py
@@ -380,7 +380,7 @@ def test_content_for_mail(submission, file_question, boolean_question):
 
         assert (
             submission.get_content_for_mail().strip()
-            == f"""**Title**: {submission.title}
+            == f"""**Proposal title**: {submission.title}
 
 **Abstract**: {submission.abstract}
 


### PR DESCRIPTION
Help texts are already configureable, and now titles are too, by popular demand!

Open question: The way this feature is currently implemented, on the first CfP config (flow) save, all current field
titles will be saved, just because they are there in the JSON data. This means future updates to the defaults will not
apply to ongoing events. This is a) a feature because organisers can rely on the field names not changing or b) a
problem, because in case of e.g. typos, we can't update those fields for ongoing events. Debate.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My change is listed in the CHANGELOG.rst if appropriate.
