### PR TITLE
feat (#1730): Allows scheduling of pending accepted/pending confirmed talks

### DIFF
--- a/src/pretalx/frontend/schedule-editor/src/components/Session.vue
+++ b/src/pretalx/frontend/schedule-editor/src/components/Session.vue
@@ -8,6 +8,9 @@
 	.info
 		.title {{ getLocalizedString(session.title) }}
 		.speakers(v-if="session.speakers") {{ session.speakers.map(s => s.name).join(', ') }}
+		.pending-line(v-if="session.state && session.state !== 'confirmed' && session.state !== 'accepted'") 
+			i.fa.fa-exclamation-circle
+			span {{ $t('Pending acceptance/confirmation') }}			
 		.bottom-info(v-if="!isBreak")
 			.track(v-if="session.track") {{ getLocalizedString(session.track.name) }}
 	.warning.no-print(v-if="warnings?.length")
@@ -64,7 +67,8 @@ export default {
 			if (this.isBreak) classes.push('isbreak')
 			else {
 				classes.push('istalk')
-				if (this.session.state !== "confirmed") classes.push('unconfirmed')
+				if (this.session.state !== "confirmed" && this.session.state !== "accepted") classes.push('pending') 
+				else if (this.session.state !== "confirmed") classes.push('unconfirmed')	
 			}
 			if (this.isDragged) classes.push('dragging')
 			if (this.isDragClone) classes.push('clone')
@@ -167,6 +171,12 @@ export default {
 				border-left: none
 				.title
 					color: var(--pretalx-clr-primary)
+	&.pending
+		.time-box
+			opacity: 0.5
+		.info
+			background-image: repeating-linear-gradient(-38deg, $clr-grey-100, $clr-grey-100 10px, $clr-white 10px, $clr-white 20px)
+			border-style: dashed dashed dashed none
 	.time-box
 		width: 69px
 		box-sizing: border-box
@@ -206,6 +216,9 @@ export default {
 				color: var(--track-color)
 				ellipsis()
 				margin-right: 4px
+		.pending-line
+			span
+				margin-left: 1em
 	.warning
 		position: absolute
 		top: 0

--- a/src/pretalx/orga/templates/orga/schedule/release.html
+++ b/src/pretalx/orga/templates/orga/schedule/release.html
@@ -53,7 +53,7 @@
                     {% plural %}
                         {{ count }} sessions are still <strong>unconfirmed</strong> and will not show up
                         on the public schedule.
-                    {% endblocktranslate %} <a href="{{ request.event.orga_urls.submissions }}?state=accepted">{% translate "See all unconfirmed sessions." %}</a></li>
+                    {% endblocktranslate %} <a href="{{ request.event.orga_urls.submissions }}?state=accepted&state=pending_state__accepted&state=pending_state__confirmed">{% translate "See all unconfirmed sessions." %}</a></li>
                 {% endif %}
                 {% if warnings.unscheduled %}
                     <li>{% blocktranslate trimmed count count=warnings.unscheduled %}

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -223,6 +223,12 @@ class SubmissionStateChange(SubmissionViewMixin, FormView):
         if pending:
             self.object.pending_state = self._target
             self.object.save()
+            if self.object.pending_state in [
+                SubmissionStates.ACCEPTED,
+                SubmissionStates.CONFIRMED,
+            ]:
+                # allow configureability of pending accepted/confirmed talks
+                self.object.update_talk_slots()
         else:
             method = getattr(self.object, SubmissionStates.method_names[self._target])
             method(person=self.request.user, force=force, orga=True)

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -420,7 +420,10 @@ class Submission(GenerateCode, PretalxModel):
         """
         from pretalx.schedule.models import TalkSlot
 
-        if self.state not in [SubmissionStates.ACCEPTED, SubmissionStates.CONFIRMED]:
+        # scheduling is only allowed (and therefore slots needed) for accepted and confirmed talks, or those pending counterparts
+        scheduling_allowed = self.state in [SubmissionStates.ACCEPTED, SubmissionStates.CONFIRMED] or self.pending_state in [SubmissionStates.ACCEPTED, SubmissionStates.CONFIRMED]
+
+        if not scheduling_allowed:
             TalkSlot.objects.filter(
                 submission=self, schedule=self.event.wip_schedule
             ).delete()


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is a draft implementation for #1730, and allows scheduling (by creating slots) for talks that are not finally accepted/confirmed, but only pending.

This allows internal time planning for organizers while not yet having to confirm the talk.
Public visibility is not changed.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->
Manually tested it by moving the states forward & backward
![Bildschirmfoto vom 2024-04-05 22-25-59](https://github.com/pretalx/pretalx/assets/1799951/9ecf8276-d128-487f-8129-1fd1919b2eae)
![Bildschirmfoto vom 2024-04-05 22-26-18](https://github.com/pretalx/pretalx/assets/1799951/368c94b7-18cb-43ed-a312-c9870dc712f1)


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.

## Open Points/RFC

This PR, at the current stage, is intended as an RFC. Open Points:
- in general, would you merge this feature? If yes, I'd clean/finish the PR.
- shall we add a config option to enable this behavior? On or off by default?
- I'm not so happy with the calls of `update_talk_slots()` - maybe this should be called at the end of every Submission Update to reduce complexity?

