### PR TITLE
switch from git to https

### DIFF
--- a/doc/administrator/maintenance.rst
+++ b/doc/administrator/maintenance.rst
@@ -52,7 +52,7 @@ If you're sure that you know what you're doing, you can also install a specific
 commit or branch of pretalx. You can replace ``main`` with a short or long
 commit ID for a specific commit::
 
-    $ pip3 install --user --upgrade-strategy eager -U "git+git://github.com/pretalx/pretalx.git@main#egg=pretalx&subdirectory=src"
+    $ pip3 install --user --upgrade-strategy eager -U "git+https://github.com/pretalx/pretalx.git@main#egg=pretalx&subdirectory=src"
 
 
 Backups


### PR DESCRIPTION
This switches the command for the `commit` version to use `https` instead of `git`. Using the unsecured `git://` protocol has been disabled in 2021 (per https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git). 

