### PR TITLE
Use django-table2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
   "django-i18nfield~=1.9.0",
   "django-libsass~=0.8",
   "django-scopes~=2.0.0",
+  "django-tables2~=2.6.0",
   "djangorestframework~=3.14.0",
   "libsass~=0.22.0",
   "Markdown~=3.4.0",  # https://python-markdown.github.io/change_log/

--- a/src/pretalx/orga/tables/submission.py
+++ b/src/pretalx/orga/tables/submission.py
@@ -1,0 +1,212 @@
+from urllib.parse import quote
+
+import django_tables2 as tables
+from django.template import Context
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
+
+from pretalx.submission.models import Submission
+
+
+def get_header(request):
+    return "hey"
+
+
+class ContextTemplateColumn(tables.TemplateColumn):
+    """Allow to change the context_object_name."""
+
+    context_object_name = "record"
+
+    def __init__(self, *args, **kwargs):
+        if "context_object_name" in kwargs:
+            self.context_object_name = kwargs.pop("context_object_name")
+        super().__init__(*args, **kwargs)
+
+    def render(self, record, table, value, bound_column, **kwargs):
+        context = getattr(table, "context", Context())
+        context[self.context_object_name] = record
+        return super().render(record, table, value, bound_column, **kwargs)
+
+
+class HelpTextMixin:
+    def __init__(self, *args, help_text=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.help_text = help_text
+
+    @property
+    def header(self):
+        if self.help_text:
+            return mark_safe(
+                f"{self.verbose_name} <i class='fa fa-question-circle' title='{self.help_text}'></i>"
+            )
+        return self.verbose_name
+
+
+class ActionsColumn(tables.Column):
+    attrs = {"td": {"class": "text-end action-column"}}
+    empty_values = ()
+    default_actions = {
+        "edit": {
+            "title": _("edit"),
+            "icon": "edit",
+            "url": "edit",
+            "permission": None,
+            "next": False,
+            "color": "info",
+        },
+        "delete": {
+            "title": _("Delete"),
+            "icon": "trash",
+            "url": "delete",
+            "permission": None,
+            "next": True,
+            "color": "danger",
+        },
+    }
+
+    def __init__(self, *args, actions=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # actions are defined by child classes as a dict of override settings,
+        # mostly to set permissions and urls
+        self.actions = {}
+        for key, value in actions.items():
+            self.actions[key] = self.default_actions.get(key, {}).copy()
+            self.actions[key].update(value)
+
+    def header(self):
+        # Don't ever show a column title
+        return ""
+
+    def render(self, record, table, **kwargs):
+        if not self.actions or not getattr(record, "pk", None):
+            return ""
+
+        request = getattr(table, "context", {}).get("request")
+        user = getattr(request, "user", None)
+
+        html = ""
+        for action in self.actions.values():
+            if user and action["permission"]:
+                if not user.has_perm(action["permission"], record):
+                    continue
+
+            inner_html = (
+                f'title="{action["title"]}" class="btn btn-sm btn-{action["color"]}">'
+            )
+            inner_html += f'<i class="fa fa-{action["icon"]}"></i>'
+
+            # url is a dotted string to be accessed on the record
+            url = action["url"]
+            if not url:
+                # Render button and hope there is some JS to handle it
+                html += f"<button {inner_html}</button>"
+            else:
+                url_parts = url.split(".")
+                url = record
+                for part in url_parts:
+                    url = getattr(url, part)
+                    if callable(url):
+                        url = url()
+                if action["next"] and request:
+                    url = f"{url}?next={quote(request.get_full_path())}"
+                html += f'<a href="{url}" {inner_html}</a>'
+        return mark_safe(html)
+
+
+class TemplateHelpTextColumn(HelpTextMixin, tables.TemplateColumn):
+    pass
+
+
+class SubmissionTable(tables.Table):
+    indicator = tables.TemplateColumn(
+        template_name="orga/tables/submission_side_indicator.html",
+        orderable=False,
+        verbose_name="",
+        exclude_from_export=True,
+    )
+    title = tables.Column(
+        linkify=lambda record: record.orga_urls.base,
+        verbose_name=_("Title"),
+        orderable=True,
+    )
+    speakers = tables.TemplateColumn(
+        template_name="orga/tables/submission_speakers.html",
+        verbose_name=_("Speakers"),
+        orderable=True,
+        order_by=("speakers__name"),
+    )
+    state = ContextTemplateColumn(
+        template_name="orga/submission/state_dropdown.html",
+        verbose_name=_("State"),
+        orderable=True,
+        context_object_name="submission",
+    )
+    submission_type = tables.Column(
+        verbose_name=_("Type"),
+        linkify=lambda record: record.submission_type.urls.base,
+        accessor="submission_type.name",
+        orderable=True,
+        order_by=("submission_type__name"),
+    )
+    is_featured = TemplateHelpTextColumn(
+        template_name="orga/tables/submission_is_featured.html",
+        verbose_name=_("Featured"),
+        orderable=True,
+        help_text=_(
+            "Show this session on the list of featured sessions, once it was accepted"
+        ),
+    )
+    actions = ActionsColumn(
+        actions={
+            "edit": {"url": "orga_urls.edit"},
+            "delete": {"url": "orga_urls.delete"},
+        }
+    )
+
+    def __init__(
+        self,
+        *args,
+        event,
+        can_view_speakers=False,
+        can_change_submission=False,
+        limit_tracks=None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+        self.exclude = list(self.exclude)  # Make sure we can add fields
+        if not event.submission_types.all().count() > 1:
+            self.exclude += ["submission_type"]
+        if not can_view_speakers:
+            self.exclude += ["speakers"]
+        show_tracks = False
+        if event.feature_flags["use_tracks"]:
+            if limit_tracks:
+                show_tracks = len(limit_tracks) > 1
+            else:
+                show_tracks = event.tracks.all().count() > 1
+        if not show_tracks:
+            self.exclude += ["track"]
+        if not can_change_submission:
+            self.exclude += ["is_featured", "actions"]
+
+        # These values are only for exports
+        self.columns.hide("code")
+        self.columns.hide("track")
+        self.columns.hide("is_anonymised")
+
+    class Meta:
+        model = Submission
+        fields = (
+            "code",
+            "track",
+            "is_anonymised",
+            "indicator",
+            "title",
+            "speakers",
+            "submission_type",
+            "state",
+            "is_featured",
+            "actions",
+        )

--- a/src/pretalx/orga/templates/orga/submission/list.html
+++ b/src/pretalx/orga/templates/orga/submission/list.html
@@ -5,6 +5,7 @@
 {% load rules %}
 {% load static %}
 {% load url_replace %}
+{% load render_table from django_tables2 %}
 
 {% block scripts %}
     {% compress js %}
@@ -75,112 +76,5 @@
         {% endif %}
     </div>
 
-    <div class="table-responsive">
-        <table class="table table-sm table-hover table-flip">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th>
-                        {% translate "Title" %}
-                        <a href="?{% url_replace request 'sort' 'title' %}"><i class="fa fa-caret-down" title="{% translate "Sort by title (a-z)" %}"></i></a>
-                        <a href="?{% url_replace request 'sort' '-title' %}"><i class="fa fa-caret-up" title="{% translate "Sort by title (z-a)" %}"></i></a>
-                    </th>
-                    {% if can_view_speakers %}<th>{% translate "Speakers" %}</th>{% endif %}
-                    {% if show_submission_types  %}
-                        <th>
-                            {% translate "Type" %}
-                        </th>
-                    {% endif %}
-                    <th>
-                        {% translate "State" %}
-                        <a href="?{% url_replace request 'sort' 'state' %}"><i class="fa fa-caret-down" title="{% translate "Sort by state (a-z)" %}"></i></a>
-                        <a href="?{% url_replace request 'sort' '-state' %}"><i class="fa fa-caret-up" title="{% translate "Sort by state (z-a)" %}"></i></a>
-                    </th>
-                    {% if can_change_submission %}
-                        <th>
-                            {% translate "Featured" %} <i class="fa fa-question-circle" data-toggle="tooltip" title="{% translate "Show this session on the list of featured sessions, once it was accepted" %}"></i>
-                            <a href="?{% url_replace request 'sort' '-is_featured' %}"><i class="fa fa-caret-down" title="{% translate "Sort by featured first" %}"></i></a>
-                            <a href="?{% url_replace request 'sort' 'is_featured' %}"><i class="fa fa-caret-up" title="{% translate "Sort featured last" %}"></i></a>
-                        </th>
-                        <th></th>
-                    {% endif %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for submission in submissions %}
-                    <tr>
-                        <td class="text-center">
-                            {% if request.event.feature_flags.use_tracks and submission.track %}
-                                {% if not submission.is_anonymised %}
-                                    <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}">
-                                    </div>
-                                {% else %}
-                                    <i class="fa fa-user-secret" style="color: {{ submission.track.color }}" title="{{ submission.track.name }}, {% translate "anonymised" %}" aria-hidden="true"></i>
-                                {% endif %}
-                            {% else %}
-                                {% if submission.anonymised %}
-                                    <i class="fa fa-user-secret" style="color: #888" title="{% translate "anonymised" %}" aria-hidden="true"></i>
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                        <td>
-                            <a href="{{ submission.orga_urls.base }}">
-                                {% if can_view_speakers %}{{ submission.title }}{% else %}{{ submission.anonymised.title|default:submission.title }}{% endif %}
-                            </a>
-                        </td>
-                        {% if can_view_speakers %}
-                            <td>
-                                {% for speaker in submission.speakers.all %}
-                                    <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.code %}">
-                                        {{ speaker.get_display_name }}
-                                    </a><br>
-                                {% endfor %}
-                            </td>
-                        {% endif %}
-                        {% if show_submission_types  %}
-                            <td>
-                                {{ submission.submission_type.name }}
-                            </td>
-                        {% endif %}
-                        <td>
-                            {% include "orga/submission/state_dropdown.html" with submission=submission %}
-                        </td>
-                        {% if can_change_submission %}
-                            <td class="submission_featured">
-                                <div class="mt-1 form-check" title="{% translate 'Show this proposal in the list of featured sessions.' %}">
-                                    <input
-                                        type="checkbox"
-                                        id="featured_{{ submission.code }}"
-                                        data-id="{{ submission.code }}"
-                                        class="submission_featured"
-                                        {% if submission.is_featured %}checked{% endif %}
-                                    >
-                                    <label for="featured_{{ submission.code }}"></label>
-                                </div>
-                                <i class="working fa fa-spinner fa-spin d-none"></i>
-                                <i class="done fa fa-check d-none"></i>
-                                <i class="fail fa fa-times d-none"></i>
-                            </td>
-                            <td class="action-column">
-                                <a href="{{ submission.orga_urls.edit }}"
-                                   title="{% translate "edit" %}"
-                                   class="btn btn-sm btn-info">
-                                    <i class="fa fa-edit"></i>
-                                </a>
-                                <a href="{{ submission.orga_urls.delete }}?from=list"
-                                   title="{% translate "Delete" %}"
-                                   class="btn btn-sm btn-danger">
-                                    <i class="fa fa-trash"></i>
-                                </a>
-                            </td>
-                        {% endif %}
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-
-    {% include "orga/includes/pagination.html" %}
-
-
+    {% render_table table %}
 {% endblock %}

--- a/src/pretalx/orga/templates/orga/tables/base.html
+++ b/src/pretalx/orga/templates/orga/tables/base.html
@@ -1,0 +1,7 @@
+{% extends 'django_tables2/bootstrap4-responsive.html' %}
+
+{% block pagination %}
+    {% if table.page and table.paginator.num_pages > 1 %}
+        {% include "orga/includes/pagination.html" with page_obj=table.page page=table.page is_paginated=True %}
+    {% endif %}
+{% endblock pagination %}

--- a/src/pretalx/orga/templates/orga/tables/submission_is_featured.html
+++ b/src/pretalx/orga/templates/orga/tables/submission_is_featured.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<div class="mt-1 form-check" title="{% translate 'Show this proposal in the list of featured sessions.' %}">
+    <input
+        type="checkbox"
+        id="featured_{{ record.code }}"
+        data-id="{{ record.code }}"
+        class="submission_featured"
+        {% if record.is_featured %}checked{% endif %}
+    >
+    <label for="featured_{{ record.code }}"></label>
+</div>
+<i class="working fa fa-spinner fa-spin d-none"></i>
+<i class="done fa fa-check d-none"></i>
+<i class="fail fa fa-times d-none"></i>

--- a/src/pretalx/orga/templates/orga/tables/submission_side_indicator.html
+++ b/src/pretalx/orga/templates/orga/tables/submission_side_indicator.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+{% if record.track and not record.is_anonymised %}
+    <div class="color-square" style="background-color: {{ submission.track.color }}" title="{{ submission.track.name }}"></div>
+{% else %}
+    <i class="fa fa-user-secret" style="color: {{ submission.track.color|default:'#888' }}" title="{{ submission.track.name }}, {% translate "anonymised" %}" aria-hidden="true"></i>
+{% endif %}

--- a/src/pretalx/orga/templates/orga/tables/submission_speakers.html
+++ b/src/pretalx/orga/templates/orga/tables/submission_speakers.html
@@ -1,0 +1,5 @@
+{% for speaker in record.speakers.all %}
+    <a href="{% url "orga:speakers.view" event=request.event.slug code=speaker.code %}">
+        {{ speaker.get_display_name }}
+    </a><br>
+{% endfor %}

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -74,6 +74,7 @@ EXTERNAL_APPS = [
     "jquery",
     "rest_framework.authtoken",
     "rules",
+    "django_tables2",
 ]
 LOCAL_APPS = [
     "pretalx.api",
@@ -596,6 +597,7 @@ BOOTSTRAP4 = {
         "event-inline": "pretalx.common.forms.renderers.EventInlineFieldRenderer",
     }
 }
+DJANGO_TABLES2_TEMPLATE = "orga/tables/base.html"
 COMPRESS_ENABLED = COMPRESS_OFFLINE = not DEBUG
 COMPRESS_PRECOMPILERS = (("text/x-scss", "django_libsass.SassCompiler"),)
 COMPRESS_FILTERS = {


### PR DESCRIPTION
This PR attempts to include django-table2 in pretalx.

## Status

The proposal list has been replaced with a feature-complete equivalent table using django-table-2, except that the changed code does not as yet respect pagination page size from urlparams. Queries have increased by a constant amount to permit links to submission types (which we didn't have previously).

## Performance

Rendering tables with django-table2 seems to be noticeably slower than running through our previous giant template. More so in `DEBUG` mode (as templates aren't cached then, and we're using more templates), but even in `DEBUG=False`, there seems to be a significant penalty:

```
## debug=true
page size  old        django-tables2
25         550-700ms   800-950ms
100        750-950ms   900-1200ms


## debug=false
page size  old        django-tables2
25         250-330ms   300-350ms
100        350-470ms   580-700ms
```

I tried to attach py-spy, and can't spot anything obvious in the block belonging to `django-table2` (svg attached). 
![2023-09-27T17:14:16+02:00](https://github.com/pretalx/pretalx/assets/2657547/0f51a106-f57a-46f0-894c-6162c8ba1ea3) 

<details>
<summary>SVG behind the fold</summary>

![profile](https://github.com/pretalx/pretalx/assets/2657547/0700e690-70d6-4fe2-8d5a-81768561ffa9)

</details>

With a performance penalty like this, I'm against using `django-table2` despite the obvious benefits in maintainable code, especially as larger pages seem to be hit disproportionately, and our review dashboard is an *unpaginated* page of all proposals. (Of course, once we have decent bulk editing, we can paginate or lazy-load there, it's not like we're out of solutions, but still).

I still want to see perf penalties on the big review dashboard, and then I'll decide what to do.

## Todo

- [ ] Decide if we want to use django-table2
- [ ] Migrate all lists to django-table2
    - [ ] review dashboard
    - [ ] questions list
    - [ ] feedback list
    - [ ] allfeedback list
    - [ ] taglist
    - [ ] speakerlist
    - [ ] informationlist
    - [ ] eventhistory
    - [ ] submissiontypelist
    - [ ] tracklist
    - [ ] accesscodelist
- [ ] Build generic filter form UI
- [ ] Build table builder / column selection UI
- [ ] Build exporter UI