### PR TITLE
Show "Full name" label on account creation field

### DIFF
--- a/src/pretalx/person/forms.py
+++ b/src/pretalx/person/forms.py
@@ -42,7 +42,7 @@ class UserForm(CfPFormMixin, forms.Form):
         widget=forms.PasswordInput(attrs={"autocomplete": "current-password"}),
     )
     register_name = forms.CharField(
-        label=_("Name"),
+        label=_("Full name"),
         required=False,
         widget=forms.TextInput(attrs={"autocomplete": "name"}),
     )


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->

We have noticed several speakers creating accounts with only their first name, instead of their full name. This might due to being a non-native English speaker. Clearify the intention of the field. Also as apparently not everybody realizes that this name is how they get listed in the public speaker and session list.

<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #XX. It does so by …

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->

No, I don't have a development setup available for Pretalx

<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
