### PR TITLE
Add draft submission state

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`672` Speakers (or rather submitters) can now save a proposal as a draft while they are working on finishing the submission process.
 - :feature:`-` The state of a proposal is now marked as "in review" on the speaker-facing side once the CfP closes, to make it clearer that there is no action to be taken at that time.
 - :feature:`-` Breaking API change: The submissions, talks and speakers API endpoints do not include all question answers the user has access to by default anymore, due to performance considerations. You can restore the old behaviour with ``?questions=all``, or ``?questions=id,id`` to show selected answers instead.
 - :feature:`-` Track descriptions are now shown publicly on the schedule page, in the track filter.

--- a/src/pretalx/agenda/views/talk.py
+++ b/src/pretalx/agenda/views/talk.py
@@ -143,10 +143,11 @@ class TalkReviewView(TalkView):
 
     def get_object(self):
         return get_object_or_404(
-            self.request.event.submissions,
+            Submission.all_objects.filter(event=self.request.event),
             review_code=self.kwargs["slug"],
             state__in=[
                 SubmissionStates.SUBMITTED,
+                SubmissionStates.DRAFT,
                 SubmissionStates.ACCEPTED,
                 SubmissionStates.CONFIRMED,
             ],

--- a/src/pretalx/cfp/permissions.py
+++ b/src/pretalx/cfp/permissions.py
@@ -1,6 +1,7 @@
 import rules
 
 from pretalx.person.permissions import can_change_submissions, is_reviewer
+from pretalx.submission.models import SubmissionStates
 from pretalx.submission.permissions import can_be_edited
 
 
@@ -12,7 +13,10 @@ def is_event_visible(user, event):
 @rules.predicate
 def can_request_speakers(user, submission):
     # Only allow to request speakers if the field is active in the CfP
-    return submission.event.cfp.request_additional_speaker
+    return (
+        submission.state != SubmissionStates.DRAFT
+        and submission.event.cfp.request_additional_speaker
+    )
 
 
 rules.add_perm(

--- a/src/pretalx/cfp/templates/cfp/event/submission_base.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_base.html
@@ -39,13 +39,17 @@
             {% endblock %}
             {% block buttons %}
                 <div class="row wizard-row">
-                    <div class="col-md-3 flip ml-auto">
-                        <button type="submit" class="btn btn-block btn-success btn-lg">
+                    <div class="col-md-3 flip ml-auto d-flex flex-column">
+                        <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="submit">
                             {% if next_url %}
                                 {% translate "Continue" %} &raquo;
                             {% else %}
                                 {% translate "Submit proposal!" %} &raquo;
                             {% endif %}
+                        </button>
+                        <button type="submit" class="btn btn-link text-center" name="action" value="draft">
+                            {% translate "or save as draft for now" %}
+                            <i class="fa fa-question-circle" data-toggle="tooltip" title="{% translate "You can save your proposal as a draft and submit it later. Organisers will not be able to see your proposal, though they will be able to send you reminder emails about the upcoming deadline." %}"></i>
                         </button>
                     </div>
                     <div class="col-md-3">

--- a/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submission_edit.html
@@ -21,7 +21,7 @@
 
 {% block content %}
     {% has_perm 'cfp.add_speakers' request.user submission  as can_invite_speakers %}
-    <h2>{% translate "Your proposal:" %} {{ submission.title }}</h2>
+    <h2>{% if submission.state != "draft" %}{% translate "Your proposal:" %}{% else %}{% translate "Your draft:" %}{% endif %} {{ submission.title }}</h2>
     {% if submission.public_slots %}
         <h3>
             <small>
@@ -32,8 +32,10 @@
         </h3>
     {% endif %}
     <p>
-        {% translate "Current state of your proposal:" %}
-        {% include "cfp/event/fragment_state.html" with state=submission.user_state %}
+        {% if submission.state != "draft" %}
+            {% translate "Current state of your proposal:" %}
+            {% include "cfp/event/fragment_state.html" with state=submission.user_state %}
+        {% endif %}
         {% if submission.state == 'accepted' %}
             <a href="{{ submission.urls.confirm }}" class="btn btn-sm btn-success">
                 <i class="fa fa-check"></i> {% translate "Confirm your attendance" %}
@@ -164,11 +166,23 @@
         {% endif %}
         {% if can_edit %}
             <div class="row mt-4">
-                <div class="col-md-3 flip ml-auto">
-                    <button type="submit" class="btn btn-block btn-success btn-lg">
-                        {% translate "Save" %}
-                    </button>
-                </div>
+                {% if submission.state == "draft" %}
+                    <div class="col-md-6 flip ml-auto">
+                        <div class="d-flex align-items-start">
+                            <button type="submit" class="btn btn-block btn-outline-success btn-lg" name="action" value="submit">
+                                {% translate "Save draft" %}
+                            </button>
+                            <button type="submit" class="btn btn-block btn-success btn-lg mt-0 ml-2" name="action" value="dedraft">
+                                {% translate "Submit proposal" %}
+                            </button>
+                        </div>
+                {% else %}
+                    <div class="col-md-3 flip ml-auto">
+                        <button type="submit" class="btn btn-block btn-success btn-lg" name="action" value="submit">
+                            {% translate "Save" %}
+                        </button>
+                {% endif %}
+            </div>
             </div>
         {% endif %}
     </form>

--- a/src/pretalx/cfp/templates/cfp/event/user_submissions.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_submissions.html
@@ -21,6 +21,45 @@
         {% endfor %}
     {% endif %}
     {% html_signal "pretalx.cfp.signals.html_above_submission_list" sender=request.event request=request %}
+    {% if drafts %}
+        <h2>{% translate "Your drafts" %}</h2>
+        <div class="table-responsive">
+            <table class="table table-sm table-flip">
+                <thead>
+                    <tr>
+                        <th>{% translate "Title" %}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for submission in drafts %}
+                        <tr>
+                            <td>
+                                <a href="{{ submission.urls.user_base }}">
+                                    {{ submission.title }}
+                                </a>
+                            </td>
+                            <td class="flip text-right">
+                                {% if submission.review_code %}
+                                    <button data-destination="{{ submission.urls.review.full }}"
+                                        class="btn btn-sm btn-info"
+                                        data-toggle="tooltip"
+                                        data-placement="top"
+                                        title="{% translate 'Copy code for review' %}"
+                                        target="_blank" rel="noopener">
+                                        <i class="fa fa-link"></i>
+                                    </button>
+                                {% endif %}
+                                <a href="{{ submission.urls.user_base }}" class="btn btn-sm btn-success">
+                                    <i class="fa fa-{{ submission.editable|yesno:'edit,eye' }}"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
     <h2>{% translate "Your proposals" %}</h2>
     {% if submissions %}
         <div class="table-responsive">

--- a/src/pretalx/locale/ar/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/ar/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2021-09-13 11:09+0000\n"
 "Last-Translator: hamza Hamwie <hamza@live.hk>\n"
 "Language-Team: none\n"
@@ -241,8 +241,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)s دقيقة"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "تم الحذف"
 
@@ -254,7 +254,7 @@ msgstr "الصورة الشخصية للمتحدث"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "اللغة"
 
@@ -285,15 +285,15 @@ msgstr "جدول المواعيدنا لم يتم تفعيله بعد."
 msgid "The session “{title}” at {event}"
 msgstr "جلسة “{title}” - {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "عام"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "مرحبا، سررت بالتعرف عليك!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -301,36 +301,41 @@ msgstr ""
 "نحن سعداء أنك تريد المساهمة في طرح طلبك (مقترحك) في هذا الحدث. لنبدأ ، لن "
 "يستغرق الأمر وقتًا طويلاً."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "الأسئلة"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "أخبرنا المزيد!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "قبل أن نتمكن من حفظ اقتراحك ، لدينا المزيد من الأسئلة لك."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "الحساب"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr "هذا كل شيء عن اقتراحك! نحن الآن فقط بحاجة إلى طريقة للتواصل معك."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -339,7 +344,7 @@ msgstr ""
 "لمشاركة اقتراحك ، تحتاج إلى إنشاء حساب في هذه الصفحة. لا يمنحنا هذا طريقة "
 "للاتصال بك فحسب ، بل يمنحك أيضًا إمكانية تعديل اقتراحك أو عرض حالته الحالية."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -347,15 +352,15 @@ msgstr ""
 "حدث خطأ أثناء عملية تسجيل الدخول. يرجى الاتصال بالمنظمين للحصول على المزيد "
 "من المساعدة."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "ملف التعريف الخاص بك"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "اخبرنا شيئا عن نفسك!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -386,13 +391,13 @@ msgid "Text"
 msgstr "النص"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} يدعوكم للإنضمام للجلسة !"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -561,36 +566,43 @@ msgid "Proposals are closed"
 msgstr "تم إغلاق الطلبات(المقترحات)"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "تمت عملية التقديم"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "شاربك تقييمك"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "لم تتم الموافقة"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "تمت الموافقة"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "تم التأكيد"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "ألغيت"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "منسحب"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "الذهاب الى دعوة المشاركة"
 
@@ -614,7 +626,7 @@ msgstr "الملخص:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "لا"
 
@@ -700,7 +712,18 @@ msgstr "استمر"
 msgid "Submit proposal!"
 msgstr "تقديم مقترحك"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -762,7 +785,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -837,7 +860,7 @@ msgid "Your proposal:"
 msgstr "مقترحك:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -845,7 +868,7 @@ msgstr "الوضع الراهن لمقترحك:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "نوع الجلسة"
 
@@ -856,7 +879,7 @@ msgstr "نوع الجلسة"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "التتبع"
 
@@ -889,13 +912,13 @@ msgid "Go back"
 msgstr "العودة للخلف"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "الحذف"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "التاكيد"
 
@@ -913,19 +936,25 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "المسودة الحالية"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "تأكيد حضورك"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "التغذية الراجعة من قبل المشاركين"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr "يمكن للمشاركين وضع ملاحظلاعم بعد أن يتم وضع الجلسة."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "المتحدث:"
@@ -935,7 +964,7 @@ msgstr[3] "المتحدثين"
 msgstr[4] "المتحدثين"
 msgstr[5] "المتحدثين"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitter"
 #| msgid_plural "submitters"
@@ -948,13 +977,13 @@ msgstr[3] "عدد المقدمين"
 msgstr[4] "عدد المقدمين"
 msgstr[5] "عدد المقدمين"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "المصادر"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -962,21 +991,33 @@ msgstr ""
 "ستكون الموارد متاحة للعامة. يرجى محاولة إبقاء التحميلات الخاصة بك أقل من 16 "
 "ميغا بايت."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "إضافة مصادر أخرى"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Current draft"
+msgid "Save draft"
+msgstr "المسودة الحالية"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "تقديم مقترحك"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "مشاركة طلبك (مقترحك)"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -984,12 +1025,12 @@ msgstr ""
 "إذا أردت الحصول على التقييمات من قبل الزملاء أو الأصدقاء ، فإليك رابطًا يمكنك "
 "إرساله للإطلاع على طلبك (مقترحك):"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "حذف طلبك (مقترحك)"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -999,11 +1040,11 @@ msgstr ""
 "العمليةا - إذا لم تكن متأكدًا مما إذا كان بإمكانك أو يجب أن تعليق جلستك ، "
 "فيرجى الاتصال بالمنظم بدلاً من ذلك."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "إلغاء طلبك (مقترحك)"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1044,7 +1085,7 @@ msgid "You will not be able to revert this action."
 msgstr "لن تتمكن من التراجع عن هذا الإجراء."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "طلبك (مقترحاتك)"
 
@@ -1052,7 +1093,14 @@ msgstr "طلبك (مقترحاتك)"
 msgid "Important Information"
 msgstr "معلومات هامة"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "المسودة الحالية"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1061,44 +1109,45 @@ msgstr "معلومات هامة"
 msgid "Title"
 msgstr "العنوان"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "انسخ الكود للعرض"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "الحالة"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "انسخ الكود للعرض"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "التغذية الراجعة"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "انشاء مقترح جديد"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "يبدو أنك لم تقم بتقديم أي شئ لهذا الحدث حتى الآن."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "إذا فعلت ذلك ، فربما قمت بإستخدام حسابًا مختلفًا؟ يرجى التحقق من رسائل البريد "
 "الإلكتروني الخاصة بك!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr ""
 "إذا لم تقم بذلك، ندعوك للمضي قدمًا وتقدم طلبا(اقتراحًا) الآن؟ نود أن نسمع منك!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "قم بتقديم شيء الان!"
 
@@ -1148,10 +1197,11 @@ msgstr ""
 "تم إعادة إنشاء رمز API المميز الخاص بك. لن يكون الرمز السابق قابلاً للاستخدام "
 "بعد الآن."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "مقترح جديد :{title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "تم حذف طلبك (مقترحك)."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1967,7 +2017,7 @@ msgid "Imprint"
 msgstr "وسم"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "الأرشيف"
 
@@ -2385,7 +2435,7 @@ msgstr "ربما"
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "نعم"
 
@@ -2976,7 +3026,7 @@ msgstr "استخدم Gravatar"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr "السماح للمتحدثين بتضمين صورة ملف Gravatar الخاص بهم تلقائيًا."
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "Slot Count"
 
@@ -3663,7 +3713,8 @@ msgstr[5] "المقترحات"
 msgid "All proposals"
 msgstr "جميع الطلبات (المقترحات)"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "لم يتم الموافقة"
 
@@ -3677,7 +3728,7 @@ msgstr "رقم الطلب (المقترح)"
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr "يتم استخدام المعرف ID للاقتراح في عنوان URL للمقترح وفي عمليات التصدير"
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "عنوان الطلب (المقترح)"
 
@@ -3867,7 +3918,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "اسم المتحدث الذي يجب مشاركته مع العامة."
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "حالة المقترح"
 
@@ -4145,7 +4196,7 @@ msgstr "أكواد الوصول"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "العلامات (Tags)"
 
@@ -4570,14 +4621,14 @@ msgstr "الحد الأعلى للمدة"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "الملخص"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "الوصف"
@@ -4594,7 +4645,7 @@ msgstr "متاح"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "ملاخطات"
 
@@ -4604,12 +4655,12 @@ msgstr "سجل المنسحبين"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "صورة الجلسة"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "المدة"
 
@@ -4664,7 +4715,7 @@ msgstr "غير نشط"
 msgid "Click here to change"
 msgstr "انقر هنا للتغيير"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "التاريخ الكامل"
 
@@ -4787,7 +4838,7 @@ msgstr "الأحداث القادمة"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] "مقترح"
@@ -5265,7 +5316,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] "المقترح ينتظر تقييمك."
@@ -5321,7 +5372,7 @@ msgstr "معدلك"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "المراجعات"
 
@@ -6084,7 +6135,7 @@ msgid "Add a new note"
 msgstr "إضافة ملاحظة جديدة"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "مقدم الطلب"
@@ -6579,22 +6630,27 @@ msgstr ""
 "تم استخدام رمز الوصول هذاضمن المقترح ولا يمكن حذفه. لتعطيله ، يمكنك ضبط "
 "تاريخ صلاحيته بتاريخ سابق."
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "حتى يتم انهاء CfP"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "تقديم مقترحك"
+msgstr[1] "تقديم مقترحك"
+msgstr[2] "تقديم مقترحك"
+msgstr[3] "تقديم مقترحك"
+msgstr[4] "تقديم مقترحك"
+msgstr[5] "تقديم مقترحك"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "proposals are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "المقترح ينتظر تقييمك."
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "يوم متبقي حتى بداية الحدث"
@@ -6604,7 +6660,7 @@ msgstr[3] "الأيام المتبقية حتى بداية الحدث"
 msgstr[4] "الأيام المتبقية حتى بداية الحدث"
 msgstr[5] "الأيام المتبقية حتى بداية الحدث"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
@@ -6614,21 +6670,21 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
@@ -6638,17 +6694,13 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-msgstr[4] ""
-msgstr[5] ""
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "تم التأكيد"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] ""
@@ -6658,7 +6710,7 @@ msgstr[3] ""
 msgstr[4] ""
 msgstr[5] ""
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -7123,15 +7175,15 @@ msgstr ""
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -7496,7 +7548,7 @@ msgstr ""
 "الانتهاء من عملية تقديم الطلب (المقترح)."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr "استخدم هذا إذا كنت تريد رسمًا توضيحيًا يتناسب مع طلبك (مقنرحك)."
 
@@ -7913,28 +7965,32 @@ msgstr ""
 "بشكل افتراضي ، يتم قفل تعديل الطلبات (المقترحات) بعد انتهاء CfP ، ويتم إعادة "
 "تمكينه بمجرد قبول المقترح."
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposal state"
 msgid "Pending proposal state"
 msgstr "حالة المقترح"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr "هذه الملاحظات مخصصة للمنظم ولن يتم نشرها على الملأ."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "ملاحظات للمنظمين فقط"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 "ملاحظات داخلية مع بقية المنظمين. لن يتم مشاركتها مع للمتحدثين أو الجمهور."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -7942,36 +7998,41 @@ msgstr ""
 "المدة بالدقائق. اتركه فارغًا تديدها ضمن المدة الافتراضية وفقا ل نوع الجلسة "
 "هذا."
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "كم مرة ستعقد هذه الجلسة."
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "اعرض هذه الجلسة في القائمة العامة للجلسات المميزة."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "لاتقم بتسجل هذه الجلسة."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Invite reviewers"
 msgid "Assigned reviewers"
 msgstr "دعوة المشاركين"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " أو "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
 "يجب أن يكون الطلب (امقترح( {src_states} وليس {state} أن يكون {new_state}."
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "مقترح جديد :{title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -8031,6 +8092,12 @@ msgstr "{name} (عدد الساعات {duration} )"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} دقيقة)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "proposals are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "المقترح ينتظر تقييمك."
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "لا يوجد متحدث يطابق عملية البحث التي قمت بإجرائها."
 
@@ -8070,9 +8137,6 @@ msgstr "{name} ({duration} دقيقة)"
 
 #~ msgid "Compose mail"
 #~ msgstr "كتابة رسالة"
-
-#~ msgid "Current draft"
-#~ msgstr "المسودة الحالية"
 
 #~ msgid "Show"
 #~ msgstr "إظهار"

--- a/src/pretalx/locale/ca/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/ca/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-05-09 09:22+0000\n"
 "Last-Translator: Víctor <vfc@uber.space>\n"
 "Language-Team: none\n"
@@ -222,8 +222,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)sminuts"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "eliminat"
 
@@ -235,7 +235,7 @@ msgstr ""
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Idioma"
 
@@ -266,71 +266,76 @@ msgstr "El nostre programa encara no està disponible."
 msgid "The session “{title}” at {event}"
 msgstr ""
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "General"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr ""
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
 msgstr ""
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Preguntes"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr ""
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Compte"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
 "your proposal or to view its current state."
 msgstr ""
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
 msgstr ""
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Perfil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr ""
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -359,13 +364,13 @@ msgid "Text"
 msgstr "Text"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr ""
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -507,36 +512,43 @@ msgid "Proposals are closed"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "enviat"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Envia la revisió"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "no acceptada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "acceptada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "confirmada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "cancel·lada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "eliminada"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr ""
 
