### PR TITLE
fix crontab install step documentation

### DIFF
--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -297,7 +297,7 @@ In the same environment as you ran the previous pretalx commands (e.g. the
 
 You could for example configure the ``pretalx`` user cron like this::
 
-  15,45 * * * * /var/pretalx/.local/bin/python -m pretalx runperiodic
+  15,45 * * * * python -m pretalx runperiodic
 
 Next Steps
 ----------


### PR DESCRIPTION
`pip install --user` is used through the install documentation, but there is no `python` binary in the user level isolation. In contrast from `gunicorn` or `celery` scripts.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've run into this, when someone else without a deeper knowledge of python ecosystem installed Pretix on a server. They were just blindly following administration documentation but `/var/pretalx/.local/bin/python` clearly does not exist.

Not sure if my documentation update is enough, but at least I wanted to report this! Thanks for all the great work on Pretalx and congrats for the release :)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
