### PR TITLE
fix error if avatars are mandatory and a logged in speaker doesn't upload a new one

### DIFF
--- a/src/pretalx/cfp/flow.py
+++ b/src/pretalx/cfp/flow.py
@@ -216,8 +216,6 @@ class FormFlowStep(TemplateFlowStep):
 
     def set_data(self, data):
         def serialize_value(value):
-            if getattr(value, "file", None):
-                return None
             if getattr(value, "pk", None):
                 return value.pk
             if getattr(value, "__iter__", None):
@@ -227,7 +225,14 @@ class FormFlowStep(TemplateFlowStep):
             return str(value)
 
         self.cfp_session["data"][self.identifier] = json.loads(
-            json.dumps(data, default=serialize_value)
+            json.dumps(
+                {
+                    key: value
+                    for key, value in data.items()
+                    if not getattr(value, "file", None)
+                },
+                default=serialize_value,
+            )
         )
 
     def get_files(self):


### PR DESCRIPTION
Hey,

so, we had an issue in production that was reproducible as follows:

* make avatars mandatory
* submit a talk, uploading an avatar in the process
* stay logged in
* submit another talk, not uploading an avatar in the process because you already have one
* error 500

```
Traceback (most recent call last):
  File "/opt/pretalx/venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/opt/pretalx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 188, in _get_response
    self.check_response(response, callback)
  File "/opt/pretalx/venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 309, in check_response
    raise ValueError(
ValueError: The view pretalx.cfp.views.wizard.SubmitWizard didn't return an HttpResponse object. It returned None instead.
```

I investigated the issue and found out that the problem is caused be the profile step form being successfully validated at first, but then being invalid when loaded from storage. 

The reason:

* For the initial validation, `data=request.POST` and `files=request.FILES` used.
  * If an avatar was uploaded, only `request.FILES` should contain it. 
  * If no avatar was uploaded, neither `request.POST` nor `request.FILES` should contain an `avatar` field. Since the user is logged in, the `initial` value for this form contains the already known avatar, and that value will be used. **If the field is required, the form will thus still validate successfully.**
* After the validation, the form data and files are serialized. 
  * However, `cleaned_data` is serialized as the new `data`, and it will contain the file field values as well, including `avatar` – no matter if an avatar was uploaded or not, because it contains all form fields, not just the ones submitted. 
  * This value will always be `None`, because `set_data` serializes all File objects to `None`.
* To decide on the next step, `is_completed` is called, which validates the form again. This time, the form is loaded from storage.
  * If an avatar was uploaded, everything is fine, because the files are serialized as well and will be passed as `files` to the form on load, which will superseed the `None` value in `data`.
  * If no avatar was uploaded, `data` contains a field `avatar` with the value `None`, which it didn't during the first validation. Since this field exists, the initial value will not be used. **If the field is required, the form will thus now fail validation.**

The proposed solution:

* Don't serialize file field values as `None` for `data`. Instead, omit them.

*Side note: Maintaining a fork of pretalx (which i cherry-pick my pull requests from) would be much easier, if `makemessages` was called with the parameter `--add-location file`, which would omit line numbers from the comments in the locale files – thereby avoiding loads of merge conflicts.*

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