@@ -559,7 +571,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "No"
 
@@ -639,7 +651,18 @@ msgstr "Segueix"
 msgid "Submit proposal!"
 msgstr "Envia una proposta!"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -695,7 +718,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -765,7 +788,7 @@ msgid "Your proposal:"
 msgstr "La vostra proposta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -773,7 +796,7 @@ msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Tipus de sessió"
 
@@ -784,7 +807,7 @@ msgstr "Tipus de sessió"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Sala"
 
@@ -812,13 +835,13 @@ msgid "Go back"
 msgstr "Torna enrere"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Confirma"
 
@@ -834,25 +857,31 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Your proposal:"
+msgid "Your draft:"
+msgstr "La vostra proposta:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Confirmeu la vostra assistència"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Comentaris del públic"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Ponent:"
 msgstr[1] "Ponents:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitted"
 msgid "Submitter:"
@@ -860,55 +889,65 @@ msgid_plural "Submitters:"
 msgstr[0] "enviat"
 msgstr[1] "enviat"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Recursos"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Afegiu un altre recurs"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+msgid "Save draft"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "Submit proposal"
+msgstr "Envia una proposta!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Compartiu la proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Retireu la proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
 "session, please contact the organiser instead."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Cancel·leu la proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -944,7 +983,7 @@ msgid "You will not be able to revert this action."
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Les vostres propostes"
 
@@ -952,7 +991,14 @@ msgstr "Les vostres propostes"
 msgid "Important Information"
 msgstr "Informació important"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Your proposals"
+msgid "Your drafts"
+msgstr "Les vostres propostes"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -961,41 +1007,42 @@ msgstr "Informació important"
 msgid "Title"
 msgstr "Títol"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr ""
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Comentaris"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Crea una nova proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr ""
 
@@ -1043,10 +1090,11 @@ msgid ""
 "any longer."
 msgstr ""
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nova proposta:{title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "La vostra proposta ha estat cancel·lada."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1767,7 +1815,7 @@ msgid "Imprint"
 msgstr ""
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr ""
 
@@ -2141,7 +2189,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr ""
 
@@ -2639,7 +2687,7 @@ msgstr ""
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr ""
 
@@ -3259,7 +3307,8 @@ msgstr[1] ""
 msgid "All proposals"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr ""
 
@@ -3271,7 +3320,7 @@ msgstr ""
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr ""
 
@@ -3453,7 +3502,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr ""
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -3719,7 +3768,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4107,14 +4156,14 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr ""
@@ -4129,7 +4178,7 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr ""
 
@@ -4139,12 +4188,12 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr ""
 
@@ -4194,7 +4243,7 @@ msgstr ""
 msgid "Click here to change"
 msgstr ""
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr ""
 
@@ -4304,7 +4353,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] ""
@@ -4734,7 +4783,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] ""
@@ -4786,7 +4835,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr ""
 
@@ -5449,7 +5498,7 @@ msgid "Add a new note"
 msgstr ""
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] ""
@@ -5917,63 +5966,67 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Envia una proposta!"
+msgstr[1] "Envia una proposta!"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-msgid "proposals are waiting for your review."
-msgstr ""
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "confirmada"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -6421,15 +6474,15 @@ msgstr ""
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -6754,7 +6807,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7130,57 +7183,66 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 msgid "Pending proposal state"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 msgid "Assigned reviewers"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr ""
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nova proposta:{title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"

--- a/src/pretalx/locale/cs/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/cs/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-04-03 18:47+0000\n"
 "Last-Translator: Greenscreener <honzikcernoh@gmail.com>\n"
 "Language-Team: none\n"
@@ -242,8 +242,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)s min"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "smazáno"
 
@@ -255,7 +255,7 @@ msgstr "Profilový obrázek přednášejícího"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Jazyk"
 
@@ -288,15 +288,15 @@ msgstr "Náš program ještě nebyl zveřejněn."
 msgid "The session “{title}” at {event}"
 msgstr "Přednáška s názvem „{title}“ na {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Obecné"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Zdravím, rád vás poznávám!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -304,7 +304,12 @@ msgstr ""
 "Jsme rádi, že se chcete svým příspěvkem podílet na naší události. Dáme se do "
 "toho, zabere to jen chvilku."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
@@ -313,29 +318,29 @@ msgstr ""
 "Gratulujeme, odeslali jste vaši přihlášku. Až do uzávěrky můžete vaši "
 "přihlášku upravovat. V případě změn nebo dalších otázek vám dáme vědět."
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Otázky"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Řekněte nám více!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "Než si uložíme Vaši přihlášku, máme pro Vás pár otázek."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Účet"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr "Tolik k přihlášce. Teď potřebujeme způsob, jak Vás kontaktovat."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -345,21 +350,21 @@ msgstr ""
 "budeme moci kontaktovat, ale také budete mít možnost váš návrh upravit nebo "
 "si prohlédnout jeho aktuální stav."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
 msgstr "Při přihlašování došlo k chybě. Pro pomoc kontaktujte administrátora."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Profil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Řekněte nám něco o sobě!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -390,13 +395,13 @@ msgid "Text"
 msgstr "Text"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} Vás chce přidat do své přednášky!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -568,36 +573,43 @@ msgid "Proposals are closed"
 msgstr "Příspěvky byly uzavřeny"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "přidáno"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Odeslat recenzi"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "zamítnuto"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "přijato"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "potvrzeno"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "zrušeno"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "staženo"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Jít na CfP"
 
@@ -622,7 +634,7 @@ msgstr "Abstrakt:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "Ne"
 
@@ -707,7 +719,18 @@ msgstr "Pokračovat"
 msgid "Submit proposal!"
 msgstr "Odeslat přihlášku!"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -768,7 +791,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -842,7 +865,7 @@ msgid "Your proposal:"
 msgstr "Vaše přihláška:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -850,7 +873,7 @@ msgstr "Aktuální stav vaší přihlášky:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Typ přednášky"
 
@@ -861,7 +884,7 @@ msgstr "Typ přednášky"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Track"
 
@@ -895,13 +918,13 @@ msgid "Go back"
 msgstr "Zpět"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Zrušit"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Potvrdit"
 
@@ -919,28 +942,34 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Your proposal:"
+msgid "Your draft:"
+msgstr "Vaše přihláška:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Potvrdit svoji účast"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Zpětná vazba publika"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "Návštěvníci zde budou moci vložit zpětnou vazbu, až se vaše přednáška "
 "uskuteční."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Přednášející:"
 msgstr[1] "Přednášející:"
 msgstr[2] "Přednášející:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitted"
 msgid "Submitter:"
@@ -949,13 +978,13 @@ msgstr[0] "přidáno"
 msgstr[1] "přidáno"
 msgstr[2] "přidáno"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Zdroje"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -963,21 +992,33 @@ msgstr ""
 "Zdroje budou veřejně přístupné. Prosíme, aby všechny soubory byly menší než "
 "16 MB."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Přidat další zdroj"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Save this!"
+msgid "Save draft"
+msgstr "Uložte si to!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "Submit proposal"
+msgstr "Odeslat přihlášku!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Sdílet přihlášku"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -985,12 +1026,12 @@ msgstr ""
 "Pokud chcete přihlášku zkontrolovat od kolegy nebo kamaráda, zde je link k "
 "zobrazení vaší přihlášky:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Stáhnout přihlášku"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1000,11 +1041,11 @@ msgstr ""
 "vrátit - pokud se jen neumíte rozhodnout, zda přednášet či ne, kontaktujte "
 "nejdříve organizátory."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Zrušit přihlášku"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1046,7 +1087,7 @@ msgid "You will not be able to revert this action."
 msgstr "Nebudete moci vrátit tuto akci."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Vaše přihlášky"
 
@@ -1054,7 +1095,14 @@ msgstr "Vaše přihlášky"
 msgid "Important Information"
 msgstr "Důležité informace"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Your proposals"
+msgid "Your drafts"
+msgstr "Vaše přihlášky"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1063,37 +1111,38 @@ msgstr "Důležité informace"
 msgid "Title"
 msgstr "Název"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Zkopírovat kód pro recenzi"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Stav"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Zkopírovat kód pro recenzi"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Zpětná vazba"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Vytvořit novou přihlášku"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "Zdá se, že jste zatím nic neposlali pro tuto událost."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Pokud tomu tak není, možná jste použili jiný účet? Zkontrolujte svoje e-"
 "maily!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
@@ -1101,7 +1150,7 @@ msgstr ""
 "Pokud tomu tak je, proč si nevytvoříte přihlášku právě teď? Rádi o vás "
 "uslyšíme!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Poslat přihlášku!"
 
@@ -1149,10 +1198,11 @@ msgid ""
 "any longer."
 msgstr "Váš API token byl přegenerován. Předchozí token již nelze použít."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nový návrh: {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Vaše přihláška byla stažena."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1901,7 +1951,7 @@ msgid "Imprint"
 msgstr ""
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr ""
 
@@ -2280,7 +2330,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr ""
 
@@ -2802,7 +2852,7 @@ msgstr ""
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr ""
 
@@ -3433,7 +3483,8 @@ msgstr[2] ""
 msgid "All proposals"
 msgstr "Přidat návrh"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr ""
 
@@ -3447,7 +3498,7 @@ msgstr "Příspěvky byly uzavřeny"
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "Název přihlášky"
 
@@ -3647,7 +3698,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr ""
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -3913,7 +3964,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4303,14 +4354,14 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Abstrakt"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Popis"
@@ -4327,7 +4378,7 @@ msgstr "Dostupnost"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "Poznámky"
 
@@ -4337,12 +4388,12 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "Obrázek přednášky"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr ""
 
@@ -4392,7 +4443,7 @@ msgstr ""
 msgid "Click here to change"
 msgstr ""
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr ""
 
@@ -4502,7 +4553,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] ""
@@ -4945,7 +4996,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] ""
@@ -4998,7 +5049,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr ""
 
@@ -5675,7 +5726,7 @@ msgid "Add a new note"
 msgstr ""
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] ""
@@ -6146,70 +6197,72 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Odeslat přihlášku!"
+msgstr[1] "Odeslat přihlášku!"
+msgstr[2] "Odeslat přihlášku!"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "Proposals are closed"
-msgid "proposals are waiting for your review."
-msgstr "Příspěvky byly uzavřeny"
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "potvrzeno"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -6677,15 +6730,15 @@ msgstr "Nová přihláška na {event}: {title}"
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -7043,7 +7096,7 @@ msgstr ""
 "přidat po dokončení přihlašovacího procesu."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7423,21 +7476,25 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposals are closed"
 msgid "Pending proposal state"
 msgstr "Příspěvky byly uzavřeny"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr "Tyto poznámky slouží pro organizátory a nebudou zveřejněny."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "Interní poznámky"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -7445,43 +7502,48 @@ msgstr ""
 "Soukromé poznámky pro ostatní organizátory/recenzenty. Neuvidí je ani "
 "řečník, ani veřejnost."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 #, fuzzy
 #| msgid "Welcome to our list of featured talks!"
 msgid "Show this session in public list of featured sessions."
 msgstr "Vítejte v přehledu vybraných přednášek!"
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "Nepřeji si nahrávání mé přednášky."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Send review"
 msgid "Assigned reviewers"
 msgstr "Odeslat recenzi"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr ""
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nový návrh: {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -7536,6 +7598,11 @@ msgstr ""
 #, python-brace-format
 msgid "{name} ({duration} minutes)"
 msgstr ""
+
+#, fuzzy
+#~| msgid "Proposals are closed"
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "Příspěvky byly uzavřeny"
 
 #~ msgid "No speaker matches your search."
 #~ msgstr "S Vaším vyhledáváním se neshoduje žádný přednášející."

--- a/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-03-17 03:38+0000\n"
 "Last-Translator: Tobias Kunze <r@rixx.de>\n"
 "Language-Team: \n"
@@ -245,8 +245,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)smin"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "gelöscht"
 
@@ -258,7 +258,7 @@ msgstr "Das Profilbild der Vortragenden"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Sprache"
 
@@ -289,15 +289,15 @@ msgstr "Das Programm ist derzeit nicht öffentlich einsehbar."
 msgid "The session “{title}” at {event}"
 msgstr "Der Vortrag „{title}“, {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Allgemein"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Hey, schön dich kennenzulernen!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -305,7 +305,12 @@ msgstr ""
 "Wir freuen uns, dass du etwas bei unserer Veranstaltung einreichen möchtest. "
 "Hier geht es los – in ein paar Schritten ist es schon geschafft."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
@@ -315,31 +320,31 @@ msgstr ""
 "sie bis zur Abgabefrist weiter anpassen, und sollten sich Änderungen oder "
 "Fragen ergeben, werden wir dich benachrichtigen."
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Fragen"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Erzähl uns mehr!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 "Bevor du deine Einreichung abschließen kannst, haben wir noch ein paar "
 "Fragen für dich."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Account"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr "Und das wars! Wir brauchen nur noch einen Weg, dich zu erreichen."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -349,22 +354,22 @@ msgstr ""
 "Seite - nicht nur, damit wir dich erreichen können, sondern auch, damit du "
 "deine Einreichung editieren und ihren Status einsehen kannst."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
 msgstr ""
 "Es gab ein Fehler beim Einloggen. Bitte wende dich an die Veranstalter."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Profil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Erzähl uns etwas über dich!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -396,13 +401,13 @@ msgid "Text"
 msgstr "Text"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} lädt dich zu einem Talk ein!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -574,36 +579,43 @@ msgid "Proposals are closed"
 msgstr "Der Einreichungszeitraum ist beendet"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "eingereicht"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Review abschicken"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "abgelehnt"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "angenommen"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "bestätigt"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "abgesagt"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "zurückgezogen"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Zum CfP"
 
@@ -628,7 +640,7 @@ msgstr "Zusammenfassung:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "Nein"
 
@@ -714,7 +726,18 @@ msgstr "Weiter"
 msgid "Submit proposal!"
 msgstr "Zur Einreichung"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -777,7 +800,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -853,7 +876,7 @@ msgid "Your proposal:"
 msgstr "Deine Einreichung:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -861,7 +884,7 @@ msgstr "Aktueller Stand deiner Einreichung:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Einreichungsart"
 
@@ -872,7 +895,7 @@ msgstr "Einreichungsart"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Track"
 
@@ -907,13 +930,13 @@ msgid "Go back"
 msgstr "Zurück"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Zurückziehen"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Bestätigen"
 
@@ -931,27 +954,33 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "Aktueller Entwurf"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Bestätige deine Teilnahme"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Publikumsfeedback"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "Teilnehmende können hier Feedback abschicken, sobald der Vortrag "
 "stattgefunden hat."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Vortragende:"
 msgstr[1] "Vortragende:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "Submitters"
 msgid "Submitter:"
@@ -959,13 +988,13 @@ msgid_plural "Submitters:"
 msgstr[0] "Einreichende"
 msgstr[1] "Einreichende"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -973,21 +1002,33 @@ msgstr ""
 "Ressourcen sind öffentlich einsehbar. Bitte versuch, die Uploads kleiner als "
 "16MB zu halten."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Einen weiteren Upload hinzufügen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "Gespeichert!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "Submit proposal"
+msgstr "Zur Einreichung"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Einreichung teilen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -996,12 +1037,12 @@ msgstr ""
 "hier ein Link, den du für eine nicht-editierbare Ansicht deiner Einreichung "
 "verschicken kannst:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Einreichung zurückziehen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1012,11 +1053,11 @@ msgstr ""
 "Veranstaltung abhalten kannst oder sollst, kontaktiere bitte lieber die "
 "Veranstalter."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Einreichung absagen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1058,7 +1099,7 @@ msgid "You will not be able to revert this action."
 msgstr "Das kannst du nicht mehr rückgängig machen."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Deine Einreichungen"
 
@@ -1066,7 +1107,14 @@ msgstr "Deine Einreichungen"
 msgid "Important Information"
 msgstr "Wichtige Informationen"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "Aktueller Entwurf"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1075,45 +1123,46 @@ msgstr "Wichtige Informationen"
 msgid "Title"
 msgstr "Titel"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Review-Link kopieren"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Status"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Review-Link kopieren"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Feedback"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Neue Einreichung"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr ""
 "Hm, du hast anscheinend noch nichts bei dieser Veranstaltung eingereicht."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Wenn doch, dann hast du vielleicht einen anderen Account genutzt? Guck im "
 "Zweifel in deine Mails."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr ""
 "Wenn nicht, dann tu das doch jetzt! Wir freuen uns auf deine Einreichungen."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Reich etwas ein!"
 
@@ -1163,10 +1212,11 @@ msgstr ""
 "Das API-Token wurde zurückgesetzt, das bisherige Token kann nicht mehr "
 "verwendet werden."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Neue Einreichung: {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Deine Einreichung wurde zurückgezogen."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1988,7 +2038,7 @@ msgid "Imprint"
 msgstr "Impressum"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "Verlauf"
 
@@ -2419,7 +2469,7 @@ msgstr "Vielleicht"
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "Ja"
 
@@ -3024,7 +3074,7 @@ msgstr "Gravatar einbinden"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr "Vortragende können ihr Profilbild automatisch von Gravatar einbinden."
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "Anzahl"
 
@@ -3714,7 +3764,8 @@ msgstr[1] "Einreichungen"
 msgid "All proposals"
 msgstr "Alle Einreichungen"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "abgelehnt"
 
@@ -3729,7 +3780,7 @@ msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 "Die eindeutigen IDs von Einreichungen werden in URLs und Exporten verwendet"
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "Titel"
 
@@ -3922,7 +3973,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "Bitte gib den Namen ein, der öffentlich erscheinen soll."
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "Einreichungsstatus"
 
@@ -4208,7 +4259,7 @@ msgstr "Zugangscodes"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "Tags"
 
@@ -4642,14 +4693,14 @@ msgstr "Maximallänge"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Zusammenfassung"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Beschreibung"
@@ -4666,7 +4717,7 @@ msgstr "Verfügbarkeit"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "Notiz"
 
@@ -4676,12 +4727,12 @@ msgstr "Aufzeichnungs-Opt-Out"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "Bild"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "Dauer"
 
@@ -4738,7 +4789,7 @@ msgstr "nicht öffentlich"
 msgid "Click here to change"
 msgstr "Klick hier, um das zu ändern"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "Kompletter Verlauf"
 
@@ -4865,7 +4916,7 @@ msgstr "Deine nächsten Veranstaltungen"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] "Einreichung"
@@ -5325,7 +5376,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] "Einreichung wartet auf dein Review."
@@ -5377,7 +5428,7 @@ msgstr "Deine Wertung"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "Reviews"
 
@@ -6133,7 +6184,7 @@ msgid "Add a new note"
 msgstr "Neue Information hinzufügen"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "Einreichende"
