### PR TITLE
overlap check: don't match with talk itself

### DIFF
--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -438,6 +438,7 @@ class Schedule(PretalxModel):
                     | models.Q(start__gt=talk.start, end__lt=talk.real_end)
                     | models.Q(start=talk.start, end=talk.real_end)
                 )
+                .exclude(pk=talk.pk)
                 .exists()
             )
             if overlaps:


### PR DESCRIPTION
after f222a57 for fixing #1494 every talk got a warning that it would overlap, but it was just "overlapping" with itself

## How has this been tested?
manual testing in the UI

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
