### PR TITLE
Allow organisers to clear submission tracks

### DIFF
--- a/src/pretalx/orga/forms/submission.py
+++ b/src/pretalx/orga/forms/submission.py
@@ -196,7 +196,9 @@ class SubmissionForm(ReadOnlyFlag, RequestRequire, forms.ModelForm):
         ]
         widgets = {
             "tags": forms.SelectMultiple(attrs={"class": "select2"}),
-            "track": forms.Select(attrs={"class": "select2"}),
+            "track": forms.Select(
+                attrs={"class": "select2", "data-allow-clear": "true"}
+            ),
             "submission_type": forms.Select(attrs={"class": "select2"}),
             "abstract": MarkdownWidget,
             "description": MarkdownWidget,


### PR DESCRIPTION
Currently, submissions with tracks cannot be edited in the organiser area to have their track removed. This pull request fixes a regression caused by use of `select2` to select tracks in organiser area submission form, updating its `select2` widget to allow a selected track to be [cleared](https://select2.org/selections#clearable-selections).

## How Has This Been Tested?

I have tested this in an updated copy of pretalx running in a virtual machine. Because this only changes the behavior of a single `select2` widget, I don't believe any changes to backend tests are necessary. I did not see any frontend or integration tests that would be affected by this change.

## Screenshots (if appropriate):

Before (*there is no way to de-select a selected track*):
![The current select2 widget in the organiser area submission form](https://user-images.githubusercontent.com/49076/204659931-89143e3f-90d9-499b-8431-7a33520f55f8.png)

After (*tracks can be un-selected by clicking the small "x"*):
![The select2 widget with "allowClear" enabled](https://user-images.githubusercontent.com/49076/204660207-f5a3933e-1532-476d-8950-7da60dd27d91.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