@@ -6637,66 +6688,67 @@ msgstr ""
 "mehr gelöscht werden. Um ihn abzuschalten kannst du aber sein Enddatum "
 "setzen."
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "bis zum CfP-Ende"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Zur Einreichung"
+msgstr[1] "Zur Einreichung"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr "Aktive Reviewer"
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "proposals are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "Einreichung wartet auf dein Review."
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "Tag bis zum Start der Veranstaltung"
 msgstr[1] "Tage bis zum Start der Veranstaltung"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] "Tag seit Veranstaltungsende"
 msgstr[1] "Tage seit Veranstaltungsende"
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "Tag {number}"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "von {total_days} Tagen"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "Aktuelles Programm"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] "Session"
 msgstr[1] "Sessions"
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "nicht bestätigte Session"
-msgstr[1] "nicht bestätigte Sessions"
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "bestätigt"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "Vortragende"
 msgstr[1] "Vortragende"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "Verschickte E-Mail"
@@ -7199,15 +7251,15 @@ msgstr "Neue Einreichung ({event}): {title}"
 msgid "Deadline"
 msgstr "Einreichungsschluss"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr "Der Tag wurde gespeichert."
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr "Der Tag wurde gelöscht."
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr "{count} Einreichungen wurden angepasst."
@@ -7583,7 +7635,7 @@ msgstr ""
 "Einreichung weitere Einladungen verschicken."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 "Lad hier ein Bild hoch, wenn Du Deine Einreichung illustrieren möchtest."
@@ -8008,21 +8060,27 @@ msgstr ""
 "CfP beendet ist, und erst wieder freigegeben, wenn eine Einreichung "
 "angenommen wurde."
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+#, fuzzy
+#| msgid "Saved!"
+msgid "draft"
+msgstr "Gespeichert!"
+
+#: pretalx/submission/models/submission.py:162
 msgid "Pending proposal state"
 msgstr "Vorgemerkter Status"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 "Diese Notizen sind für die Veranstalter bestimmt und werden nicht "
 "veröffentlicht."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "Interner Vermerk"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -8030,7 +8088,7 @@ msgstr ""
 "Interner Vermerk der Veranstaltenden. Weder für Vortragende noch für die "
 "Öffentlichkeit einsehbar."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -8038,37 +8096,42 @@ msgstr ""
 "Die Dauer in Minuten. Wenn du nichts einträgst, wird der Standard für diese "
 "Einreichungsart genommen."
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "Wie oft der Vortrag gehalten wird."
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "Zeige diese Einreichung in der öffentlichen Liste der Highlights."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "Zeichnet meine Veranstaltung nicht auf."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Active reviewers"
 msgid "Assigned reviewers"
 msgstr "Aktive Reviewer"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " oder "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
 "Eine Einreichung muss {src_states} sein, nicht {state}, um {new_state} zu "
 "werden."
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Neue Einreichung: {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -8128,6 +8191,17 @@ msgstr "{name} ({duration} Stunden)"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} Minuten)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "proposals are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "Einreichung wartet auf dein Review."
+
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "nicht bestätigte Session"
+#~ msgstr[1] "nicht bestätigte Sessions"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "Keine Vortragenden wurden für diese Suche gefunden."
 
@@ -8165,9 +8239,6 @@ msgstr "{name} ({duration} Minuten)"
 
 #~ msgid "Compose mail"
 #~ msgstr "E-Mails schreiben"
-
-#~ msgid "Current draft"
-#~ msgstr "Aktueller Entwurf"
 
 #~ msgid "Show"
 #~ msgstr "Zeigen"

--- a/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-03-17 03:38+0000\n"
 "Last-Translator: Tobias Kunze <r@rixx.de>\n"
 "Language-Team: \n"
@@ -244,8 +244,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)smin"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "gelöscht"
 
@@ -257,7 +257,7 @@ msgstr "Das Profilbild der Vortragenden"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Sprache"
 
@@ -288,15 +288,15 @@ msgstr "Das Programm ist derzeit nicht öffentlich einsehbar."
 msgid "The session “{title}” at {event}"
 msgstr "Der Vortrag „{title}“, {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Allgemein"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Schön Sie kennenzulernen!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -304,7 +304,12 @@ msgstr ""
 "Wir freuen uns, dass Sie etwas bei unserer Veranstaltung einreichen möchten. "
 "Hier geht es los – in ein paar Schritten ist es schon geschafft."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
@@ -314,31 +319,31 @@ msgstr ""
 "sie bis zur Abgabefrist weiter anpassen, und sollten sich Änderungen oder "
 "Fragen ergeben, werden wir Sie benachrichtigen."
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Fragen"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Erzählen Sie uns mehr!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 "Bevor Sie Ihre Einreichung abschließen können, haben wir noch ein paar "
 "Fragen für Sie."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Account"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr "Und das wars! Wir brauchen nur noch einen Weg, Sie zu erreichen."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -348,22 +353,22 @@ msgstr ""
 "Seite - nicht nur, damit wir Sie erreichen können, sondern auch, damit Sie "
 "Ihre Einreichung editieren und ihren Status einsehen können."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
 msgstr ""
 "Es gab ein Fehler beim Einloggen. Bitte wenden Sie sich an die Veranstalter."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Profil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Erzählen Sie uns etwas über sich!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -395,13 +400,13 @@ msgid "Text"
 msgstr "Text"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} lädt Sie zu einem Talk ein!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -575,36 +580,43 @@ msgid "Proposals are closed"
 msgstr "Der Einreichungszeitraum ist beendet"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "eingereicht"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Review abschicken"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "abgelehnt"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "angenommen"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "bestätigt"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "abgesagt"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "zurückgezogen"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Zum CfP"
 
@@ -629,7 +641,7 @@ msgstr "Zusammenfassung:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "Nein"
 
@@ -715,7 +727,18 @@ msgstr "Weiter"
 msgid "Submit proposal!"
 msgstr "Zur Einreichung"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -778,7 +801,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -854,7 +877,7 @@ msgid "Your proposal:"
 msgstr "Ihre Einreichung:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -862,7 +885,7 @@ msgstr "Aktueller Stand Ihrer Einreichung:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Einreichungsart"
 
@@ -873,7 +896,7 @@ msgstr "Einreichungsart"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Track"
 
@@ -908,13 +931,13 @@ msgid "Go back"
 msgstr "Zurück"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Zurückziehen"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Bestätigen"
 
@@ -932,27 +955,33 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "Aktueller Entwurf"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Bestätigen Sie Ihre Teilnahme"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Publikumsfeedback"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "Teilnehmende können hier Feedback abschicken, sobald der Vortrag "
 "stattgefunden hat."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Vortragende:"
 msgstr[1] "Vortragende:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "Submitters"
 msgid "Submitter:"
@@ -960,13 +989,13 @@ msgid_plural "Submitters:"
 msgstr[0] "Einreichende"
 msgstr[1] "Einreichende"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Ressourcen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -974,21 +1003,33 @@ msgstr ""
 "Ressourcen sind öffentlich einsehbar. Bitte versuchen Sie, die Uploads "
 "kleiner als 16MB zu halten."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Einen weiteren Upload hinzufügen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "Gespeichert!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "Submit proposal"
+msgstr "Zur Einreichung"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Einreichung teilen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -997,12 +1038,12 @@ msgstr ""
 "hier ein Link, den Sie für eine nicht-editierbare Ansicht Ihrer Einreichung "
 "verschicken kannst:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Einreichung zurückziehen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1013,11 +1054,11 @@ msgstr ""
 "Veranstaltung abhalten können oder sollen, kontaktieren Sie bitte lieber die "
 "Veranstalter."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Einreichung absagen"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1059,7 +1100,7 @@ msgid "You will not be able to revert this action."
 msgstr "Das können Sie nicht mehr rückgängig machen."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Ihre Einreichungen"
 
@@ -1067,7 +1108,14 @@ msgstr "Ihre Einreichungen"
 msgid "Important Information"
 msgstr "Wichtige Informationen"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "Aktueller Entwurf"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1076,38 +1124,39 @@ msgstr "Wichtige Informationen"
 msgid "Title"
 msgstr "Titel"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Review-Link kopieren"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Status"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Review-Link kopieren"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Feedback"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Neue Einreichung"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr ""
 "Sie haben anscheinend noch nichts bei dieser Veranstaltung eingereicht."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Wenn doch, dann haben Sie vielleicht einen anderen Account genutzt? Sehen "
 "Sie im Zweifel in Ihren Mails nach."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
@@ -1115,7 +1164,7 @@ msgstr ""
 "Wenn nicht, dann tun Sie das doch jetzt! Wir freuen uns auf Ihre "
 "Einreichungen."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Reichen Sie etwas ein!"
 
@@ -1165,10 +1214,11 @@ msgstr ""
 "Das API-Token wurde zurückgesetzt, das bisherige Token kann nicht mehr "
 "verwendet werden."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Neue Einreichung: {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Ihre Einreichung wurde zurückgezogen."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1994,7 +2044,7 @@ msgid "Imprint"
 msgstr "Impressum"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "Verlauf"
 
@@ -2425,7 +2475,7 @@ msgstr "Vielleicht"
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "Ja"
 
@@ -3030,7 +3080,7 @@ msgstr "Gravatar einbinden"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr "Vortragende können ihr Profilbild automatisch von Gravatar einbinden."
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "Anzahl"
 
@@ -3722,7 +3772,8 @@ msgstr[1] "Einreichungen"
 msgid "All proposals"
 msgstr "Alle Einreichungen"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "abgelehnt"
 
@@ -3737,7 +3788,7 @@ msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 "Die eindeutigen IDs von Einreichungen werden in URLs und Exporten verwendet"
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "Titel"
 
@@ -3931,7 +3982,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "Bitte geben Sie den Namen ein, der öffentlich erscheinen soll."
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "Einreichungsstatus"
 
@@ -4220,7 +4271,7 @@ msgstr "Zugangscodes"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "Tags"
 
@@ -4654,14 +4705,14 @@ msgstr "Maximallänge"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Zusammenfassung"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Beschreibung"
@@ -4678,7 +4729,7 @@ msgstr "Verfügbarkeit"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "Notiz"
 
@@ -4688,12 +4739,12 @@ msgstr "Aufzeichnungs-Opt-Out"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "Bild"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "Dauer"
 
@@ -4750,7 +4801,7 @@ msgstr "nicht öffentlich"
 msgid "Click here to change"
 msgstr "Klicken Sie hier, um das zu ändern"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "Kompletter Verlauf"
 
@@ -4878,7 +4929,7 @@ msgstr "Ihre nächsten Veranstaltungen"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] "Einreichung"
@@ -5339,7 +5390,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] "Einreichung wartet auf Ihre Bewertung."
@@ -5391,7 +5442,7 @@ msgstr "Ihre Wertung"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "Reviews"
 
@@ -6150,7 +6201,7 @@ msgid "Add a new note"
 msgstr "Neue Information hinzufügen"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "Einreichende"
@@ -6655,66 +6706,67 @@ msgstr ""
 "mehr gelöscht werden. Um ihn abzuschalten können Sie aber sein Enddatum "
 "setzen."
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "bis zum CfP-Ende"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Zur Einreichung"
+msgstr[1] "Zur Einreichung"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr "Aktive Reviewer"
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "proposals are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "Einreichung wartet auf Ihre Bewertung."
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "Tag bis zum Start der Veranstaltung"
 msgstr[1] "Tage bis zum Start der Veranstaltung"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] "Tag seit Veranstaltungsende"
 msgstr[1] "Tage seit Veranstaltungsende"
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "Tag {number}"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "von {total_days} Tagen"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "Aktuelles Programm"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] "Vortrag"
 msgstr[1] "Vorträge"
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "nicht bestätigte Session"
-msgstr[1] "nicht bestätigte Sessions"
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "bestätigt"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "Vortragende"
 msgstr[1] "Vortragende"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "Verschickte E-Mail"
@@ -7218,15 +7270,15 @@ msgstr "Neue Einreichung ({event}): {title}"
 msgid "Deadline"
 msgstr "Einreichungsschluss"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr "Der Tag wurde gespeichert."
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr "Der Tag wurde gelöscht."
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr "{count} Einreichungen wurden angepasst."
@@ -7604,7 +7656,7 @@ msgstr ""
 "erfolgter Einreichung weitere Einladungen verschicken."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 "Laden Sie hier ein Bild hoch, wenn Sie Ihre Einreichung illustrieren "
@@ -8031,21 +8083,25 @@ msgstr ""
 "CfP beendet ist, und erst wieder freigegeben, wenn eine Einreichung "
 "angenommen wurde."
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 msgid "Pending proposal state"
 msgstr "Vorgemerkter Status"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 "Diese Notizen sind für die Veranstalter bestimmt und werden nicht "
 "veröffentlicht."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "Interner Vermerk"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -8053,7 +8109,7 @@ msgstr ""
 "Interner Vermerk der Veranstaltenden. Weder für Vortragende noch für die "
 "Öffentlichkeit einsehbar."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -8061,37 +8117,42 @@ msgstr ""
 "Die Dauer in Minuten. Wenn Sie nichts eintragen, wird der Standard für diese "
 "Einreichungsart genommen."
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "Wie oft der Vortrag gehalten wird."
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "Zeige diese Einreichung in der öffentlichen Liste der Highlights."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "Zeichnet meine Veranstaltung nicht auf."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Active reviewers"
 msgid "Assigned reviewers"
 msgstr "Aktive Reviewer"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " oder "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
 "Eine Einreichung muss {src_states} sein, nicht {state}, um {new_state} zu "
 "werden."
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Neue Einreichung: {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -8151,6 +8212,17 @@ msgstr "{name} ({duration} Stunden)"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} Minuten)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "proposals are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "Einreichung wartet auf Ihre Bewertung."
+
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "nicht bestätigte Session"
+#~ msgstr[1] "nicht bestätigte Sessions"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "Keine Vortragenden wurden für diese Suche gefunden."
 
@@ -8194,9 +8266,6 @@ msgstr "{name} ({duration} Minuten)"
 
 #~ msgid "Compose mail"
 #~ msgstr "E-Mails schreiben"
-
-#~ msgid "Current draft"
-#~ msgstr "Aktueller Entwurf"
 
 #~ msgid "Show"
 #~ msgstr "Zeigen"

--- a/src/pretalx/locale/django.pot
+++ b/src/pretalx/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -220,8 +220,8 @@ msgid "%(minutes)smin"
 msgstr ""
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr ""
 
@@ -264,71 +264,76 @@ msgstr ""
 msgid "The session “{title}” at {event}"
 msgstr ""
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr ""
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr ""
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
 msgstr ""
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr ""
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr ""
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr ""
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
 "your proposal or to view its current state."
 msgstr ""
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
 msgstr ""
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr ""
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr ""
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -357,13 +362,13 @@ msgid "Text"
 msgstr ""
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr ""
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -505,36 +510,41 @@ msgid "Proposals are closed"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
-msgid "not accepted"
+msgid "in review"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
-msgid "accepted"
+msgid "not accepted"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
-msgid "confirmed"
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
+msgid "accepted"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
-msgid "canceled"
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
+msgid "confirmed"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:13
 #: pretalx/submission/models/submission.py:53
+msgid "canceled"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr ""
 
@@ -557,7 +567,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr ""
 
@@ -637,7 +647,18 @@ msgstr ""
 msgid "Submit proposal!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -693,7 +714,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -763,7 +784,7 @@ msgid "Your proposal:"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -771,7 +792,7 @@ msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr ""
 
@@ -782,7 +803,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr ""
 
@@ -810,13 +831,13 @@ msgid "Go back"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr ""
 
@@ -832,79 +853,91 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+msgid "Your draft:"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 msgid "Submitter:"
 msgid_plural "Submitters:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+msgid "Save draft"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+msgid "Submit proposal"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
 "session, please contact the organiser instead."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -940,7 +973,7 @@ msgid "You will not be able to revert this action."
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr ""
 
@@ -948,7 +981,12 @@ msgstr ""
 msgid "Important Information"
 msgstr ""
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+msgid "Your drafts"
+msgstr ""
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -957,41 +995,42 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr ""
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr ""
 
@@ -1039,9 +1078,8 @@ msgid ""
 "any longer."
 msgstr ""
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
+#: pretalx/cfp/views/user.py:389
+msgid "Your proposal has been submitted."
 msgstr ""
 
 #: pretalx/common/context_processors.py:42
@@ -1763,7 +1801,7 @@ msgid "Imprint"
 msgstr ""
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr ""
 
@@ -2137,7 +2175,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr ""
 
@@ -2635,7 +2673,7 @@ msgstr ""
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr ""
 
@@ -3255,7 +3293,8 @@ msgstr[1] ""
 msgid "All proposals"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr ""
 
@@ -3267,7 +3306,7 @@ msgstr ""
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr ""
 
@@ -3447,7 +3486,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr ""
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -3713,7 +3752,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4101,14 +4140,14 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr ""
@@ -4123,7 +4162,7 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr ""
 
@@ -4133,12 +4172,12 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr ""
 
@@ -4188,7 +4227,7 @@ msgstr ""
 msgid "Click here to change"
 msgstr ""
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr ""
 
@@ -4298,7 +4337,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] ""
@@ -4724,7 +4763,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] ""
@@ -4776,7 +4815,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr ""
 
@@ -5437,7 +5476,7 @@ msgid "Add a new note"
 msgstr ""
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] ""
@@ -5905,63 +5944,63 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-msgid "proposals are waiting for your review."
-msgstr ""
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
+#: pretalx/orga/views/dashboard.py:288
+msgid "unconfirmed"
+msgstr ""
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -6409,15 +6448,15 @@ msgstr ""
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -6742,7 +6781,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7118,56 +7157,65 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 msgid "Pending proposal state"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 msgid "Assigned reviewers"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr ""
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
+msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
 msgstr ""
 
 #: pretalx/submission/models/tag.py:31

--- a/src/pretalx/locale/el/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/el/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-05-17 00:41+0000\n"
 "Last-Translator: EELLAK WebDev <webmaster@eellak.gr>\n"
 "Language-Team: none\n"
@@ -227,8 +227,8 @@ msgid "%(minutes)smin"
 msgstr ""
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "διαγράφηκε"
 
@@ -240,7 +240,7 @@ msgstr ""
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr ""
 
@@ -271,57 +271,62 @@ msgstr ""
 msgid "The session “{title}” at {event}"
 msgstr ""
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Γενικά"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Χαρήκαμε για τη γνωριμία!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
 msgstr ""
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Ερωτήσεις"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Πείτε μας περισσότερα!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr ""
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
 "your proposal or to view its current state."
 msgstr ""
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -329,15 +334,15 @@ msgstr ""
 "Υπήρξε πρόβλημα κατά την σύνδεση. Παρακαλώ επικοινωνήστε με τους διοργανωτές "
 "για επιπλέον βοήθεια."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr ""
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Πείτε μας κάτι για τον εαυτό σας!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -366,13 +371,13 @@ msgid "Text"
 msgstr "Κείμενο"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr ""
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -521,36 +526,43 @@ msgid "Proposals are closed"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "υπεβλήθη"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Στείλτε ανασκόπηση"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "μη αποδεκτή"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "αποδεκτή"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "επιβεβαιώθηκε"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "ακυρώθηκε"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "αποσύρθηκε"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Πηγαίνετε στο CfP"
 
@@ -573,7 +585,7 @@ msgstr "Περίληψη:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "Όχι"
 
