### PR TITLE
Fix avatar content-type in empty_avatar_view

### DIFF
--- a/src/pretalx/agenda/views/speaker.py
+++ b/src/pretalx/agenda/views/speaker.py
@@ -163,5 +163,5 @@ def empty_avatar_view(request, event):
     return FileResponse(
         io.BytesIO(avatar_template.encode()),
         as_attachment=True,
-        headers={"content-type": "image/svg+xml"},
+        content_type="image/svg+xml",
     )


### PR DESCRIPTION
Apparently passing a content-type header to the FileResponse constructor gets overriden at some point, which makes it ship the .svg with application/octet-stream, which prevents Firefox from rendering it.

The FileResponse constructor¹ however accepts a content_type kwarg, which reliably resolves this situation.

[1] https://github.com/django/django/blob/4.2.4/django/http/response.py#L541-L543

Closes: #1558

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #1558. It does so by using the `content_type` kwarg of the `FileResponse` constructor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in production on talks.mrmcd.net with Python 3.9 and gunicorn.

```
# curl --GET --unix-socket /run/gunicorn/pretalx http://localhost/2023/speaker/avatar.svg -v
*   Trying /run/gunicorn/pretalx:0...
* Connected to localhost (/run/gunicorn/pretalx) port 80 (#0)
> GET /2023/speaker/avatar.svg HTTP/1.1
> Host: localhost
> User-Agent: curl/7.74.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: gunicorn
< Date: Thu, 24 Aug 2023 00:25:25 GMT
< Connection: close
< Content-Type: image/svg+xml
< Content-Length: 649
< Content-Disposition: attachment
< Content-Security-Policy: base-uri 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; default-src 'self'; img-src 'self' data:
< X-Frame-Options: DENY
< Vary: Cookie
< X-Content-Type-Options: nosniff
< Referrer-Policy: strict-origin-when-cross-origin
< Cross-Origin-Opener-Policy: same-origin
< 
<svg
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 100 100">
  <g>
    <path
       id="body"
       d="m 2,98 h 96 0 c 0,0 6,-65 -48,-52 c 0,0 -54,-10 -48,52"
       style="fill:none;stroke:#E32F67;stroke-width:1.6;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.1, 2.1;stroke-dashoffset:0;stroke-opacity:0.87" />
    <ellipse
       ry="27"
       rx="27"
       cy="28"
       cx="50"
       id="heady"
       style="fill:#ffffff;stroke:#E32F67;stroke-width:1.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6.5, 8;stroke-dashoffset:4;stroke-opacity:0.87" />
  </g>
* Closing connection 0
</svg>
```

## Screenshots (if appropriate):

https://talks.mrmcd.net/2023/talk/7RKEUH/

The avatar.svg showing the outline of the speaker now gets loaded properly. 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change is listed in the CHANGELOG.rst if appropriate.
