### PR TITLE
Make sure proposal can keep track if submission is closed

### DIFF
--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.db.models import Count, Exists, OuterRef
+from django.db.models import Count, Exists, OuterRef, Q
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from django_scopes.forms import SafeModelChoiceField
@@ -72,9 +72,14 @@ class InfoForm(CfPFormMixin, RequestRequire, PublicContent, forms.ModelForm):
 
             access_code = self.access_code or getattr(instance, "access_code", None)
             if not access_code or not access_code.track:
-                self.fields["track"].queryset = self.event.tracks.filter(
+                filter = self.event.tracks.filter(
                     requires_access_code=False
                 )
+                # ensure current track selection can be preserved
+                if instance and instance.track:
+                    filter = self.event.tracks.filter(Q(requires_access_code=False)|Q(pk=instance.track.pk))
+
+                self.fields["track"].queryset = filter
             else:
                 self.fields["track"].queryset = self.event.tracks.filter(
                     pk=access_code.track.pk

--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -72,14 +72,14 @@ class InfoForm(CfPFormMixin, RequestRequire, PublicContent, forms.ModelForm):
 
             access_code = self.access_code or getattr(instance, "access_code", None)
             if not access_code or not access_code.track:
-                filter = self.event.tracks.filter(
+                track_filter = self.event.tracks.filter(
                     requires_access_code=False
                 )
                 # ensure current track selection can be preserved
                 if instance and instance.track and instance.track.requires_access_code:
-                    filter = self.event.tracks.filter(Q(requires_access_code=False)|Q(pk=instance.track.pk))
+                    track_filter = self.event.tracks.filter(Q(requires_access_code=False)|Q(pk=instance.track.pk))
 
-                self.fields["track"].queryset = filter
+                self.fields["track"].queryset = track_filter
             else:
                 self.fields["track"].queryset = self.event.tracks.filter(
                     pk=access_code.track.pk

--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -76,7 +76,7 @@ class InfoForm(CfPFormMixin, RequestRequire, PublicContent, forms.ModelForm):
                     requires_access_code=False
                 )
                 # ensure current track selection can be preserved
-                if instance and instance.track:
+                if instance and instance.track and instance.track.requires_access_code:
                     filter = self.event.tracks.filter(Q(requires_access_code=False)|Q(pk=instance.track.pk))
 
                 self.fields["track"].queryset = filter


### PR DESCRIPTION
We used the "require access token" to close certain tracks before the whole conference cfp was closed.

After this was done, submitters who wanted to update their proposal were unable to save it unless they also changed the track.

In any case, I think it is logical that you can keep the existing track if you edit a proposal.

## How has this been tested?

Manual test + deployed on live instance. Still need to add a unit test. If you have a suggestion of a similar test I'm willing to do so.

Existing unit tests fail, but that does not seem related.

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