@@ -655,7 +667,18 @@ msgstr "Συνέχεια"
 msgid "Submit proposal!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -711,7 +734,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -784,7 +807,7 @@ msgid "Your proposal:"
 msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -792,7 +815,7 @@ msgstr ""
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr ""
 
@@ -803,7 +826,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr ""
 
@@ -831,13 +854,13 @@ msgid "Go back"
 msgstr "Πήγαινε πίσω"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Απόσυρση"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
@@ -855,25 +878,31 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Your Profile"
+msgid "Your draft:"
+msgstr "Το προφίλ σας"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Επιβεβαίωση παρουσίας"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Ομιλητής:"
 msgstr[1] "Ομιλητές:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitted"
 msgid "Submitter:"
@@ -881,13 +910,13 @@ msgid_plural "Submitters:"
 msgstr[0] "υπεβλήθη"
 msgstr[1] "υπεβλήθη"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Πόροι"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -895,43 +924,55 @@ msgstr ""
 "Οι πόροι θα είναι δημόσια ορατοί. Παρακαλώ προσπαθήστε να κρατήσετε τα "
 "αρχεία σας κάτω από 16ΜΒ."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "Αποθηκεύτηκε!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "Υποβολή πρότασης"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
 "session, please contact the organiser instead."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -967,7 +1008,7 @@ msgid "You will not be able to revert this action."
 msgstr "Δεν θα είστε σε θέση να αναιρέσετε αυτή την ενέργεια."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr ""
 
@@ -975,7 +1016,14 @@ msgstr ""
 msgid "Important Information"
 msgstr "Σημαντικές πληροφορίες"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Your Profile"
+msgid "Your drafts"
+msgstr "Το προφίλ σας"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -984,44 +1032,45 @@ msgstr "Σημαντικές πληροφορίες"
 msgid "Title"
 msgstr "Τίτλος"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Κατάσταση"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr ""
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Παρατηρήσεις"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr ""
 "Φαίνεται πως δεν έχετε υποβάλει ακόμη κάποια αίτηση σε αυτή την εκδήλωση."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Αν έχετε, μήπως χρησιμοποιήσατε διαφορετικό λογαριασμό; Ελέγξτε τα emails "
 "σας!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr "Αν δεν έχετε, μπορείτε να δημιουργήσετε μια πρόταση τώρα!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Υποβάλετε κάτι τώρα!"
 
@@ -1071,10 +1120,11 @@ msgstr ""
 "Το API token σας αναδημιουργήθηκε. Το προηγούμενο token δε θα είναι πια "
 "χρησιμοποιήσιμο."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr ""
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your changes have been saved."
+msgid "Your proposal has been submitted."
+msgstr "Οι αλλαγές σας έχουν αποθηκευτεί."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1824,7 +1874,7 @@ msgid "Imprint"
 msgstr ""
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "Ιστορικό"
 
@@ -2222,7 +2272,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "Ναι"
 
@@ -2725,7 +2775,7 @@ msgstr ""
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr ""
 
@@ -3353,7 +3403,8 @@ msgstr[1] ""
 msgid "All proposals"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "απορρίφθηκε"
 
@@ -3365,7 +3416,7 @@ msgstr ""
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr ""
 
@@ -3549,7 +3600,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr ""
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -3816,7 +3867,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4224,14 +4275,14 @@ msgstr "Μέγιστη διάρκεια"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Περίληψη"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Περιγραφή"
@@ -4248,7 +4299,7 @@ msgstr "Διαθεσιμότητα"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr ""
 
@@ -4258,12 +4309,12 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "Διάρκεια"
 
@@ -4313,7 +4364,7 @@ msgstr ""
 msgid "Click here to change"
 msgstr ""
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr ""
 
@@ -4423,7 +4474,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] ""
@@ -4863,7 +4914,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] ""
@@ -4915,7 +4966,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "Αξιολογήσεις"
 
@@ -5587,7 +5638,7 @@ msgid "Add a new note"
 msgstr "Προσθέστε μια νέα σημείωση"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] ""
@@ -6058,63 +6109,67 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Υποβολή πρότασης"
+msgstr[1] "Υποβολή πρότασης"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-msgid "proposals are waiting for your review."
-msgstr ""
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "Ημέρα {number}"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "{total_days} ημερών"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "τρέχον πρόγραμμα"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "επιβεβαιώθηκε"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "ομιλητής"
 msgstr[1] "ομιλητές"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -6576,15 +6631,15 @@ msgstr ""
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -6923,7 +6978,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7305,56 +7360,65 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 msgid "Pending proposal state"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 msgid "Assigned reviewers"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " ή "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
+msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
 msgstr ""
 
 #: pretalx/submission/models/tag.py:31

--- a/src/pretalx/locale/es/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-02-24 19:37+0000\n"
 "Last-Translator: Manuel Martin <draxus@gmail.com>\n"
 "Language-Team: none\n"
@@ -244,8 +244,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)sminutos"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "eliminado/a"
 
@@ -257,7 +257,7 @@ msgstr "Foto de perfíl del o de la ponente"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Idioma"
 
@@ -288,15 +288,15 @@ msgstr "Nuestra agenda todavía no está en vivo."
 msgid "The session “{title}” at {event}"
 msgstr "La sesión \"{title}\" en {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "General"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "¡Hola, es un placer conocerle!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -304,7 +304,12 @@ msgstr ""
 "Nos alegra que quiera contribuir a nuestro evento con su propuesta. "
 "Empecemos ahora, no tomará mucho tiempo."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
@@ -314,31 +319,31 @@ msgstr ""
 "propuesta hasta la fecha límite de envío. Le notificaremos con cualquier "
 "cambio o pregunta que tengamos."
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Preguntas"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "¡Cuéntenos más!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "Antes de guardar su propuesta, tenemos algunas preguntas."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Cuenta"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 "Hemos terminado la preparación de su propuesta! Solo necesitamos saber como "
 "contactarle."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -348,7 +353,7 @@ msgstr ""
 "contactarle, pero también nos da la posibilidad de editar su propuesta o de "
 "ver su estado actual."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -356,15 +361,15 @@ msgstr ""
 "Une error ha occurido durante la conexión. Favor de contactar a los "
 "organizadores para conseguir ayuda."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Perfíl"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Di nos algo sobre ti!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -395,13 +400,13 @@ msgid "Text"
 msgstr "Texto"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} te invitaron a unirte a la sesión!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -575,36 +580,43 @@ msgid "Proposals are closed"
 msgstr "El envío de propuestas esta cerrado"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "enviado"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Enviar evaluación"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "no aceptada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "aceptado"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "confirmado"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "cancelado"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "retirado"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Ir a CfP"
 
@@ -629,7 +641,7 @@ msgstr "Resumen:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "No"
 
@@ -717,7 +729,18 @@ msgstr "Continuar"
 msgid "Submit proposal!"
 msgstr "Enviar una propuesta"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -780,7 +803,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -855,7 +878,7 @@ msgid "Your proposal:"
 msgstr "Tu propuesta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -863,7 +886,7 @@ msgstr "Estado actual de su propuesta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Tipo de sesión"
 
@@ -874,7 +897,7 @@ msgstr "Tipo de sesión"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Sala"
 
@@ -909,13 +932,13 @@ msgid "Go back"
 msgstr "Regresa"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Retirar"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -933,27 +956,33 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "Borrador actual"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Confirme su asistencia"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Comentarios de la audiencia"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "Los asistentes pueden dejar comentarios aquí después de que se haya "
 "realizado la sesión."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Ponente:"
 msgstr[1] "Ponentes:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitter"
 #| msgid_plural "submitters"
@@ -962,13 +991,13 @@ msgid_plural "Submitters:"
 msgstr[0] "remitente"
 msgstr[1] "remitentes"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Recursos"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -976,21 +1005,33 @@ msgstr ""
 "Los recursos serán visibles públicamente. Intente mantener sus envíos por "
 "debajo de 16 MB."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Agregar otro recurso"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "¡Guardado!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "Enviar una propuesta"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Compartir propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -998,12 +1039,12 @@ msgstr ""
 "Si necesita una revisión de un colega o un amigo, aquí hay un enlace que "
 "puede enviar para ver su propuesta:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Retirar propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1013,11 +1054,11 @@ msgstr ""
 "esto - Si no está seguro de si puede o debería realizar la sesión, "
 "comuníquese con el organizador."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Cancelar propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1059,7 +1100,7 @@ msgid "You will not be able to revert this action."
 msgstr "No podrás revertir esta acción."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Tus propuestas"
 
@@ -1067,7 +1108,14 @@ msgstr "Tus propuestas"
 msgid "Important Information"
 msgstr "Información importante"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "Borrador actual"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1076,36 +1124,37 @@ msgstr "Información importante"
 msgid "Title"
 msgstr "Título"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Copiar código para reseña"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Estado"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Copiar código para reseña"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Comentarios"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Crea una nueva propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "Parece que aún no has enviado nada a este evento."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Si lo hiciste, ¿quizás usaste una cuenta diferente? ¡Revisa tus correos!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
@@ -1113,7 +1162,7 @@ msgstr ""
 "Si no lo hiciste, ¿por qué no seguir adelante y crear una propuesta ahora? "
 "¡Nos encantaría saber de ti!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Envíe algo ahora!"
 
@@ -1163,10 +1212,11 @@ msgstr ""
 "Su token de API se ha regenerado. El token anterior ya no se podrá utilizar "
 "más."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nueva propuesta:{title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Su propuesta ha sido retirada."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1990,7 +2040,7 @@ msgid "Imprint"
 msgstr "Información legal"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "Historia"
 
@@ -2423,7 +2473,7 @@ msgstr "A lo mejor"
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "Si"
 
@@ -3019,7 +3069,7 @@ msgstr "Usa un avatar"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr "Permitir a los usuarios de incluir sus imágenes de perfil gravatar."
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "Recuento de espacios"
 
@@ -3723,7 +3773,8 @@ msgstr[1] "Propuestas"
 msgid "All proposals"
 msgstr "Todas las propuestas"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "rechazada"
 
@@ -3739,7 +3790,7 @@ msgstr ""
 "El ID único de una propuesta se utiliza en la URL de la propuesta y en las "
 "exportaciones"
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "Título de la propuesta"
 
@@ -3932,7 +3983,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "El nombre del orador que debe mostrarse públicamente."
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "Estado de la propuesta"
 
@@ -4217,7 +4268,7 @@ msgstr "Códigos de acceso"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "Etiquetas"
 
@@ -4652,14 +4703,14 @@ msgstr "Longitud máxima"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Resumen"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Descripción"
@@ -4676,7 +4727,7 @@ msgstr "Disponibilidad"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "Notas"
 
@@ -4686,12 +4737,12 @@ msgstr "Exclusión de grabación"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "Imagen de la sesión"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "Duración"
 
@@ -4748,7 +4799,7 @@ msgstr "no en vivo"
 msgid "Click here to change"
 msgstr "Haga clic aquí para cambiar"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "Historia completa"
 
@@ -4876,7 +4927,7 @@ msgstr "Tus próximos eventos"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] "propuesta"
@@ -5353,7 +5404,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] "La propuesta está esperando su revisión."
@@ -5405,7 +5456,7 @@ msgstr "Tu puntuación"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "Reseñas"
 
@@ -6177,7 +6228,7 @@ msgid "Add a new note"
 msgstr "Agregar una nueva nota"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "remitente"
@@ -6674,66 +6725,67 @@ msgstr ""
 "Este código de acceso ha sido utilizado para una propuesta y no puede ser "
 "eliminado. Para desactivarlo, puede fijar su fecha de validez en el pasado."
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "hasta que finalice la convocatoria de propuestas"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Enviar una propuesta"
+msgstr[1] "Enviar una propuesta"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr "Revisadores activos"
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "proposals are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "La propuesta está esperando su revisión."
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "día hasta el inicio del evento"
 msgstr[1] "días hasta el inicio del evento"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] "día hasta el fin del evento"
 msgstr[1] "días hasta el fin del evento"
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "Día {number}"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "de {total_days} días"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "agenda actual"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] "sesión"
 msgstr[1] "sesiones"
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "sesión no confirmada"
-msgstr[1] "sesiones no confirmadas"
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "confirmado"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "orador/a"
 msgstr[1] "oradores/as"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "correo electrónico enviado"
@@ -7238,15 +7290,15 @@ msgstr "Nueva propuesta {event}: {title}"
 msgid "Deadline"
 msgstr "Fecha límite"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr "Se ha guardado la etiqueta."
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr "La etiqueta ha sido eliminada."
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, fuzzy, python-brace-format
 #| msgid "New {event} proposal: {title}"
 msgid "Changed {count} proposal states."
@@ -7630,7 +7682,7 @@ msgstr ""
 "más oradores tras finalizar el proceso de propuesta."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr "Utilízalo si quieres una ilustración que acompañe a tu propuesta."
 
@@ -8060,21 +8112,25 @@ msgstr ""
 "que finaliza el CfP y se vuelve a habilitar una vez que se aceptó la "
 "propuesta."
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposal state"
 msgid "Pending proposal state"
 msgstr "Estado de la propuesta"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr "Estas notas están destinadas al organizador y no se harán públicas."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "Notas internas"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -8082,7 +8138,7 @@ msgstr ""
 "Notas internas para otros organizadores / revisores. No visible para los "
 "ponentes ni para el público."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -8090,35 +8146,40 @@ msgstr ""
 "La duración en minutos. Déjelo en blanco durante la duración predeterminada "
 "de este tipo de sesión."
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "Cuántas veces se llevará a cabo esta sesión."
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "Muestre esta sesión en una lista pública de sesiones destacadas."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "No grabe esta sesión."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Active reviewers"
 msgid "Assigned reviewers"
 msgstr "Revisadores activos"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " o "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr "La propuesta debe ser{src_states} no {state} ser {new_state}."
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nueva propuesta:{title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -8182,6 +8243,17 @@ msgstr "{name} ({duration} horas)"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} minutos)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "proposals are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "La propuesta está esperando su revisión."
+
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "sesión no confirmada"
+#~ msgstr[1] "sesiones no confirmadas"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "Ningún/a ponente se encontró con esta búsqueda."
 
@@ -8225,9 +8297,6 @@ msgstr "{name} ({duration} minutos)"
 
 #~ msgid "Compose mail"
 #~ msgstr "Escribir un email"
-
-#~ msgid "Current draft"
-#~ msgstr "Borrador actual"
 
 #~ msgid "Show"
 #~ msgstr "Ver"

--- a/src/pretalx/locale/es_MX/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/es_MX/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2021-02-03 16:17+0000\n"
 "Last-Translator: Bryan Hernandez <bryan27hr@protonmail.ch>\n"
 "Language-Team: none\n"
@@ -240,8 +240,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)smin"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "eliminada"
 
@@ -253,7 +253,7 @@ msgstr "Imagen del conferencista"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Idioma"
 
@@ -284,15 +284,15 @@ msgstr "Nuestro horario no se ha hecho público todavía."
 msgid "The session “{title}” at {event}"
 msgstr "La charla “{title}” en {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "General"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Hola, ¡es un placer saludarte!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -300,36 +300,41 @@ msgstr ""
 "Estamos encantados de que te interese participar en nuestro evento. Esto "
 "será rápido, comencemos."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Preguntas"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "¡Cuéntanos más!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "Antes de guardar tu propuesta, tenemos unas preguntas más."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Cuenta"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr "Ya casi terminamos. Solo necesitamos alguna forma para contactarte."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -339,7 +344,7 @@ msgstr ""
 "solamente nos permitirá contactarte, sino que también te permite editar tu "
 "propuesta o consultar su estatus."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -347,15 +352,15 @@ msgstr ""
 "Hubo un error al tratar de acceder. Por favor contacta al administrador del "
 "sitio para más ayuda."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Perfil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "¡Dinos algo sobre tí!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -386,13 +391,13 @@ msgid "Text"
 msgstr "Texto"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "¡{speaker} te invita a unirte a su charla!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -564,36 +569,43 @@ msgid "Proposals are closed"
 msgstr "La convocatoria está cerrada"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "enviada"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Enviar revisión"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "no aceptada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "aceptada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "seleccionada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "cancelada"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "retirada"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Ir a la convocatoria"
 
@@ -618,7 +630,7 @@ msgstr "Resumen (abstract):"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "No"
 
@@ -705,7 +717,18 @@ msgstr "Continuar"
 msgid "Submit proposal!"
 msgstr "Envía una propuesta"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -766,7 +789,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -841,7 +864,7 @@ msgid "Your proposal:"
 msgstr "Tu propuesta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -849,7 +872,7 @@ msgstr "Estatus actual de tu propuesta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Tipo de propuesta"
 
@@ -860,7 +883,7 @@ msgstr "Tipo de propuesta"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Track"
 
@@ -894,13 +917,13 @@ msgid "Go back"
 msgstr "Regresar"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Retirar"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -918,26 +941,32 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Your proposal:"
+msgid "Your draft:"
+msgstr "Tu propuesta:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Confirma tu participación"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Retroalimentación de la audiencia"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "Los participantes pueden dejar retroalimentación aquí después de tu charla."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Conferencista:"
 msgstr[1] "Conferencistas:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitted"
 msgid "Submitter:"
@@ -945,13 +974,13 @@ msgid_plural "Submitters:"
 msgstr[0] "enviada"
 msgstr[1] "enviada"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Recursos"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -959,33 +988,45 @@ msgstr ""
 "Los recursos estarán visibles al público. Por favor manten tus archivos "
 "abajo de 16 MB."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Agregar otro recurso"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Save this!"
+msgid "Save draft"
+msgstr "¡Guardar esto!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "Envía una propuesta"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Compartir propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
 msgstr ""
 "Si deseas solicitar una reseña a un colega o amigo puedes darles este enlace:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Retirar propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -995,11 +1036,11 @@ msgstr ""
 "irreversible - si simplemente no estás segura(o) de si tendrás oportunidad "
 "de participar, mejor contacta al organizador antes de retirar tu propuesta."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Cancelar propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1039,7 +1080,7 @@ msgid "You will not be able to revert this action."
 msgstr "No podrás revertir esta acción."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Tus propuestas"
 
@@ -1047,7 +1088,14 @@ msgstr "Tus propuestas"
 msgid "Important Information"
 msgstr "Información Importante"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Your proposals"
+msgid "Your drafts"
+msgstr "Tus propuestas"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1056,42 +1104,43 @@ msgstr "Información Importante"
 msgid "Title"
 msgstr "Título"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Copiar código para reseña"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Estatus"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Copiar código para reseña"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Retroalimentación"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Crear una nueva propuesta"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "Parece que no has enviado ninguna propuesta para este evento todavía."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Si lo hiciste, tal vez utilizaste otra cuenta o correo. Consulta tus correos."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr "Si no, ¿por qué no creas una propuesta? Nos encantaría que participes."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "¡Enviar algo ahora!"
 
