### PR TITLE
removed superfluous colons in German translations on speaker submission page

### DIFF
--- a/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
@@ -1068,8 +1068,8 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_submission_edit.html:65
 msgid "Speaker:"
 msgid_plural "Speakers:"
-msgstr[0] "Vortragende:"
-msgstr[1] "Vortragende:"
+msgstr[0] "Vortragende"
+msgstr[1] "Vortragende"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_edit.html:67
 msgid "Submitter"

--- a/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
@@ -1069,8 +1069,8 @@ msgstr ""
 #: pretalx/cfp/templates/cfp/event/user_submission_edit.html:65
 msgid "Speaker:"
 msgid_plural "Speakers:"
-msgstr[0] "Vortragende:"
-msgstr[1] "Vortragende:"
+msgstr[0] "Vortragende"
+msgstr[1] "Vortragende"
 
 #: pretalx/cfp/templates/cfp/event/user_submission_edit.html:67
 msgid "Submitter"


### PR DESCRIPTION
Currently, e.g. on https://fahrplan.eh21.easterhegg.eu/ submissions, there are double colons visible after "Vortragende" (::).

That's because both the translation and the code that creates the page contain colons.

Might be a wider issue: the msgid includes colons, too, but not all (other) translations do. E.g., one of the variations in the arabic translations includes colons, the rest doesn't.