### PR TITLE
Customize slug help text

### DIFF
--- a/src/pretalx/orga/forms/event.py
+++ b/src/pretalx/orga/forms/event.py
@@ -147,14 +147,15 @@ class EventForm(ReadOnlyFlag, I18nHelpText, JsonSubfieldMixin, I18nModelForm):
         self.fields["name"].widget.attrs["placeholder"] = (
             _("The name of your conference, e.g. My Conference") + " " + year
         )
-        self.fields["slug"].help_text = _(
-            "Please contact your administrator if you need to change the short name of your event."
-        )
+        if not self.is_administrator:
+            self.fields["slug"].disabled = True
+            self.fields["slug"].help_text = _(
+                "Please contact your administrator if you need to change the short name of your event."
+            )
         self.fields["primary_color"].widget.attrs["placeholder"] = _(
             "A color hex value, e.g. #ab01de"
         )
         self.fields["primary_color"].widget.attrs["class"] = "colorpickerfield"
-        self.fields["slug"].disabled = not self.is_administrator
         self.fields["date_to"].help_text = _(
             "Any sessions you have scheduled already will be moved if you change the event dates. You will have to release a new schedule version to notify all speakers."
         )


### PR DESCRIPTION
Currently, all users editing event settings see the slug field's help text as "Please contact your administrator if you need to change the short name of your event." This commit customizes the slug help text depending on whether the user is an administrator, so that administrators are not asked to contact themselves.

## How Has This Been Tested?

I used a local copy of pretalx to confirm that administrators see the help text "The slug may only contain letters, numbers, dots and dashes" and that non-administrators are asked to contact an administrator.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