@@ -1140,10 +1189,11 @@ msgid ""
 msgstr ""
 "Tu API token se ha regenerado. El token anterior ya no se podrá utilizar."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nueva propuesta: {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Tu propuesta ha sido retirada."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1900,7 +1950,7 @@ msgid "Imprint"
 msgstr ""
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr ""
 
@@ -2277,7 +2327,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr ""
 
@@ -2813,7 +2863,7 @@ msgstr ""
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr ""
 
@@ -3451,7 +3501,8 @@ msgstr[1] ""
 msgid "All proposals"
 msgstr "Tus propuestas"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr ""
 
@@ -3465,7 +3516,7 @@ msgstr "La convocatoria está cerrada"
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr ""
 
@@ -3668,7 +3719,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr ""
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -3934,7 +3985,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4326,14 +4377,14 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr ""
@@ -4350,7 +4401,7 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr ""
 
@@ -4360,12 +4411,12 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr ""
 
@@ -4415,7 +4466,7 @@ msgstr ""
 msgid "Click here to change"
 msgstr ""
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr ""
 
@@ -4525,7 +4576,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] ""
@@ -4955,7 +5006,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] ""
@@ -5007,7 +5058,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr ""
 
@@ -5684,7 +5735,7 @@ msgid "Add a new note"
 msgstr ""
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] ""
@@ -6154,65 +6205,67 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Envía una propuesta"
+msgstr[1] "Envía una propuesta"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "Copy code for review"
-msgid "proposals are waiting for your review."
-msgstr "Copiar código para reseña"
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "seleccionada"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -6664,15 +6717,15 @@ msgstr "Nueva propuesta \"{title}\" para evento {event}"
 msgid "Deadline"
 msgstr "Fecha límite"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr "Esta etiqueta ha sido agregada."
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr "Esta etiqueta ha sido eliminada."
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, fuzzy, python-brace-format
 #| msgid "New {event} proposal: {title}"
 msgid "Changed {count} proposal states."
@@ -7008,7 +7061,7 @@ msgstr ""
 "que hayas terminado la propuesta."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7394,61 +7447,70 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "New proposal: {title}"
 msgid "Pending proposal state"
 msgstr "Nueva propuesta: {title}"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "Mostrar esta sesión en la lista pública de sesiones destacadas."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Send review"
 msgid "Assigned reviewers"
 msgstr "Enviar revisión"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr ""
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nueva propuesta: {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -7505,6 +7567,11 @@ msgstr ""
 #, python-brace-format
 msgid "{name} ({duration} minutes)"
 msgstr ""
+
+#, fuzzy
+#~| msgid "Copy code for review"
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "Copiar código para reseña"
 
 #~ msgid "No speaker matches your search."
 #~ msgstr "Tu búsqueda no empata con ningún conferencista."

--- a/src/pretalx/locale/fr_FR/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/fr_FR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-09-16 11:29+0000\n"
 "Last-Translator: Stéphane Parunakian <parunakian.stephane@gmail.com>\n"
 "Language-Team: \n"
@@ -246,8 +246,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)sminutes"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "supprimé"
 
@@ -259,7 +259,7 @@ msgstr "L'image de profil de l'intervenant"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Langue"
 
@@ -290,15 +290,15 @@ msgstr "Notre agenda n'est pas encore visible."
 msgid "The session “{title}” at {event}"
 msgstr "L'intervention \"{title}\" pour {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Général"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Hey, ravi de vous rencontrer !"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -306,7 +306,12 @@ msgstr ""
 "Nous sommes heureux de voir que vous voulez proposer une intervention pour "
 "notre évènement. Commençons, ça ne va pas être long."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
@@ -316,33 +321,33 @@ msgstr ""
 "la modifier jusqu'à la date butoir de dépôt et vous serez notifié de tout "
 "changement ou de toute question."
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Questions"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Dites-nous en plus !"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 "Avant de sauver votre proposition, nous avons quelques questions "
 "supplémentaires à vous poser."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Compte"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 "C'est tout pour votre proposition ! Maintenant nous avons juste besoin d'un "
 "moyen de vous contacter."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -352,7 +357,7 @@ msgstr ""
 "Non seulement cela nous permet de vous contacter, mais cela vous permet "
 "aussi d'éditer votre proposition et de voir son état."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -360,15 +365,15 @@ msgstr ""
 "Il y a eu un problème lors de la connexion. Veuillez contacter l'équipe "
 "d'organisation pour obtenir de l'aide supplémentaire."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Profil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Parlez nous de vous !"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -400,13 +405,13 @@ msgid "Text"
 msgstr "Texte"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} vous a invité à rejoindre son intervention !"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -583,36 +588,43 @@ msgid "Proposals are closed"
 msgstr "L'appel à participation est clôt"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "proposé"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Envoyer l'évaluation"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "rejeté"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "accepté"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "confirmé"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "annulé"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "retiré"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Aller à l'appel à participation"
 
@@ -637,7 +649,7 @@ msgstr "Résumé :"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "Non"
 
@@ -726,7 +738,18 @@ msgstr "Continuer"
 msgid "Submit proposal!"
 msgstr "Proposer une intervention !"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -788,7 +811,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -863,7 +886,7 @@ msgid "Your proposal:"
 msgstr "Votre proposition :"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -871,7 +894,7 @@ msgstr "État actuel de votre proposition :"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Type de proposition"
 
@@ -882,7 +905,7 @@ msgstr "Type de proposition"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Parcours"
 
@@ -917,13 +940,13 @@ msgid "Go back"
 msgstr "Retourner en arrière"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Retirer"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Confirmer"
 
@@ -943,38 +966,44 @@ msgstr ""
 "avec un autre compte ou contactez les organisateurs de l'évènement pour plus "
 "d'informations."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "Brouillon actuel"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Confirmez votre présence"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Commentaires des visiteurs"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "Les visiteurs peuvent laisser des commentaires ici après votre intervention."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Intervenant :"
 msgstr[1] "Intervenants :"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 msgid "Submitter:"
 msgid_plural "Submitters:"
 msgstr[0] "Intervenant :"
 msgstr[1] "Intervenants :"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Ressources"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -982,21 +1011,33 @@ msgstr ""
 "Les ressources seront accessibles publiquement. Veuillez effectuer des "
 "envois de moins de 16 Mo."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Ajouter une nouvelle ressource"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "Sauvegardé !"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "Submit proposal"
+msgstr "Proposer une intervention !"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Partager la proposition"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -1004,12 +1045,12 @@ msgstr ""
 "Si vous souhaitez faire relire votre proposition par un collègue ou un ami, "
 "voilà un lien que vous pouvez envoyer pour la partager :"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Retirer la proposition"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1019,11 +1060,11 @@ msgstr ""
 "pourrez pas annuler cette action - si vous avez des doutes, veuillez "
 "contacter l'organisateur à la place."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Annuler la proposition"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1065,7 +1106,7 @@ msgid "You will not be able to revert this action."
 msgstr "Cette action est irréversible."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Vos propositions"
 
@@ -1073,7 +1114,14 @@ msgstr "Vos propositions"
 msgid "Important Information"
 msgstr "Informations importantes"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "Brouillon actuel"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1082,37 +1130,38 @@ msgstr "Informations importantes"
 msgid "Title"
 msgstr "Titre"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Copier le code pour évaluation"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "État"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Copier le code pour évaluation"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Commentaires"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Créer une nouvelle proposition"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "Il semblerait que vous n'ayez encore rien proposé pour cet évènement."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Si vous avez déjà proposé quelque chose, peut-être était-ce avec un compte "
 "différent ? Vérifiez vos courriels !"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
@@ -1120,7 +1169,7 @@ msgstr ""
 "Si vous ne l'avez pas déjà fait, pourquoi ne créeriez vous pas une "
 "proposition maintenant ? On adorerait avoir de vos nouvelles !"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Proposer quelque chose maintenant !"
 
@@ -1169,10 +1218,11 @@ msgid ""
 msgstr ""
 "Votre jeton d'API a été re-généré. Le précédent jeton n'est plus utilisable."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nouvelle proposition de session : {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Votre proposition a été retirée."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1998,7 +2048,7 @@ msgid "Imprint"
 msgstr "Mentions légales"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "Historique"
 
@@ -2433,7 +2483,7 @@ msgstr "Peut-être"
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "Oui"
 
@@ -3051,7 +3101,7 @@ msgstr "Votre avatar"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "Compteur de slots"
 
@@ -3768,7 +3818,8 @@ msgstr[1] "Propositions"
 msgid "All proposals"
 msgstr "Toutes les propositions"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "rejeté"
 
@@ -3784,7 +3835,7 @@ msgstr ""
 "L'identifiant unique d'une proposition apparaît dans l'URL de la proposition "
 "et dans les exports"
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "Titre de la proposition"
 
@@ -3981,7 +4032,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "Le nom de l'intervenant qui sera affiché publiquement."
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "Statut de la proposition"
 
@@ -4269,7 +4320,7 @@ msgstr "Codes d'accès"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "Étiquettes"
 
@@ -4717,14 +4768,14 @@ msgstr "Longueur maximale"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Résumé"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Description"
@@ -4741,7 +4792,7 @@ msgstr "Disponibilité"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "Notes"
 
@@ -4751,12 +4802,12 @@ msgstr "Autorisation d'être enregistré"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "Image pour la proposition"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "Durée"
 
@@ -4814,7 +4865,7 @@ msgstr "inactif"
 msgid "Click here to change"
 msgstr "Cliquez ici pour changer ça"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "Historique complet"
 
@@ -4943,7 +4994,7 @@ msgstr "Vos évènements à venir"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] "proposition"
@@ -5402,7 +5453,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] "proposition est en attente de votre évaluation."
@@ -5454,7 +5505,7 @@ msgstr "Votre score"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "Évaluations"
 
@@ -6240,7 +6291,7 @@ msgid "Add a new note"
 msgstr "Ajouter une nouvelle note"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "personne ayant déposé une proposition"
@@ -6758,66 +6809,67 @@ msgstr ""
 "supprimé. Pour le désactiver, vous pouvez configurer sa date de validité "
 "dans le passé."
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "avant la fin de l'appel à participation"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Proposer une intervention !"
+msgstr[1] "Proposer une intervention !"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr "Évaluateurs actif"
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "proposals are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "proposition est en attente de votre évaluation."
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "jour avant que l'évènement commence"
 msgstr[1] "jours avant que l'évènement commence"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] "jour depuis la fin de l'évènement"
 msgstr[1] "jours depuis la fin de l'évènement"
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "Jour {number}"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "de {total_days} jours"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "version actuelle du planning"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] "intervention"
 msgstr[1] "interventions"
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "intervention non confirmée"
-msgstr[1] "interventions non confirmées"
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "confirmé"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "intervenant"
 msgstr[1] "intervenants"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "courriel envoyé"
@@ -7332,15 +7384,15 @@ msgstr "Nouvelle proposition pour {event} : {title}"
 msgid "Deadline"
 msgstr "Date butoir"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr "L'étiquette a été sauvegardée."
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr "L'étiquette a été supprimée."
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, fuzzy, python-brace-format
 #| msgid "New {event} proposal: {title}"
 msgid "Changed {count} proposal states."
@@ -7728,7 +7780,7 @@ msgstr ""
 "personnes une fois la proposition créée."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr "Si vous souhaitez utiliser une image pour illustrer votre proposition."
 
@@ -8163,23 +8215,27 @@ msgstr ""
 "l'appel à participation, et est déverrouillée une fois la proposition "
 "acceptée."
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposal state"
 msgid "Pending proposal state"
 msgstr "Statut de la proposition"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 "Ces notes sont à l'intention de l'équipe d'organisation et ne seront pas "
 "rendues publiques."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "Notes internes"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -8187,7 +8243,7 @@ msgstr ""
 "Notes internes pour les organisateurs et les évaluateurs. Les intervenants "
 "et le public n'y ont pas accès."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -8195,37 +8251,42 @@ msgstr ""
 "La durée en minutes. Laisser vide pour utiliser la durée par défaut pour ce "
 "type de proposition."
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "Nombre de fois que votre intervention aura lieu."
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "Afficher cette proposition dans la liste publique des interventions."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "N'enregistrez pas cette intervention."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Active reviewers"
 msgid "Assigned reviewers"
 msgstr "Évaluateurs actif"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " ou "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
 "La proposition doit être dans l'état {src_states}, pas {state}, pour passer "
 "dans l'état {new_state}."
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nouvelle proposition de session : {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -8290,6 +8351,17 @@ msgstr "{name} ({duration} heures)"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} minutes)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "proposals are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "proposition est en attente de votre évaluation."
+
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "intervention non confirmée"
+#~ msgstr[1] "interventions non confirmées"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "Votre recherche n'a retourné aucun intervenant."
 
@@ -8339,9 +8411,6 @@ msgstr "{name} ({duration} minutes)"
 
 #~ msgid "Compose mail"
 #~ msgstr "Composer des couriels"
-
-#~ msgid "Current draft"
-#~ msgstr "Brouillon actuel"
 
 #~ msgid "Show"
 #~ msgstr "Afficher"

--- a/src/pretalx/locale/it/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/it/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2022-09-04 14:27+0000\n"
 "Last-Translator: Luca Delucchi <lucadeluge@gmail.com>\n"
 "Language-Team: none\n"
@@ -245,8 +245,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)sminuti"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "eliminato"
 
@@ -258,7 +258,7 @@ msgstr "La foto del profilo del relatore"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Linguaggio"
 
@@ -289,15 +289,15 @@ msgstr "Il nostro programma non è ancora disponibile."
 msgid "The session “{title}” at {event}"
 msgstr "La sessione “{title}” al {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Generale"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Ehi, piacere di conoscerti!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -305,7 +305,12 @@ msgstr ""
 "Siamo lieti che tu voglia contribuire al nostro evento con la tua proposta. "
 "Cominciamo, non ci vorrà molto tempo."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
@@ -315,32 +320,32 @@ msgstr ""
 "apportare modifiche fino alla scadenza della presentazione, e sarai avvisato "
 "di qualsiasi cambiamento o domanda."
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Domande"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Dicci di più!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr ""
 "Prima di poter salvare la sua proposta, abbiamo qualche altra domanda per te."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr ""
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 "Questo è tutto per la tua proposta! Ora abbiamo solo bisogno di un modo per "
 "contattarti."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -350,7 +355,7 @@ msgstr ""
 "Questo non solo ci dà modo di contattarti, ma ti dà anche la possibilità di "
 "modificare la tua proposta o di vedere il suo stato attuale."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -358,15 +363,15 @@ msgstr ""
 "Si è verificato un errore durante il login. Si prega di contattare "
 "l'organizzatore per ulteriore aiuto."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Profilo"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Dicci qualcosa su di te!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -397,13 +402,13 @@ msgid "Text"
 msgstr "Testo"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} ti invita a partecipare alla sua sessione!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -563,36 +568,43 @@ msgid "Proposals are closed"
 msgstr "Le proposte sono chiuse"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "inviata"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Inviare review"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "non accettata"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "accettata"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "confermata"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "cancellata"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "eliminata"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Vai alla CfP"
 
@@ -617,7 +629,7 @@ msgstr "Abstract:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "No"
 
@@ -702,7 +714,18 @@ msgstr "Continua"
 msgid "Submit proposal!"
 msgstr "Invia proposta!"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -764,7 +787,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -839,7 +862,7 @@ msgid "Your proposal:"
 msgstr "La tua proposta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -847,7 +870,7 @@ msgstr "Lo stato corrente della tua proposta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Tipologia di sessione"
 
@@ -858,7 +881,7 @@ msgstr "Tipologia di sessione"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr ""
 
@@ -893,13 +916,13 @@ msgid "Go back"
 msgstr "Torna indietro"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Ritira"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Conferma"
 
@@ -917,27 +940,33 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Your proposal:"
+msgid "Your draft:"
+msgstr "La tua proposta:"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Conferma la tua presenza"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Commenti del pubblico"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr ""
 "I partecipanti possono lasciare un feedback qui dopo lo svolgimento della "
 "tua sessione."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Relatore:"
 msgstr[1] "Relatori:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitted"
 msgid "Submitter:"
@@ -945,13 +974,13 @@ msgid_plural "Submitters:"
 msgstr[0] "inviata"
 msgstr[1] "inviata"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Risorse"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -959,21 +988,33 @@ msgstr ""
 "Le risorse saranno visibili pubblicamente. Per favore cerca di mantenere i "
 "tuoi upload al di sotto dei 16MB."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Aggiungi un'altra risorsa"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Save this!"
+msgid "Save draft"
+msgstr "Salva questo!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "Submit proposal"
+msgstr "Invia proposta!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Condividi la proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -981,12 +1022,12 @@ msgstr ""
 "Se hai bisogno di una revisione da parte di un collega o un amico ecco un "
 "link che puoi inviare per visualizzare la tua proposta:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Ritira la proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -996,11 +1037,11 @@ msgstr ""
 "annullare questa operazione - se non sei sicuro di poter o dover tenere la "
 "tua sessione, contatta invece l'organizzatore."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Elimina proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1042,7 +1083,7 @@ msgid "You will not be able to revert this action."
 msgstr "Non sarà possibile tornare indietro dopo questa scelta."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "La tua proposta"
 
@@ -1050,7 +1091,14 @@ msgstr "La tua proposta"
 msgid "Important Information"
 msgstr "Informazioni importanti"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Your proposals"
+msgid "Your drafts"
+msgstr "La tua proposta"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1059,42 +1107,43 @@ msgstr "Informazioni importanti"
 msgid "Title"
 msgstr "Titolo"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Copia il codice per le revisioni"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Stato"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Copia il codice per le revisioni"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Commento"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Crea una nuova proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "Sembra che tu non abbia ancora inviato nulla a questo evento."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Se l'hai fatto, forse hai usato un account diverso? Controlla le tue e-mail!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Proponi qualcosa ora!"
 
@@ -1142,10 +1191,11 @@ msgid ""
 "any longer."
 msgstr ""
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nuova proposta: {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "La tua proposta è stata cancellata."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1868,7 +1918,7 @@ msgid "Imprint"
 msgstr ""
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr ""
 
@@ -2242,7 +2292,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr ""
 
@@ -2744,7 +2794,7 @@ msgstr ""
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr ""
 
@@ -3366,7 +3416,8 @@ msgstr[1] ""
 msgid "All proposals"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr ""
 
@@ -3378,7 +3429,7 @@ msgstr ""
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr ""
 
@@ -3560,7 +3611,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr ""
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -3826,7 +3877,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4214,14 +4265,14 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr ""
@@ -4236,7 +4287,7 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr ""
 
@@ -4246,12 +4297,12 @@ msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr ""
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr ""
 
@@ -4301,7 +4352,7 @@ msgstr ""
 msgid "Click here to change"
 msgstr ""
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr ""
 
@@ -4411,7 +4462,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] ""
@@ -4841,7 +4892,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] ""
@@ -4893,7 +4944,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr ""
 
