### PR TITLE
schedule.json extensions

### DIFF
--- a/src/pretalx/person/models/user.py
+++ b/src/pretalx/person/models/user.py
@@ -1,9 +1,9 @@
 import json
 import random
+import uuid
 from contextlib import suppress
 from hashlib import md5
 from urllib.parse import urljoin
-import uuid
 
 from django.conf import settings
 from django.contrib.auth.models import (

--- a/src/pretalx/person/models/user.py
+++ b/src/pretalx/person/models/user.py
@@ -3,6 +3,7 @@ import random
 from contextlib import suppress
 from hashlib import md5
 from urllib.parse import urljoin
+import uuid
 
 from django.conf import settings
 from django.contrib.auth.models import (
@@ -283,6 +284,10 @@ class User(PermissionsMixin, GenerateCode, FileCleanupMixin, AbstractBaseUser):
             self.delete()
 
     shred.alters_data = True
+
+    @cached_property
+    def guid(self) -> str:
+        return uuid.uuid5(uuid.NAMESPACE_URL, f"acct:{self.email.strip()}").__str__()
 
     @cached_property
     def gravatar_parameter(self) -> str:

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -27,7 +27,7 @@ class ScheduleData(BaseExporter):
 
         return {
             "url": self.event.urls.schedule.full(),
-            "base_url": get_base_url(self.event)
+            "base_url": get_base_url(self.event),
         }
 
     @cached_property
@@ -166,9 +166,7 @@ class FrabJsonExporter(ScheduleData):
                 "daysCount": self.event.duration,
                 "timeslot_duration": "00:05",
                 "time_zone_name": self.event.timezone,
-                "colors": {
-                    "primary": self.event.primary_color
-                },
+                "colors": {"primary": self.event.primary_color},
                 # "url": self.event.urls.base.full(),  # TODO this should be the URL of the conference website itself, but we do not have a field for this value yet
                 "rooms": [
                     {
@@ -222,7 +220,8 @@ class FrabJsonExporter(ScheduleData):
                                             "id": person.id,
                                             "code": person.code,
                                             "public_name": person.get_display_name(),
-                                            "avatar": person.get_avatar_url(self.event) or None,
+                                            "avatar": person.get_avatar_url(self.event)
+                                            or None,
                                             "biography": getattr(
                                                 person.profiles.filter(
                                                     event=self.event
@@ -281,14 +280,14 @@ class FrabJsonExporter(ScheduleData):
         return (
             f"{self.event.slug}.json",
             "application/json",
-            json.dumps({
-                "$schema": "https://c3voc.de/schedule/schema.json",
-                "generator": {
-                    "name": "pretalx",
-                    "version": __version__
+            json.dumps(
+                {
+                    "$schema": "https://c3voc.de/schedule/schema.json",
+                    "generator": {"name": "pretalx", "version": __version__},
+                    "schedule": content,
                 },
-                "schedule": content
-            }, cls=I18nJSONEncoder),
+                cls=I18nJSONEncoder,
+            ),
         )
 
 

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -181,9 +181,9 @@ class FrabJsonExporter(ScheduleData):
                                 {
                                     "id": talk.submission.id,
                                     "guid": talk.uuid,
-                                    "logo": talk.submission.urls.image,
                                     "date": talk.local_start.isoformat(),
                                     "start": talk.local_start.strftime("%H:%M"),
+                                    "logo": talk.submission.image_url,
                                     "duration": talk.export_duration,
                                     "room": str(room["name"]),
                                     "slug": talk.frab_slug,
@@ -206,6 +206,7 @@ class FrabJsonExporter(ScheduleData):
                                             "id": person.id,
                                             "code": person.code,
                                             "public_name": person.get_display_name(),
+                                            "avatar": person.get_avatar_url,
                                             "biography": getattr(
                                                 person.profiles.filter(
                                                     event=self.event

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -198,9 +198,11 @@ class FrabJsonExporter(ScheduleData):
                                     "guid": talk.uuid,
                                     "date": talk.local_start.isoformat(),
                                     "start": talk.local_start.strftime("%H:%M"),
-                                    "logo": talk.submission.urls.image.full()
-                                    if talk.submission.image
-                                    else None,
+                                    "logo": (
+                                        talk.submission.urls.image.full()
+                                        if talk.submission.image
+                                        else None
+                                    ),
                                     "duration": talk.export_duration,
                                     "room": str(room["name"]),
                                     "slug": talk.frab_slug,

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -161,6 +161,10 @@ class FrabJsonExporter(ScheduleData):
                 "daysCount": self.event.duration,
                 "timeslot_duration": "00:05",
                 "time_zone_name": self.event.timezone,
+                "colors": {
+                    "primary": self.event.primary_color
+                },
+                "url": self.event.urls.schedule.full(),
                 "rooms": [
                     {
                         "name": str(room.name),
@@ -169,6 +173,13 @@ class FrabJsonExporter(ScheduleData):
                         "capacity": room.capacity,
                     }
                     for room in self.event.rooms.all()
+                ],
+                "tracks": [
+                    {
+                        "name": str(track.name),
+                        "color": track.color,
+                    }
+                    for track in self.event.tracks.all()
                 ],
                 "days": [
                     {

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -264,7 +264,10 @@ class FrabJsonExporter(ScheduleData):
         return (
             f"{self.event.slug}.json".format(self.event.slug),
             "application/json",
-            json.dumps({"schedule": content}, cls=I18nJSONEncoder),
+            json.dumps({
+                "$schema": "https://c3voc.de/schedule/schema.json",
+                "schedule": content
+            }, cls=I18nJSONEncoder),
         )
 
 

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -219,6 +219,7 @@ class FrabJsonExporter(ScheduleData):
                                     "do_not_record": talk.submission.do_not_record,
                                     "persons": [
                                         {
+                                            "guid": person.guid,
                                             "id": person.id,
                                             "code": person.code,
                                             "public_name": person.get_display_name(),

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -198,7 +198,9 @@ class FrabJsonExporter(ScheduleData):
                                     "guid": talk.uuid,
                                     "date": talk.local_start.isoformat(),
                                     "start": talk.local_start.strftime("%H:%M"),
-                                    "logo": talk.submission.image_url or None,
+                                    "logo": talk.submission.urls.image.full()
+                                    if talk.submission.image
+                                    else None,
                                     "duration": talk.export_duration,
                                     "room": str(room["name"]),
                                     "slug": talk.frab_slug,


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a few missing attributes to schedule.json export, including speaker avatars and switching from relative URIs for external assets to absolute URLs. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* run locally with democon test data (which has no images on event nor speaker/person)
* validated output agains schedule.json json-schema

## Screenshots (if appropriate):
<img width="772" alt="image" src="https://github.com/pretalx/pretalx/assets/40266/3fdf9fd8-3874-4a7a-abe4-17bd002af1fb">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
