### PR TITLE
Fix Czech language flag

### DIFF
--- a/src/pretalx/static/common/scss/_flags.scss
+++ b/src/pretalx/static/common/scss/_flags.scss
@@ -214,7 +214,7 @@ div[lang=cr], input[lang=cr], textarea[lang=cr] {
 }
 
 div[lang=cs], input[lang=cs], textarea[lang=cs] {
-  background-image: url(static("vendored/flags/cs.png"));
+  background-image: url(static("vendored/flags/cz.png"));
 }
 
 div[lang=cu], input[lang=cu], textarea[lang=cu] {
@@ -231,10 +231,6 @@ div[lang=cx], input[lang=cx], textarea[lang=cx] {
 
 div[lang=cy], input[lang=cy], textarea[lang=cy] {
   background-image: url(static("vendored/flags/cy.png"));
-}
-
-div[lang=cz], input[lang=cz], textarea[lang=cz] {
-  background-image: url(static("vendored/flags/cz.png"));
 }
 
 div[lang=de], input[lang=de], textarea[lang=de], .checkbox > input[lang=de] + label,


### PR DESCRIPTION
Czech language has ISO 639-1 code of `cs` while the proper flag is associated with the Czech Republic, that is ISO 3166-2 code `CZ`. This is a simple fix to display proper flag for Czech language.