### PR TITLE
Don't recommend `sudo` in a venv

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -54,7 +54,7 @@ do so automatically).
 If you are working on Ubuntu or Debian, we strongly recommend upgrading your pip and setuptools
 installation inside the virtual environment, otherwise some of the dependencies might fail::
 
-    sudo pip3 install -U pip setuptools wheel
+    pip3 install -U pip setuptools wheel
 
 
 Get a copy of the source code

--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -54,15 +54,15 @@ do so automatically).
 If you are working on Ubuntu or Debian, we strongly recommend upgrading your pip and setuptools
 installation inside the virtual environment, otherwise some of the dependencies might fail::
 
-    pip3 install -U pip setuptools wheel
+    (env)$ pip3 install -U pip setuptools wheel
 
 
 Get a copy of the source code
 -----------------------------
 You can clone our git repository::
 
-    git clone https://github.com/pretalx/pretalx.git
-    cd pretalx/
+    (env)$ git clone https://github.com/pretalx/pretalx.git
+    (env)$ cd pretalx/
 
 
 Working with the code


### PR DESCRIPTION
Using `sudo` in a venv is a) not necessary and b) potentially dangerous since it may cause system `pip3` to be used.

## How has this been tested?

I tested the fixed command, albeit on a Fedora machine.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
