### PR TITLE
fix setting a field to required in CfP not having any effect

### DIFF
--- a/src/pretalx/submission/models/cfp.py
+++ b/src/pretalx/submission/models/cfp.py
@@ -50,7 +50,7 @@ def default_fields():
         "image": {"visibility": "optional"},
         "track": {"visibility": "do_not_ask"},
         "duration": {"visibility": "do_not_ask"},
-        "content_locale": {"visibility": "require"},
+        "content_locale": {"visibility": "required"},
         "additional_speaker": {"visibility": "optional"},
     }
 
@@ -64,7 +64,7 @@ def field_helper(cls):
 
     def is_field_required(self, field):
         return (
-            self.fields.get(field, default_fields()[field])["visibility"] == "require"
+            self.fields.get(field, default_fields()[field])["visibility"] == "required"
         )
 
     for field in default_fields().keys():


### PR DESCRIPTION
Setting avatars to be required had no effect in our instance.

Upon further inspection, i found that while in the settings, the value `"required"` is stored in this case, `is_field_required()` checked for `"require"` (without d) instead.

This PR fixes this typo.

Drawback: While nearly all CfP fields that are required by default use the value `"required"`, the field `"content_locale"` used `"require"` (which this PR also fixes). If this default value has persisted for some users, this field might no longer be required now (didn'tread into the code enough to check if this method is called for all of the CfP form generation).

Now, setting avatars to be required and not filling out that field actually throws a validation error as expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