@@ -5556,7 +5607,7 @@ msgid "Add a new note"
 msgstr ""
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] ""
@@ -6024,65 +6075,67 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit proposal!"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Invia proposta!"
+msgstr[1] "Invia proposta!"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "Copy code for review"
-msgid "proposals are waiting for your review."
-msgstr "Copia il codice per le revisioni"
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] ""
-msgstr[1] ""
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "confermata"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] ""
 msgstr[1] ""
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] ""
@@ -6531,15 +6584,15 @@ msgstr ""
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr ""
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -6866,7 +6919,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7246,59 +7299,68 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 msgid "Pending proposal state"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Send review"
 msgid "Assigned reviewers"
 msgstr "Inviare review"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr ""
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nuova proposta: {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -7353,6 +7415,11 @@ msgstr ""
 #, python-brace-format
 msgid "{name} ({duration} minutes)"
 msgstr ""
+
+#, fuzzy
+#~| msgid "Copy code for review"
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "Copia il codice per le revisioni"
 
 #~ msgid "No speaker matches your search."
 #~ msgstr "Nessun relatore corrisponde alla tua ricerca."

--- a/src/pretalx/locale/ja_JP/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/ja_JP/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2020-09-28 02:42+0000\n"
 "Last-Translator: Satoshi IIDA <nyampire@gmail.com>\n"
 "Language-Team: \n"
@@ -245,8 +245,8 @@ msgid "%(minutes)smin"
 msgstr ""
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "削除済"
 
@@ -258,7 +258,7 @@ msgstr "登壇者のプロフィール写真"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "言語"
 
@@ -291,15 +291,15 @@ msgstr "私たちのスケジュールはまだ公開されていません。"
 msgid "The session “{title}” at {event}"
 msgstr "講演 “{title}” at {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "一般"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "こんにちは、はじめまして！"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -307,38 +307,43 @@ msgstr ""
 "あなたの投稿でイベントに貢献したいと思っていただけて嬉しいです。さっそく始め"
 "てみましょう！それほど時間はかかりません。"
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "質問"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "もっと教えて下さい！"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "投稿を保存する前に、いくつか質問があります。"
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "アカウント"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 "あなたの提出物については以上です！私たちは今、あなたに連絡する方法を必要とし"
 "ています。"
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -348,7 +353,7 @@ msgstr ""
 "絡を取ることができるだけでなく、投稿を編集したり、現在の状態を確認したりする"
 "ことができます。"
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -356,15 +361,15 @@ msgstr ""
 "ログイン時にエラーが発生しました。お手数ですが、主催者にお問い合わせくださ"
 "い。"
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "プロフィール"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "あなたについて教えて下さい！"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -395,13 +400,13 @@ msgid "Text"
 msgstr "テキスト"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} があなたを講演に招待しています！"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -569,36 +574,43 @@ msgid "Proposals are closed"
 msgstr "提案期間は終了しました"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "提出済"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "レビューを送る"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "受理されませんでした"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "受理されました"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "確定済"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "キャンセル済"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "取り下げ"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "提案ページへ"
 
@@ -623,7 +635,7 @@ msgstr "概要: "
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "いいえ"
 
@@ -710,7 +722,18 @@ msgstr "続ける"
 msgid "Submit proposal!"
 msgstr "提案を送信する"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -771,7 +794,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -846,7 +869,7 @@ msgid "Your proposal:"
 msgstr "あなたの提案: "
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -854,7 +877,7 @@ msgstr "あなたの提案の現在の状況"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "提案のタイプ"
 
@@ -865,7 +888,7 @@ msgstr "提案のタイプ"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "トラック"
 
@@ -902,13 +925,13 @@ msgid "Go back"
 msgstr "戻る"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "撤回する"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "確認"
 
@@ -926,25 +949,31 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "現状のドラフト"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "あなたの出席を確認"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "参加者の感想"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr "あなたの講演実施後、参加者がここに感想を残すことができます"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "登壇者: "
 msgstr[1] "Vortragende:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "Submitters"
 msgid "Submitter:"
@@ -952,33 +981,45 @@ msgid_plural "Submitters:"
 msgstr[0] "投稿者"
 msgstr[1] "投稿者"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "参考資料"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
 msgstr "参考資料は一般に公開されます。サイズは16MB以下に保ってください。"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "他の参考資料を追加する"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "保存しました！"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "提案を送信する"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "提案をシェアする"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -986,12 +1027,12 @@ msgstr ""
 "もし同僚や友人からのレビューが必要な場合は、このリンクを送ることで提案内容を"
 "確認してもらうことができます。"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "提案を撤回する"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1001,11 +1042,11 @@ msgstr ""
 "ができません。撤回しても良いかどうか確かでない場合は主催者に連絡してくださ"
 "い。"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "提案をキャンセルする"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1047,7 +1088,7 @@ msgid "You will not be able to revert this action."
 msgstr "この動作は取り消しが"
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "あなたの提案: "
 
@@ -1055,7 +1096,14 @@ msgstr "あなたの提案: "
 msgid "Important Information"
 msgstr "重要な情報"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "現状のドラフト"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1064,37 +1112,38 @@ msgstr "重要な情報"
 msgid "Title"
 msgstr "タイトル"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "コードのコピーまたはレビュー"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "状態"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "コードのコピーまたはレビュー"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "感想"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "新しい提案を作る"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "まだあなたはこのイベントに対して提案を行っていないようです。"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "もしそうだとしたら、もしかして違うアカウントを使っていませんか？メールを"
 "チェックしてみてください"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
@@ -1102,7 +1151,7 @@ msgstr ""
 "そうでない方は、プロポーザルを作成してみてはいかがでしょうか？あなたのご意見"
 "をお待ちしております。"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "何か提案しましょう！"
 
@@ -1151,10 +1200,11 @@ msgid ""
 msgstr ""
 "APIトークンが再生成されました。以前のトークンはもう使うことができません。"
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr ""
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "あなたの投稿は取り下げられました。"
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1980,7 +2030,7 @@ msgid "Imprint"
 msgstr "免責事項"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "履歴"
 
@@ -2416,7 +2466,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "はい"
 
@@ -3061,7 +3111,7 @@ msgstr "あなたのアバター"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "スロット数"
 
@@ -3769,7 +3819,8 @@ msgstr[1] "投稿"
 msgid "All proposals"
 msgstr "私の提案"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "リジェクト済"
 
@@ -3783,7 +3834,7 @@ msgstr "提案"
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "投稿タイトル"
 
@@ -4005,7 +4056,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "公表すべき登壇者名。"
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "投稿の状態"
 
@@ -4286,7 +4337,7 @@ msgstr "アクセスコード"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr ""
 
@@ -4710,14 +4761,14 @@ msgstr "最大長"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "概要"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "詳細"
@@ -4734,7 +4785,7 @@ msgstr "空き時間"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "備考"
 
@@ -4744,12 +4795,12 @@ msgstr "録画の許可"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "講演イメージ"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "時間"
 
@@ -4804,7 +4855,7 @@ msgstr "未公開"
 msgid "Click here to change"
 msgstr "こちらをクリックして変更"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "全ての履歴"
 
@@ -4930,7 +4981,7 @@ msgstr "あなたの近日公開イベント"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 #, fuzzy
 #| msgid "proposal"
 #| msgid_plural "submissions"
@@ -5392,7 +5443,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 #, fuzzy
 #| msgid "proposal is waiting for your review."
 #| msgid_plural "submissions are waiting for your review."
@@ -5451,7 +5502,7 @@ msgstr "あなたのスコア"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "レビュー"
 
@@ -6231,7 +6282,7 @@ msgid "Add a new note"
 msgstr "ノートを新規追加"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "投稿者"
@@ -6734,48 +6785,49 @@ msgstr ""
 "このアクセスコードは投稿に利用され、削除できません。コードを無効化するには過"
 "去の日付を入力してください。"
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "CfP終了まで"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "提案を送信する"
+msgstr[1] "提案を送信する"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr "活動中のレビュアー"
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "submissions are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "投稿は審査待ちです。"
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "イベント開始まで"
 msgstr[1] "イベント開始まで"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] "イベント終了から"
 msgstr[1] "イベント終了から"
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "{number} 日"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "全 {total_days} 日"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "現在のスケジュール"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 #, fuzzy
 #| msgid "session"
 #| msgid_plural "talks"
@@ -6784,22 +6836,19 @@ msgid_plural "sessions"
 msgstr[0] "講演"
 msgstr[1] "講演"
 
-#: pretalx/orga/views/dashboard.py:270
+#: pretalx/orga/views/dashboard.py:288
 #, fuzzy
-#| msgid "unconfirmed session"
-#| msgid_plural "unconfirmed talks"
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "未確認の講演"
-msgstr[1] "未確認の講演"
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "確定済"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "講演者"
 msgstr[1] "講演者"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "送信済みメール"
@@ -7292,19 +7341,19 @@ msgstr "新しいイベント {event} への投稿: {title}"
 msgid "Deadline"
 msgstr "締め切り"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 #, fuzzy
 #| msgid "The track has been saved."
 msgid "The tag has been saved."
 msgstr "トラックが保存されました。"
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 #, fuzzy
 #| msgid "The track has been deleted."
 msgid "The tag has been deleted."
 msgstr "トラックが削除されました。"
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, fuzzy, python-brace-format
 #| msgid "New {event} proposal: {title}"
 msgid "Changed {count} proposal states."
@@ -7682,7 +7731,7 @@ msgstr ""
 "投稿プロセスが完了した後に追加することができます。"
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr "投稿にイラストを添付する場合、こちらを利用ください。"
 
@@ -8110,21 +8159,25 @@ msgstr ""
 "通常、CfPの終了後は投稿の修正がロックされ、投稿がアクセプトされると再び有効と"
 "なります。"
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposal state"
 msgid "Pending proposal state"
 msgstr "投稿の状態"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr "これらのノートは主催者のみが対象となっており、一般公開されません。"
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "内部ノート"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -8132,7 +8185,7 @@ msgstr ""
 "他の主催者/レビュアーに対する内部メモ。講演者からは閲覧できませんし、公開もさ"
 "れません。"
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -8140,39 +8193,44 @@ msgstr ""
 "待ち時間（分）。この投稿タイプには標準の待ち時間を適用する場合、空欄にしてお"
 "いてください。"
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "この講演が何回行われるか"
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 #, fuzzy
 #| msgid "Show this submission in the list of featured talks."
 msgid "Show this session in public list of featured sessions."
 msgstr "この投稿を特別講演の一覧に表示します。"
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "動画や録音など記録を希望しません。"
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Active reviewers"
 msgid "Assigned reviewers"
 msgstr "活動中のレビュアー"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " あるいは "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr ""
 "投稿は {state} ではなく {src_states} から {new_state} として記載する必要があ"
 "ります。"
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr ""
 
 #: pretalx/submission/models/tag.py:31
 #, fuzzy
@@ -8234,6 +8292,20 @@ msgstr "{name} ({duration} 時間)"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} 分)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "submissions are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "投稿は審査待ちです。"
+
+#, fuzzy
+#~| msgid "unconfirmed session"
+#~| msgid_plural "unconfirmed talks"
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "未確認の講演"
+#~ msgstr[1] "未確認の講演"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "条件に合う登壇者はいませんでした。"
 
@@ -8285,9 +8357,6 @@ msgstr "{name} ({duration} 分)"
 
 #~ msgid "Compose mail"
 #~ msgstr "メール作成"
-
-#~ msgid "Current draft"
-#~ msgstr "現状のドラフト"
 
 #~ msgid "Show"
 #~ msgstr "表示"

--- a/src/pretalx/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/pt_BR/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2021-09-22 18:56+0000\n"
 "Last-Translator: Alberto Leoncio <albertoleoncio@hotmail.com>\n"
 "Language-Team: none\n"
@@ -244,8 +244,8 @@ msgid "%(minutes)smin"
 msgstr "%(minutes)smin"
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "deletado"
 
@@ -257,7 +257,7 @@ msgstr "A foto de perfil do palestrante"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "Idioma"
 
@@ -288,15 +288,15 @@ msgstr "Nosso cronograma ainda não está no ar."
 msgid "The session “{title}” at {event}"
 msgstr "A sessão “{title}” no {event}"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "Geral"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "Ei, prazer em conhecer você!"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
@@ -304,37 +304,42 @@ msgstr ""
 "Estamos felizes que você queira contribuir para o nosso evento com sua "
 "proposta. Vamos começar, isso não vai ser demorado."
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "Perguntas"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "Conte-nos mais!"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "Antes de salvar sua proposta, temos mais algumas perguntas pra você."
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "Conta"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr ""
 "Isso é sobre a sua proposta! Agora precisamos de uma forma de contactar você."
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -344,7 +349,7 @@ msgstr ""
 "apenas nos permite te contactar, mas também te possibilita editar sua "
 "proposta ou visualizar seu estado atual."
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
@@ -352,15 +357,15 @@ msgstr ""
 "Houve um erro ao fazer login. Por favor entre em contato com o organizar "
 "para obter ajuda."
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 msgid "Profile"
 msgstr "Perfil"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "Conte-nos algo sobre você!"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -391,13 +396,13 @@ msgid "Text"
 msgstr "Texto"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} convida você a participar da sua sessão!"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -569,36 +574,43 @@ msgid "Proposals are closed"
 msgstr "Propostas estão encerradas"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "enviado"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "Enviar revisão"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "não aceito"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "aceito"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "confirmado"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "cancelado"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "retirado"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "Vá para a chamada de trabalhos"
 
@@ -623,7 +635,7 @@ msgstr "Resumo:"
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "Não"
 
@@ -711,7 +723,18 @@ msgstr "Continuar"
 msgid "Submit proposal!"
 msgstr "Submeta uma proposta"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -773,7 +796,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -848,7 +871,7 @@ msgid "Your proposal:"
 msgstr "Sua proposta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -856,7 +879,7 @@ msgstr "Estado atual da sua proposta:"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "Tipo de sessão"
 
@@ -867,7 +890,7 @@ msgstr "Tipo de sessão"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "Tema"
 
@@ -901,13 +924,13 @@ msgid "Go back"
 msgstr "Volte"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "Retirar"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "Confirmar"
 
@@ -925,25 +948,31 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "Rascunho atual"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "Confirme sua participação"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "Feedback do público"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr "Os participantes podem deixar comentários aqui após o fim da sessão."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "Palestrante:"
 msgstr[1] "Palestrantes:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitter"
 #| msgid_plural "submitters"
@@ -952,13 +981,13 @@ msgid_plural "Submitters:"
 msgstr[0] "remetente"
 msgstr[1] "remetentes"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "Recursos"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
@@ -966,21 +995,33 @@ msgstr ""
 "Os recursos estarão visíveis publicamente. Por favor tente manter seus "
 "uploads abaixo de 16 MB."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "Adicionar outro recurso"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "Salvo!"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "Submeta uma proposta"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "Compartilhe a proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
@@ -988,12 +1029,12 @@ msgstr ""
 "Se você precisar de uma revisão de um colega ou um amigo aqui está o link "
 "que você pode enviar para visualização da sua proposta:"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "Retirar proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -1003,11 +1044,11 @@ msgstr ""
 "desfazer essa ação. - se você está inseguro se pode ou deve manter sua "
 "seção, por favor primeiro contacte o organizador."
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "Cancelar proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1049,7 +1090,7 @@ msgid "You will not be able to revert this action."
 msgstr "Você não poderá reverter essa ação."
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "Suas propostas"
 
@@ -1057,7 +1098,14 @@ msgstr "Suas propostas"
 msgid "Important Information"
 msgstr "Informação importante"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "Rascunho atual"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1066,37 +1114,38 @@ msgstr "Informação importante"
 msgid "Title"
 msgstr "Título"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "Copie o código para revisão"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "Estado"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "Copie o código para revisão"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "Feedback"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "Criar uma nova proposta"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "Parece que você ainda não submeteu nada para esse evento."
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr ""
 "Se você submeteu, talvez tenha usado uma conta diferente? Confira seus "
 "emails!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
@@ -1104,7 +1153,7 @@ msgstr ""
 "Se você não submeteu, por que não ir em frente e criar uma proposta agora? "
 "Adoraríamos ouvir você!"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "Submeta algo agora!"
 
@@ -1153,10 +1202,11 @@ msgid ""
 msgstr ""
 "Seu token de API foi regenerado. O token anterior não pode mais ser usado."
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr "Nova proposta: {title}"
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "Sua proposta foi retirada."
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1985,7 +2035,7 @@ msgid "Imprint"
 msgstr "Impressão"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "História"
 
@@ -2413,7 +2463,7 @@ msgstr "Talvezz"
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "Sim"
 
@@ -3011,7 +3061,7 @@ msgstr ""
 "Permitir que os palestrantes incluam automaticamente sua imagem de perfil do "
 "gravatar."
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "Contagem de espaços"
 
@@ -3711,7 +3761,8 @@ msgstr[1] "Propostas"
 msgid "All proposals"
 msgstr "Todas as propostas"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr "rejeitado"
 
@@ -3726,7 +3777,7 @@ msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 "O ID exclusivo de uma proposta é usado no URL da proposta e nas exportações"
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr "Título proposto"
 
@@ -3919,7 +3970,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "Nome do palestrante que deve ser exibido publicamente."
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr "Estado da proposta"
 
@@ -4202,7 +4253,7 @@ msgstr "Códigos de acesso"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "Tags"
 
@@ -4638,14 +4689,14 @@ msgstr "Tamanho máximo"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "Resumo"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "Descrição"
@@ -4662,7 +4713,7 @@ msgstr "Disponibilidade"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "Notas"
 
@@ -4672,12 +4723,12 @@ msgstr "Exclusão da gravação"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "Imagem da sessão"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "Duração"
 
@@ -4734,7 +4785,7 @@ msgstr "não ao vivo"
 msgid "Click here to change"
 msgstr "Clique aqui para alterar"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "Full history"
 msgstr "Histórico completo"
 
@@ -4859,7 +4910,7 @@ msgstr "Seus próximos eventos"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 msgid "proposal"
 msgid_plural "proposals"
 msgstr[0] "Proposta"
@@ -5318,7 +5369,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 msgid "proposal is waiting for your review."
 msgid_plural "proposals are waiting for your review."
 msgstr[0] "proposta está aguardando pela sua revisão."
@@ -5370,7 +5421,7 @@ msgstr "Sua nota"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "Revisões"
 
@@ -6139,7 +6190,7 @@ msgid "Add a new note"
 msgstr "Adicionar uma nova nota"
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "remetente"
@@ -6636,66 +6687,67 @@ msgstr ""
 "Este código de acesso foi usado para uma proposta e não pode ser excluído. "
 "Para desativá-lo, você pode definir sua data de validade para o passado."
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "até que o CfP termine"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "Submeta uma proposta"
+msgstr[1] "Submeta uma proposta"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr "Revisores ativos"
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "proposals are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "proposta está aguardando pela sua revisão."
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "dia até o início do evento"
 msgstr[1] "dias até o início do evento"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] "dia desde o final do evento"
 msgstr[1] "dias desde o final do evento"
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "Dia {number}"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "de {total_days} dias"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "programação atual"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 msgid "session"
 msgid_plural "sessions"
 msgstr[0] "sessão"
 msgstr[1] "sessões"
 
-#: pretalx/orga/views/dashboard.py:270
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "sessão não confirmada"
-msgstr[1] "sessões não confirmadas"
+#: pretalx/orga/views/dashboard.py:288
+#, fuzzy
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "confirmado"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "palestrante"
 msgstr[1] "palestrantes"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "e-mail enviado"
