### PR TITLE
fix: handle team without members in tests

### DIFF
--- a/src/pretalx/orga/views/organiser.py
+++ b/src/pretalx/orga/views/organiser.py
@@ -65,7 +65,10 @@ class TeamDetail(PermissionRequired, TeamMixin, CreateOrUpdateView):
     @context
     @cached_property
     def members(self):
-        return self.team.members.all().order_by("name")
+        if hasattr(self.team, "members"):
+            return self.team.members.all().order_by("name")
+        else:
+            return []
 
     def post(self, *args, **kwargs):
         if self.invite_form.is_bound:


### PR DESCRIPTION
fix #1452 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #1452. It does so by handling teams without `members` field. I am not 100% sure though if it's a valid case in the real operations and it's not test fixtures that are lacking.

## How Has This Been Tested?
Run `PRETALX_CONFIG_FILE=tests/ci_sqlite.cfg py.test -nauto -p no:sugar --cov=./ --cov-report=xml --reruns 3 tests --maxfail=100` locally and the three tests failing in Github Actions passed.

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
