### PR TITLE
use speaker code consistently in warnings

### DIFF
--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -444,7 +444,7 @@ class Schedule(PretalxModel):
                         "type": "speaker",
                         "speaker": {
                             "name": speaker.get_display_name(),
-                            "id": speaker.pk,
+                            "code": speaker.code,
                         },
                         "message": str(
                             _(


### PR DESCRIPTION
It's a bit inconsistent to return the speaker code for an availability warning (line 422) and the id for an overlap warning.

somewhat related: it may be a good idea to use different types for both warnings.

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