@@ -7189,15 +7241,15 @@ msgstr "Nova proposta de {event}: {title}"
 msgid "Deadline"
 msgstr "Prazo final"
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 msgid "The tag has been saved."
 msgstr "A tag foi salva."
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 msgid "The tag has been deleted."
 msgstr "A tag foi excluída."
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, fuzzy, python-brace-format
 #| msgid "New {event} proposal: {title}"
 msgid "Changed {count} proposal states."
@@ -7570,7 +7622,7 @@ msgstr ""
 "poderá adicionar mais palestrantes após concluir o processo de proposta."
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr "Use-o se quiser uma ilustração para acompanhar a sua proposta."
 
@@ -7999,21 +8051,25 @@ msgstr ""
 "Por padrão, a modificação de propostas é bloqueada após o término do CfP e "
 "reativada quando a proposta é aceita."
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposal state"
 msgid "Pending proposal state"
 msgstr "Estado da proposta"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr "Essas notas são destinadas ao organizador e não serão publicadas."
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr "Notas internas"
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
@@ -8021,7 +8077,7 @@ msgstr ""
 "Notas internas para outros organizadores/revisores. Não visível para os "
 "palestrantes ou o público."
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
@@ -8029,35 +8085,40 @@ msgstr ""
 "A duração em minutos. Deixe em branco para a duração padrão para este tipo "
 "de sessão."
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr "Quantas vezes essa sessão ocorrerá."
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 msgid "Show this session in public list of featured sessions."
 msgstr "Mostre esta sessão na lista pública de sessões em destaque."
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr "Não grave esta sessão."
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Active reviewers"
 msgid "Assigned reviewers"
 msgstr "Revisores ativos"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr " ou "
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
 msgstr "A proposta deve ser {src_states} e não {state} para ser {new_state}."
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
+msgstr "Nova proposta: {title}"
 
 #: pretalx/submission/models/tag.py:31
 msgid "Show tag publicly"
@@ -8121,6 +8182,17 @@ msgstr "{name} ({duration} horas)"
 msgid "{name} ({duration} minutes)"
 msgstr "{name} ({duration} minutos)"
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "proposals are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "proposta está aguardando pela sua revisão."
+
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "sessão não confirmada"
+#~ msgstr[1] "sessões não confirmadas"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "Nenhum palestrante corresponde à sua pesquisa."
 
@@ -8164,9 +8236,6 @@ msgstr "{name} ({duration} minutos)"
 
 #~ msgid "Compose mail"
 #~ msgstr "Escrever e-mail"
-
-#~ msgid "Current draft"
-#~ msgstr "Rascunho atual"
 
 #~ msgid "Show"
 #~ msgstr "Mostrar"

--- a/src/pretalx/locale/zh_TW/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/zh_TW/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-29 23:38+0000\n"
+"POT-Creation-Date: 2022-10-31 00:08+0000\n"
 "PO-Revision-Date: 2020-01-29 12:01+0000\n"
 "Last-Translator: Franklin Weng <franklin@goodhorse.idv.tw>\n"
 "Language-Team: none\n"
@@ -239,8 +239,8 @@ msgid "%(minutes)smin"
 msgstr ""
 
 #: pretalx/agenda/templates/agenda/session_block.html:27
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
-#: pretalx/submission/models/submission.py:54
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:17
+#: pretalx/submission/models/submission.py:55
 msgid "deleted"
 msgstr "已刪除"
 
@@ -252,7 +252,7 @@ msgstr "講者的頭像"
 #: pretalx/agenda/templates/agenda/talk.html:50
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:18
 #: pretalx/orga/templates/orga/cfp/text.html:92
-#: pretalx/submission/models/submission.py:202
+#: pretalx/submission/models/submission.py:210
 msgid "Language"
 msgstr "語言"
 
@@ -285,50 +285,55 @@ msgstr ""
 msgid "The session “{title}” at {event}"
 msgstr "{event}的議程：「{title}」"
 
-#: pretalx/cfp/flow.py:298 pretalx/orga/templates/orga/base.html:198
+#: pretalx/cfp/flow.py:303 pretalx/orga/templates/orga/base.html:198
 msgid "General"
 msgstr "一般"
 
-#: pretalx/cfp/flow.py:302
+#: pretalx/cfp/flow.py:307
 msgid "Hey, nice to meet you!"
 msgstr "嗨，很高興見到您！"
 
-#: pretalx/cfp/flow.py:307
+#: pretalx/cfp/flow.py:312
 msgid ""
 "We're glad that you want to contribute to our event with your proposal. "
 "Let's get started, this won't take long."
 msgstr "我們很高興看到您想投稿我們的活動。讓我們開始吧，不用很久！"
 
-#: pretalx/cfp/flow.py:338
+#: pretalx/cfp/flow.py:345
+msgid ""
+"Your draft was saved. You can continue to edit it as long as the CfP is open."
+msgstr ""
+
+#: pretalx/cfp/flow.py:353
 msgid ""
 "Congratulations, you've submitted your proposal! You can continue to make "
 "changes to it up to the submission deadline, and you will be notified of any "
 "changes or questions."
 msgstr ""
 
-#: pretalx/cfp/flow.py:370 pretalx/orga/forms/cfp.py:483
+#: pretalx/cfp/flow.py:387 pretalx/orga/forms/cfp.py:483
 #: pretalx/orga/templates/orga/base.html:242
 #: pretalx/orga/templates/orga/submission/content.html:144
 msgid "Questions"
 msgstr "問題"
 
-#: pretalx/cfp/flow.py:374
+#: pretalx/cfp/flow.py:391
 msgid "Tell us more!"
 msgstr "給我們多一點資訊！"
 
-#: pretalx/cfp/flow.py:379
+#: pretalx/cfp/flow.py:396
 msgid "Before we can save your proposal, we have some more questions for you."
 msgstr "在我們儲存您的提交之前，我們還有些問題想請問您。"
 
-#: pretalx/cfp/flow.py:434
+#: pretalx/cfp/flow.py:451
 msgid "Account"
 msgstr "帳號"
 
-#: pretalx/cfp/flow.py:439
+#: pretalx/cfp/flow.py:456
 msgid "That's it about your proposal! We now just need a way to contact you."
 msgstr "就這樣！現在我們需要知道怎麼跟您聯繫。"
 
-#: pretalx/cfp/flow.py:445
+#: pretalx/cfp/flow.py:462
 msgid ""
 "To create your proposal, you need an account on this page. This not only "
 "gives us a way to contact you, it also gives you the possibility to edit "
@@ -337,23 +342,23 @@ msgstr ""
 "要投稿議程，您需要有一個帳號。註冊帳號的目的不只是讓我們方便聯繫您，也讓您可"
 "以編輯您提交的內容，或查看目前的狀態。"
 
-#: pretalx/cfp/flow.py:461
+#: pretalx/cfp/flow.py:478
 msgid ""
 "There was an error when logging in. Please contact the organiser for further "
 "help."
 msgstr "登入時發生了錯誤。請聯繫主辦者以尋求協助。"
 
-#: pretalx/cfp/flow.py:478
+#: pretalx/cfp/flow.py:495
 #, fuzzy
 #| msgid "Your Profile"
 msgid "Profile"
 msgstr "您的個人資料"
 
-#: pretalx/cfp/flow.py:482
+#: pretalx/cfp/flow.py:499
 msgid "Tell us something about yourself!"
 msgstr "多告訴我們一些關於您自己的事吧！"
 
-#: pretalx/cfp/flow.py:487
+#: pretalx/cfp/flow.py:504
 msgid ""
 "This information will be publicly displayed next to your session - you can "
 "always edit for as long as proposals are still open."
@@ -383,13 +388,13 @@ msgid "Text"
 msgstr "文字"
 
 #: pretalx/cfp/forms/submissions.py:13
-#: pretalx/submission/models/submission.py:819
+#: pretalx/submission/models/submission.py:872
 #, python-brace-format
 msgid "{speaker} invites you to join their session!"
 msgstr "{speaker} 邀請您參加他們的議程！"
 
 #: pretalx/cfp/forms/submissions.py:18
-#: pretalx/submission/models/submission.py:826
+#: pretalx/submission/models/submission.py:879
 #, python-brace-format
 msgid ""
 "Hi!\n"
@@ -554,36 +559,43 @@ msgid "Proposals are closed"
 msgstr "議程投稿階段已關閉"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:3
-#: pretalx/submission/models/submission.py:48
+#: pretalx/orga/views/dashboard.py:294 pretalx/orga/views/dashboard.py:325
+#: pretalx/submission/models/submission.py:49
 msgid "submitted"
 msgstr "已提交"
 
 #: pretalx/cfp/templates/cfp/event/fragment_state.html:5
+#, fuzzy
+#| msgid "Send review"
+msgid "in review"
+msgstr "傳送檢閱意見"
+
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
 msgid "not accepted"
 msgstr "未接受"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:7
-#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:49
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
+#: pretalx/orga/forms/review.py:209 pretalx/submission/models/submission.py:50
 msgid "accepted"
 msgstr "已接受"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:9
-#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:50
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
+#: pretalx/orga/forms/review.py:210 pretalx/submission/models/submission.py:51
 msgid "confirmed"
 msgstr "已確認"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:11
-#: pretalx/submission/models/submission.py:52
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
+#: pretalx/submission/models/submission.py:53
 msgid "canceled"
 msgstr "已取消"
 
-#: pretalx/cfp/templates/cfp/event/fragment_state.html:13
-#: pretalx/submission/models/submission.py:53
+#: pretalx/cfp/templates/cfp/event/fragment_state.html:15
+#: pretalx/submission/models/submission.py:54
 msgid "withdrawn"
 msgstr "已退回"
 
 #: pretalx/cfp/templates/cfp/event/index.html:31
-#: pretalx/orga/views/dashboard.py:134
+#: pretalx/orga/views/dashboard.py:131
 msgid "Go to CfP"
 msgstr "前往「徵求議程投稿」頁面"
 
@@ -607,7 +619,7 @@ msgstr "摘要："
 #: pretalx/cfp/templates/cfp/event/invitation.html:30
 #: pretalx/event/models/event.py:605 pretalx/orga/forms/review.py:336
 #: pretalx/submission/models/question.py:416
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "No"
 msgstr "不要"
 
@@ -691,7 +703,18 @@ msgstr "繼續"
 msgid "Submit proposal!"
 msgstr "提交一份議程投稿"
 
-#: pretalx/cfp/templates/cfp/event/submission_base.html:54
+#: pretalx/cfp/templates/cfp/event/submission_base.html:51
+msgid "or save as draft for now"
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:52
+msgid ""
+"You can save your proposal as a draft and submit it later. Organisers will "
+"not be able to see your proposal, though they will be able to send you "
+"reminder emails about the upcoming deadline."
+msgstr ""
+
+#: pretalx/cfp/templates/cfp/event/submission_base.html:58
 #: pretalx/orga/templates/orga/cfp/access_code_delete.html:11
 #: pretalx/orga/templates/orga/cfp/question_delete.html:11
 #: pretalx/orga/templates/orga/cfp/submission_type_delete.html:11
@@ -750,7 +773,7 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_profile.html:47
 #: pretalx/cfp/templates/cfp/event/user_profile.html:61
 #: pretalx/cfp/templates/cfp/event/user_profile.html:82
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:169
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:182
 #: pretalx/common/phrases.py:44
 #: pretalx/orga/templates/orga/cfp/access_code_form.html:53
 #: pretalx/orga/templates/orga/mails/outbox_form.html:109
@@ -824,7 +847,7 @@ msgid "Your proposal:"
 msgstr "您的投稿："
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:13
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:35
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:36
 #: pretalx/cfp/templates/cfp/event/user_submission_invitation.html:14
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:9
 msgid "Current state of your proposal:"
@@ -832,7 +855,7 @@ msgstr "您的議程投稿目前的狀態："
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:16
 #: pretalx/orga/templates/orga/cfp/submission_type_view.html:17
-#: pretalx/submission/models/submission.py:127
+#: pretalx/submission/models/submission.py:135
 msgid "Session type"
 msgstr "提交型態"
 
@@ -843,7 +866,7 @@ msgstr "提交型態"
 #: pretalx/orga/templates/orga/cfp/track_view.html:17
 #: pretalx/orga/templates/orga/submission/review.html:63
 #: pretalx/submission/models/access_code.py:26
-#: pretalx/submission/models/submission.py:133
+#: pretalx/submission/models/submission.py:141
 msgid "Track"
 msgstr "議程軌"
 
@@ -878,13 +901,13 @@ msgid "Go back"
 msgstr "返回"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:56
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:194
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:208
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:23
 msgid "Withdraw"
 msgstr "撤回"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:62
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:73
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:112
 msgid "Confirm"
 msgstr "確認"
 
@@ -902,24 +925,30 @@ msgid ""
 "different account, or contact the event organisers for further information."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:39
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:24
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your draft:"
+msgstr "目前的草稿"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:41
 msgid "Confirm your attendance"
 msgstr "確認您可以參加"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:44
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
 msgid "Audience feedback"
 msgstr "聽眾的回饋"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:46
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:48
 msgid "Attendees can leave feedback here after your session has taken place."
 msgstr "參加者在您的演講結束後可以在此留下回饋意見。"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:55
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:57
 msgid "Speaker:"
 msgid_plural "Speakers:"
 msgstr[0] "講者："
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:61
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:63
 #, fuzzy
 #| msgid "submitter"
 #| msgid_plural "submitters"
@@ -927,44 +956,56 @@ msgid "Submitter:"
 msgid_plural "Submitters:"
 msgstr[0] "名提交者"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:90
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:92
 #: pretalx/orga/forms/schedule.py:116
 #: pretalx/orga/templates/orga/submission/content.html:80
 msgid "Resources"
 msgstr "資源"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:94
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:96
 msgid ""
 "Resources will be publicly visible. Please try to keep your uploads below "
 "16MB."
 msgstr "資源將可以公開檢視。請盡量將您上傳的資源保持在 16MB 以下。"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:145
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:147
 #: pretalx/orga/templates/orga/submission/content.html:130
 msgid "You can either provide a URL or upload a file."
 msgstr ""
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:159
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:161
 #: pretalx/orga/templates/orga/submission/content.html:137
 msgid "Add another resource"
 msgstr "新增其他資源"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:175
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:173
+#, fuzzy
+#| msgid "Saved!"
+msgid "Save draft"
+msgstr "已儲存！"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:176
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "Submit proposal"
+msgstr "提交一份議程投稿"
+
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:189
 msgid "Share proposal"
 msgstr "分享議程投稿"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:177
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:191
 msgid ""
 "If you need a review from a colleague or a friend here's a link that you can "
 "send out for viewing your proposal:"
 msgstr "如果您需要朋友或同事幫您檢閱，您可以將此連結傳送給他們："
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:183
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:197
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:14
 msgid "Withdraw proposal"
 msgstr "撤回投稿"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:185
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
 msgid ""
 "You can withdraw your proposal from the selection process here. You cannot "
 "undo this - if you are just uncertain if you can or should hold your "
@@ -973,11 +1014,11 @@ msgstr ""
 "您可以依照這裡的流程撤回您的投稿。但請留意，您撤回了就無法再恢復—如果您只是不"
 "確定是否可以或需要保留您的投稿，請先跟主辦單位聯繫。"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:199
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:213
 msgid "Cancel proposal"
 msgstr "取消投稿"
 
-#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:201
+#: pretalx/cfp/templates/cfp/event/user_submission_edit.html:215
 msgid ""
 "As your proposal has been accepted already, please contact the event's "
 "organising team to cancel it. The best way to reach out would be an answer "
@@ -1017,7 +1058,7 @@ msgid "You will not be able to revert this action."
 msgstr "這個動作是不可挽回的。"
 
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:9
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:24
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:63
 msgid "Your proposals"
 msgstr "您的議程投稿"
 
@@ -1025,7 +1066,14 @@ msgstr "您的議程投稿"
 msgid "Important Information"
 msgstr "重要資訊"
 
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:25
+#, fuzzy
+#| msgid "Current draft"
+msgid "Your drafts"
+msgstr "目前的草稿"
+
 #: pretalx/cfp/templates/cfp/event/user_submissions.html:30
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:69
 #: pretalx/orga/templates/orga/cfp/text.html:67
 #: pretalx/orga/templates/orga/review/dashboard.html:124
 #: pretalx/orga/templates/orga/speaker/information_list.html:23
@@ -1034,41 +1082,42 @@ msgstr "重要資訊"
 msgid "Title"
 msgstr "標題"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:31
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:48
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+msgid "Copy code for review"
+msgstr "複製檢閱代碼"
+
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:70
 #: pretalx/orga/templates/orga/review/dashboard.html:128
 #: pretalx/orga/templates/orga/submission/list.html:96
 msgid "State"
 msgstr "狀態"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:62
-msgid "Copy code for review"
-msgstr "複製檢閱代碼"
-
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:79
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:118
 #: pretalx/orga/templates/orga/base.html:282
 #: pretalx/orga/templates/orga/submission/base.html:63
 msgid "Feedback"
 msgstr "回饋"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:92
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:131
 msgid "Create a new proposal"
 msgstr "建立新的議程投稿"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:98
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:137
 msgid "It seems like you haven't submitted anything to this event yet."
 msgstr "您似乎還沒提交任何議程投稿給此活動。"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:101
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:140
 msgid "If you did, maybe you used a different account? Check your emails!"
 msgstr "若您有提交過，可能您是用另一個帳號？請檢查看看您的電子郵件！"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:105
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:144
 msgid ""
 "If you did not, why not go ahead and create a proposal now? We'd love to "
 "hear from you!"
 msgstr "如果您還沒投稿，為何不現在就來投呢？我們期待您的加入！"
 
-#: pretalx/cfp/templates/cfp/event/user_submissions.html:110
+#: pretalx/cfp/templates/cfp/event/user_submissions.html:149
 msgid "Submit something now!"
 msgstr "現在就投稿！"
 
@@ -1118,10 +1167,11 @@ msgid ""
 "any longer."
 msgstr "您的 API token 已重新產生。先前的 token 將無法再使用。"
 
-#: pretalx/cfp/views/wizard.py:98
-#, python-brace-format
-msgid "New proposal: {title}"
-msgstr ""
+#: pretalx/cfp/views/user.py:389
+#, fuzzy
+#| msgid "Your proposal has been withdrawn."
+msgid "Your proposal has been submitted."
+msgstr "您投稿的議程已被退回。"
 
 #: pretalx/common/context_processors.py:42
 msgid "“"
@@ -1930,7 +1980,7 @@ msgid "Imprint"
 msgstr "版本說明"
 
 #: pretalx/common/templates/common/logs.html:7
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 msgid "History"
 msgstr "歷史"
 
@@ -2355,7 +2405,7 @@ msgstr ""
 #: pretalx/orga/templates/orga/speaker/reset_password.html:16
 #: pretalx/orga/templates/orga/submission/tag_delete.html:15
 #: pretalx/submission/models/question.py:414
-#: pretalx/submission/models/submission.py:807
+#: pretalx/submission/models/submission.py:860
 msgid "Yes"
 msgstr "是"
 
