### PR TITLE
Fix additional speaker help text

### DIFF
--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -17,7 +17,7 @@ class InfoForm(CfPFormMixin, RequestRequire, PublicContent, forms.ModelForm):
     additional_speaker = forms.EmailField(
         label=_("Additional Speaker"),
         help_text=_(
-            "If you have a co-speaker, please add their email address here, and we will invite them to create an account. If you have more than one co-speaker, you can add more speakers after finishing the proposal process."
+            "If you have a co-speaker, please add his email address here, and we will invite him to create an account. If you have more than one co-speaker, you can add more speakers after finishing the proposal process."
         ),
         required=False,
     )


### PR DESCRIPTION
CfP form allow to add a single co-speaker email address but the help text mention "their email address" and "invite them".

This pull request should fix the incoherence by replacing "their email address" by "his email address" and "invite them" by "invite him".

## How Has This Been Tested?

I run: `python -m pytest tests/`

On a side note, on the first run of the test I got the following failed tests:
```
============================================= short test summary info ==============================================
FAILED tests/agenda/test_agenda_schedule_export.py::test_html_export_language - assert 'Kontakt' in '\n\n\n\n<!DOCTYPE html>\n<html lang="de">\n    <head>\n        <meta charset="utf-8">\n   ...
FAILED tests/cfp/views/test_cfp_user.py::test_can_change_locale - assert 'Einreichung' in '\n\n\n\n<!DOCTYPE html>\n<html lang="de">\n    <head>\n        <meta charset="utf-8">\...
FAILED tests/cfp/views/test_cfp_user.py::test_can_change_locale_with_queryparam - assert 'Einreichung' in '\n\n\n\n<!DOCTYPE html>\n<html lang="de">\n    <head>\n        <meta charset="utf-8">\...
FAILED tests/common/test_common_utils.py::test_daterange[es-start11-end11-1 de Febrero de 2003 -3 de Abril de 2005] - AssertionError: assert '1 de Febrero...Abril de 2005' == '1 de Febrero...Abril de 2005'

Results (248.88s):
    1372 passed
       4 failed
         - tests/agenda/test_agenda_schedule_export.py:336 test_html_export_language
         - tests/cfp/views/test_cfp_user.py:492 test_can_change_locale
         - tests/cfp/views/test_cfp_user.py:505 test_can_change_locale_with_queryparam
         - tests/common/test_common_utils.py:10 test_daterange[es-start11-end11-1 de Febrero de 2003 -3 de Abril de 2005]
```
Running again the tests without any modification result in a successful execution of all tests.

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
