### PR TITLE
Fix typo in Japanese Kanji

### DIFF
--- a/src/pretalx/locale/ja_JP/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/ja_JP/LC_MESSAGES/django.po
@@ -958,7 +958,7 @@ msgid ""
 msgstr ""
 "提案を送信することで、このイベントに参加し、提案内容について発表を行うことを"
 "受諾したものとみなします。タイトルや概要、詳細、アップロード資料などの提出済"
-"のデータは、提案内奥が確定した時点で一般に公開されます。"
+"のデータは、提案内容が確定した時点で一般に公開されます。"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_confirm.html:49
 #: pretalx/cfp/templates/cfp/event/user_submission_withdraw.html:27


### PR DESCRIPTION
Thank you for this awesome application.

<!--- Why is this change required? What problem does it solve? -->
This is a small pull request to fix typo in Japanese translation.

内奥 (naiou) seems a typo.
It should be 内容 (naiyou)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

N/A

This is a change of translation.

## Screenshots (if appropriate):

N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

Question: Is there a corresponding item in the checklist for pull requests that correct typos of translation?

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