@@ -2998,7 +3048,7 @@ msgstr "您的頭像"
 msgid "Allow speakers to automatically include their gravatar profile image."
 msgstr ""
 
-#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:194
+#: pretalx/orga/forms/cfp.py:37 pretalx/submission/models/submission.py:202
 msgid "Slot Count"
 msgstr "議程數"
 
@@ -3678,7 +3728,8 @@ msgstr[0] "份議程投稿"
 msgid "All proposals"
 msgstr "我提交的議程稿件"
 
-#: pretalx/orga/forms/review.py:211 pretalx/submission/models/submission.py:51
+#: pretalx/orga/forms/review.py:211 pretalx/orga/views/dashboard.py:320
+#: pretalx/submission/models/submission.py:52
 msgid "rejected"
 msgstr ""
 
@@ -3692,7 +3743,7 @@ msgstr "議程投稿"
 msgid "The unique ID of a proposal is used in the proposal URL and in exports"
 msgstr ""
 
-#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:122
+#: pretalx/orga/forms/review.py:224 pretalx/submission/models/submission.py:130
 msgid "Proposal title"
 msgstr ""
 
@@ -3911,7 +3962,7 @@ msgid "The name of the speaker that should be displayed publicly."
 msgstr "公開顯示的講者姓名。"
 
 #: pretalx/orga/forms/submission.py:81
-#: pretalx/submission/models/submission.py:146
+#: pretalx/submission/models/submission.py:154
 msgid "Proposal state"
 msgstr ""
 
@@ -4181,7 +4232,7 @@ msgstr "存取代碼"
 #: pretalx/orga/templates/orga/review/dashboard.html:127
 #: pretalx/orga/templates/orga/submission/tag_list.html:6
 #: pretalx/submission/forms/submission.py:270
-#: pretalx/submission/models/submission.py:140
+#: pretalx/submission/models/submission.py:148
 msgid "Tags"
 msgstr "標籤"
 
@@ -4580,14 +4631,14 @@ msgstr "最大長度"
 
 #: pretalx/orga/templates/orga/cfp/text.html:73
 #: pretalx/orga/templates/orga/submission/review.html:71
-#: pretalx/submission/models/submission.py:159
+#: pretalx/submission/models/submission.py:167
 msgid "Abstract"
 msgstr "摘要"
 
 #: pretalx/orga/templates/orga/cfp/text.html:79
 #: pretalx/orga/templates/orga/submission/review.html:79
 #: pretalx/schedule/models/room.py:33
-#: pretalx/submission/models/submission.py:165
+#: pretalx/submission/models/submission.py:173
 #: pretalx/submission/models/tag.py:19 pretalx/submission/models/track.py:28
 msgid "Description"
 msgstr "說明"
@@ -4604,7 +4655,7 @@ msgstr "可參加日期"
 
 #: pretalx/orga/templates/orga/cfp/text.html:123
 #: pretalx/orga/templates/orga/submission/review.html:87
-#: pretalx/submission/models/submission.py:171
+#: pretalx/submission/models/submission.py:179
 msgid "Notes"
 msgstr "備忘"
 
@@ -4614,12 +4665,12 @@ msgstr "拒絕錄影"
 
 #: pretalx/orga/templates/orga/cfp/text.html:135
 #: pretalx/submission/forms/submission.py:26
-#: pretalx/submission/models/submission.py:215
+#: pretalx/submission/models/submission.py:223
 msgid "Session image"
 msgstr "議程影像"
 
 #: pretalx/orga/templates/orga/cfp/text.html:141
-#: pretalx/submission/models/submission.py:187
+#: pretalx/submission/models/submission.py:195
 msgid "Duration"
 msgstr "時間長度"
 
@@ -4673,7 +4724,7 @@ msgstr "未上線"
 msgid "Click here to change"
 msgstr "點擊此處以變更"
 
-#: pretalx/orga/templates/orga/event/dashboard.html:82
+#: pretalx/orga/templates/orga/event/dashboard.html:101
 #, fuzzy
 #| msgid "History"
 msgid "Full history"
@@ -4790,7 +4841,7 @@ msgstr "正在進行的活動"
 #: pretalx/orga/templates/orga/event_list.html:60
 #: pretalx/orga/templates/orga/speaker/form.html:21
 #: pretalx/orga/templates/orga/submission/list.html:28
-#: pretalx/orga/views/dashboard.py:240
+#: pretalx/orga/views/dashboard.py:305
 #, fuzzy
 #| msgid "proposal"
 #| msgid_plural "submissions"
@@ -5235,7 +5286,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/orga/templates/orga/review/dashboard.html:26
-#: pretalx/orga/views/dashboard.py:170
+#: pretalx/orga/views/dashboard.py:199
 #, fuzzy
 #| msgid "proposal is waiting for your review."
 #| msgid_plural "submissions are waiting for your review."
@@ -5289,7 +5340,7 @@ msgstr "您的分數"
 #: pretalx/orga/templates/orga/review/dashboard.html:120
 #: pretalx/orga/templates/orga/submission/base.html:73
 #: pretalx/orga/templates/orga/submission/content.html:54
-#: pretalx/orga/views/dashboard.py:151
+#: pretalx/orga/views/dashboard.py:175
 msgid "Reviews"
 msgstr "檢閱"
 
@@ -6010,7 +6061,7 @@ msgid "Add a new note"
 msgstr ""
 
 #: pretalx/orga/templates/orga/speaker/list.html:10
-#: pretalx/orga/views/dashboard.py:248
+#: pretalx/orga/views/dashboard.py:335
 msgid "submitter"
 msgid_plural "submitters"
 msgstr[0] "名提交者"
@@ -6509,46 +6560,46 @@ msgid ""
 "disable it, you can set its validity date to the past."
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:130
+#: pretalx/orga/views/dashboard.py:140
 msgid "until the CfP ends"
 msgstr "後徵稿結束"
 
-#: pretalx/orga/views/dashboard.py:155
+#: pretalx/orga/views/dashboard.py:152
+#, fuzzy
+#| msgid "Submit a proposal"
+msgid "unsubmitted proposal draft"
+msgid_plural "unsubmitted proposal drafts"
+msgstr[0] "提交一份議程投稿"
+
+#: pretalx/orga/views/dashboard.py:180
 msgid "Active reviewers"
 msgstr ""
 
-#: pretalx/orga/views/dashboard.py:171
-#, fuzzy
-#| msgid "proposal is waiting for your review."
-#| msgid_plural "submissions are waiting for your review."
-msgid "proposals are waiting for your review."
-msgstr "有議程投稿制在等待您的檢閱。"
-
-#: pretalx/orga/views/dashboard.py:202
+#: pretalx/orga/views/dashboard.py:238
 msgid "day until event start"
 msgid_plural "days until event start"
 msgstr[0] "天後活動開始"
 
-#: pretalx/orga/views/dashboard.py:212
+#: pretalx/orga/views/dashboard.py:249
 msgid "day since event end"
 msgid_plural "days since event end"
 msgstr[0] ""
 
-#: pretalx/orga/views/dashboard.py:220
+#: pretalx/orga/views/dashboard.py:258
 #, python-brace-format
 msgid "Day {number}"
 msgstr "第 {number} 天"
 
-#: pretalx/orga/views/dashboard.py:221
+#: pretalx/orga/views/dashboard.py:259
 #, python-brace-format
 msgid "of {total_days} days"
 msgstr "，共 {total_days} 天"
 
-#: pretalx/orga/views/dashboard.py:231
+#: pretalx/orga/views/dashboard.py:270
 msgid "current schedule"
 msgstr "目前的議程表"
 
-#: pretalx/orga/views/dashboard.py:257
+#: pretalx/orga/views/dashboard.py:283
 #, fuzzy
 #| msgid "session"
 #| msgid_plural "talks"
@@ -6556,20 +6607,18 @@ msgid "session"
 msgid_plural "sessions"
 msgstr[0] "個議程"
 
-#: pretalx/orga/views/dashboard.py:270
+#: pretalx/orga/views/dashboard.py:288
 #, fuzzy
-#| msgid "unconfirmed session"
-#| msgid_plural "unconfirmed talks"
-msgid "unconfirmed session"
-msgid_plural "unconfirmed sessions"
-msgstr[0] "個未確認的議程"
+#| msgid "confirmed"
+msgid "unconfirmed"
+msgstr "已確認"
 
-#: pretalx/orga/views/dashboard.py:283
+#: pretalx/orga/views/dashboard.py:316
 msgid "speaker"
 msgid_plural "speakers"
 msgstr[0] "名講者"
 
-#: pretalx/orga/views/dashboard.py:291
+#: pretalx/orga/views/dashboard.py:344
 msgid "sent email"
 msgid_plural "sent emails"
 msgstr[0] "份已傳送的電子郵件"
@@ -7030,19 +7079,19 @@ msgstr ""
 msgid "Deadline"
 msgstr ""
 
-#: pretalx/orga/views/submission.py:989
+#: pretalx/orga/views/submission.py:991
 #, fuzzy
 #| msgid "The track has been saved."
 msgid "The tag has been saved."
 msgstr "此議程軌已被儲存。"
 
-#: pretalx/orga/views/submission.py:1010
+#: pretalx/orga/views/submission.py:1012
 #, fuzzy
 #| msgid "The track has been deleted."
 msgid "The tag has been deleted."
 msgstr "此議程軌已被刪除。"
 
-#: pretalx/orga/views/submission.py:1035
+#: pretalx/orga/views/submission.py:1037
 #, python-brace-format
 msgid "Changed {count} proposal states."
 msgstr ""
@@ -7381,7 +7430,7 @@ msgid ""
 msgstr ""
 
 #: pretalx/submission/forms/submission.py:27
-#: pretalx/submission/models/submission.py:216
+#: pretalx/submission/models/submission.py:224
 msgid "Use this if you want an illustration to go with your proposal."
 msgstr ""
 
@@ -7788,62 +7837,71 @@ msgid ""
 "re-enabled once the proposal was accepted."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:154
+#: pretalx/submission/models/submission.py:56
+msgid "draft"
+msgstr ""
+
+#: pretalx/submission/models/submission.py:162
 #, fuzzy
 #| msgid "Proposals by state"
 msgid "Pending proposal state"
 msgstr "議程投稿（依狀態）"
 
-#: pretalx/submission/models/submission.py:173
+#: pretalx/submission/models/submission.py:181
 msgid "These notes are meant for the organiser and won't be made public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:179
+#: pretalx/submission/models/submission.py:187
 msgid "Internal notes"
 msgstr ""
 
-#: pretalx/submission/models/submission.py:181
+#: pretalx/submission/models/submission.py:189
 msgid ""
 "Internal notes for other organisers/reviewers. Not visible to the speakers "
 "or the public."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:189
+#: pretalx/submission/models/submission.py:197
 msgid ""
 "The duration in minutes. Leave empty for default duration for this session "
 "type."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:195
+#: pretalx/submission/models/submission.py:203
 msgid "How many times this session will take place."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:206
+#: pretalx/submission/models/submission.py:214
 #, fuzzy
 #| msgid "Show this submission in the public sneak peek."
 msgid "Show this session in public list of featured sessions."
 msgstr "將此議程投稿公開顯示在「議程搶先看」頁面中。"
 
-#: pretalx/submission/models/submission.py:209
+#: pretalx/submission/models/submission.py:217
 msgid "Don't record this session."
 msgstr ""
 
-#: pretalx/submission/models/submission.py:231
+#: pretalx/submission/models/submission.py:239
 #, fuzzy
 #| msgid "Invite reviewers"
 msgid "Assigned reviewers"
 msgstr "邀請檢閱者"
 
-#: pretalx/submission/models/submission.py:388
+#: pretalx/submission/models/submission.py:401
 msgctxt ""
 "used in talk confirm/accept/reject/...-errors, like \"... must be accepted "
 "OR foo OR bar ...\""
 msgid " or "
 msgstr ""
 
-#: pretalx/submission/models/submission.py:396
+#: pretalx/submission/models/submission.py:409
 #, python-brace-format
 msgid "Proposal must be {src_states} not {state} to be {new_state}."
+msgstr ""
+
+#: pretalx/submission/models/submission.py:478
+#, python-brace-format
+msgid "New proposal: {title}"
 msgstr ""
 
 #: pretalx/submission/models/tag.py:31
@@ -7902,6 +7960,19 @@ msgstr ""
 msgid "{name} ({duration} minutes)"
 msgstr ""
 
+#, fuzzy
+#~| msgid "proposal is waiting for your review."
+#~| msgid_plural "submissions are waiting for your review."
+#~ msgid "proposals are waiting for your review."
+#~ msgstr "有議程投稿制在等待您的檢閱。"
+
+#, fuzzy
+#~| msgid "unconfirmed session"
+#~| msgid_plural "unconfirmed talks"
+#~ msgid "unconfirmed session"
+#~ msgid_plural "unconfirmed sessions"
+#~ msgstr[0] "個未確認的議程"
+
 #~ msgid "No speaker matches your search."
 #~ msgstr "找不到符合的講者。"
 
@@ -7950,9 +8021,6 @@ msgstr ""
 
 #~ msgid "Compose mail"
 #~ msgstr "撰寫郵件"
-
-#~ msgid "Current draft"
-#~ msgstr "目前的草稿"
 
 #~ msgid "Show"
 #~ msgstr "顯示"

--- a/src/pretalx/orga/views/dashboard.py
+++ b/src/pretalx/orga/views/dashboard.py
@@ -14,7 +14,7 @@ from pretalx.common.mixins.views import EventPermissionRequired, PermissionRequi
 from pretalx.common.models.log import ActivityLog
 from pretalx.event.models import Event, Organiser
 from pretalx.event.stages import get_stages
-from pretalx.submission.models import Review, SubmissionStates
+from pretalx.submission.models import Review, Submission, SubmissionStates
 
 
 def start_redirect_view(request):
@@ -141,6 +141,21 @@ class EventDashboardView(EventPermissionRequired, TemplateView):
                     "priority": 40,
                 }
             )
+            draft_proposals = Submission.all_objects.filter(
+                state=SubmissionStates.DRAFT, event=self.request.event
+            ).count()
+            if draft_proposals:
+                result.append(
+                    {
+                        "large": draft_proposals,
+                        "small": ngettext_lazy(
+                            "unsubmitted proposal draft",
+                            "unsubmitted proposal drafts",
+                            draft_proposals,
+                        ),
+                        "priority": 50,
+                    }
+                )
         return result
 
     def get_review_tiles(self):

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -809,7 +809,9 @@ class SubmissionStats(PermissionRequired, TemplateView):
     def submission_state_data(self):
         counter = Counter(
             submission.get_state_display()
-            for submission in Submission.all_objects.exclude(state=SubmissionStates.DRAFT).filter(event=self.request.event)
+            for submission in Submission.all_objects.exclude(
+                state=SubmissionStates.DRAFT
+            ).filter(event=self.request.event)
         )
         return json.dumps(
             sorted(

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -115,7 +115,7 @@ The {event} orga crew"""
 
 class SubmissionViewMixin(PermissionRequired):
     def get_queryset(self):
-        return Submission.all_objects.filter(event=self.request.event)
+        return Submission.objects.filter(event=self.request.event)
 
     def get_object(self):
         return get_object_or_404(
@@ -611,7 +611,7 @@ class FeedbackList(SubmissionViewMixin, ListView):
     @cached_property
     def submission(self):
         return get_object_or_404(
-            Submission.all_objects.filter(event=self.request.event),
+            Submission.objects.filter(event=self.request.event),
             code__iexact=self.kwargs.get("code"),
         )
 
@@ -809,7 +809,7 @@ class SubmissionStats(PermissionRequired, TemplateView):
     def submission_state_data(self):
         counter = Counter(
             submission.get_state_display()
-            for submission in Submission.all_objects.filter(event=self.request.event)
+            for submission in Submission.all_objects.exclude(state=SubmissionStates.DRAFT).filter(event=self.request.event)
         )
         return json.dumps(
             sorted(

--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -278,7 +278,7 @@ class SubmissionFilterForm(forms.Form):
         initial["exclude_pending"] = False
         super().__init__(*args, initial=initial, **kwargs)
         qs = event.submissions
-        state_qs = Submission.all_objects.filter(event=event)
+        state_qs = Submission.objects.filter(event=event)
         if usable_states:
             qs = qs.filter(state__in=usable_states)
             state_qs = state_qs.filter(state__in=usable_states)

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -53,7 +53,7 @@ class SubmissionStates(Choices):
         CANCELED: _("canceled"),
         WITHDRAWN: _("withdrawn"),
         DELETED: _("deleted"),
-        DRAFT: _("Draft"),
+        DRAFT: _("draft"),
     }
     valid_choices = [(key, value) for key, value in display_values.items()]
 

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -43,6 +43,7 @@ class SubmissionStates(Choices):
     CANCELED = "canceled"
     WITHDRAWN = "withdrawn"
     DELETED = "deleted"
+    DRAFT = "draft"
 
     display_values = {
         SUBMITTED: _("submitted"),
@@ -52,6 +53,7 @@ class SubmissionStates(Choices):
         CANCELED: _("canceled"),
         WITHDRAWN: _("withdrawn"),
         DELETED: _("deleted"),
+        DRAFT: _("Draft"),
     }
     valid_choices = [(key, value) for key, value in display_values.items()]
 
@@ -63,6 +65,7 @@ class SubmissionStates(Choices):
         CANCELED: (ACCEPTED, CONFIRMED),
         WITHDRAWN: (SUBMITTED),
         DELETED: tuple(),
+        DRAFT: (SUBMITTED,),
     }
 
     method_names = {
@@ -78,7 +81,12 @@ class SubmissionStates(Choices):
 
 class SubmissionManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().exclude(state=SubmissionStates.DELETED)
+        return (
+            super()
+            .get_queryset()
+            .exclude(state=SubmissionStates.DELETED)
+            .exclude(state=SubmissionStates.DRAFT)
+        )
 
 
 class DeletedSubmissionManager(models.Manager):

--- a/src/tests/agenda/views/test_agenda_talks.py
+++ b/src/tests/agenda/views/test_agenda_talks.py
@@ -241,7 +241,7 @@ def test_talk_speaker_other_submissions_only_if_visible(
 def test_talk_review_page(
     client, django_assert_num_queries, event, submission, other_submission
 ):
-    with django_assert_num_queries(13):
+    with django_assert_num_queries(15):
         response = client.get(submission.urls.review, follow=True)
     assert response.status_code == 200
     assert submission.title in response.content.decode()

--- a/src/tests/submission/test_submission_model.py
+++ b/src/tests/submission/test_submission_model.py
@@ -213,7 +213,7 @@ def test_submission_set_state_error_msg(submission):
             submission._set_state(SubmissionStates.SUBMITTED)
 
         assert (
-            "must be rejected or accepted or withdrawn not canceled to be submitted"
+            "must be rejected or accepted or withdrawn or draft not canceled to be submitted"
             in str(excinfo.value)
         )
 


### PR DESCRIPTION
Closes #672 

Missing features:

- [ ] Send emails to users with drafts
- [ ] Discard drafts (note: even after CfP has ended)
- [ ] Mandatory profile questions can remain unanswered