### PR TITLE
Allow longer urls

### DIFF
--- a/src/pretalx/submission/models/resource.py
+++ b/src/pretalx/submission/models/resource.py
@@ -27,7 +27,7 @@ class Resource(PretalxModel):
         null=True,
         blank=True,
     )
-    link = models.URLField(verbose_name=_("URL"), null=True, blank=True)
+    link = models.URLField(max_length=400, verbose_name=_("URL"), null=True, blank=True)
     description = models.CharField(
         null=True, blank=True, max_length=1000, verbose_name=_("Description")
     )


### PR DESCRIPTION
We currently allow titles up to 200 characters. External url's using the same title will fail in that case. I think we should up it a bit.

eg eg we wanted to link 
https://ftp.fau.de/fosdem/2024/ub4132/fosdem-2024-3152-node-reduction-through-artificial-intelligence-inferences-using-graphology-and-sigmajs-a-case-study-on-hypertextual-conversations-in-freight-train-graffiti-in-the-north-american-region-.mp4

and that fails, even though that admittedly long title is valid as a title in pretalx.

max_length defaults to 200.
https://docs.djangoproject.com/en/5.0/ref/models/fields/#urlfield