### PR TITLE
ci: fix failing documentation spellcheck build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt update
-          sudo apt install enchant hunspell aspell-en
+          sudo apt install enchant-2 hunspell aspell-en
       - name: Install Dependencies
         run: python -m pip install -Ur doc/requirements.txt
       - name: Spellcheck docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   spelling:
     name: Spellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
@@ -45,7 +45,7 @@ jobs:
 
   linkcheck:
     name: Linkcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   isort:
     name: isort
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./src
   flake:
     name: flake8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./src
   black:
     name: black
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
@@ -81,7 +81,7 @@ jobs:
         working-directory: ./src
   djhtml:
     name: djhtml
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9
@@ -101,7 +101,7 @@ jobs:
         working-directory: ./src
   packaging:
     name: packaging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Tests
     strategy:
       fail-fast: false


### PR DESCRIPTION
fix #1454

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #1454. It does so by replacing `enchant` package by `enchant-2`, because the first one is not available in Ubuntu 22.04. Also to prevent future breakage like this, I change the runner from `ubuntu-latest` to `ubuntu-22.04`. It's effectively the same image for now, but it will prevent this from happening in the future.

## How Has This Been Tested?
I was running `make spelling` locally in a container based on Ubuntu 22.04.

## Screenshots (if appropriate):

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
