### PR TITLE
[Issue 1761] Add Proposal Title to Tab of Proposal Wizard

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/submission_step.html
+++ b/src/pretalx/cfp/templates/cfp/event/submission_step.html
@@ -1,9 +1,17 @@
 {% extends "cfp/event/submission_base.html" %}
 {% load bootstrap4 %}
+{% load compress %}
 {% load i18n %}
 {% load orga_edit_link %}
 {% load rich_text %}
 {% load rules %}
+{% load static %}
+
+{% block cfp_submission_header %}
+    {% compress js %}
+        <script defer src="{% static 'cfp/js/proposalTabTitles.js' %}"></script>
+    {% endcompress %}
+{% endblock %}
 
 {% block inner %}
     <div class="d-flex">

--- a/src/pretalx/static/cfp/js/proposalTabTitles.js
+++ b/src/pretalx/static/cfp/js/proposalTabTitles.js
@@ -4,7 +4,7 @@ function updateTitle(newTitle) {
     if (newTitle === "") {
         document.title = titleParts.join("::");
     } else {
-        document.title = `${newTitle}::${titleParts[1]}::${titleParts[2]}`;
+        document.title = `${newTitle} ::${titleParts[1]}::${titleParts[2]}`;
     }
 }
 

--- a/src/pretalx/static/cfp/js/proposalTabTitles.js
+++ b/src/pretalx/static/cfp/js/proposalTabTitles.js
@@ -2,9 +2,9 @@ const titleParts = document.title.split("::");
 
 function updateTitle(newTitle) {
     if (newTitle === "") {
-        document.title = titleParts.join(" :: ");
+        document.title = titleParts.join("::");
     } else {
-        document.title = `${newTitle} :: ${titleParts[1]} :: ${titleParts[2]}`;
+        document.title = `${newTitle}::${titleParts[1]}::${titleParts[2]}`;
     }
 }
 

--- a/src/pretalx/static/cfp/js/proposalTabTitles.js
+++ b/src/pretalx/static/cfp/js/proposalTabTitles.js
@@ -1,0 +1,15 @@
+// Parse and store title from the server's render since it may have been translated.
+let defaultTitleElements = document.title.split('::');
+
+if (defaultTitleElements.length !== 3) {
+  console.error('Could not parse site title while adding proposal title change listener.');
+} else {
+  document.getElementById('id_title').addEventListener('change', (event) => {
+    let newTitle = event.target.value;
+    if (newTitle === '') {
+      document.title = defaultTitleElements.join(' :: ');
+    } else {
+      document.title = `${newTitle} :: ${defaultTitleElements[1]} :: ${defaultTitleElements[2]}`;
+    }
+  });
+}

--- a/src/pretalx/static/cfp/js/proposalTabTitles.js
+++ b/src/pretalx/static/cfp/js/proposalTabTitles.js
@@ -1,15 +1,23 @@
-// Parse and store title from the server's render since it may have been translated.
-const defaultTitleElements = document.title.split('::');
+const titleParts = document.title.split("::")
 
-if (defaultTitleElements.length !== 3) {
-  console.error('Could not parse site title while adding proposal title change listener.');
-} else {
-  document.getElementById('id_title').addEventListener('change', (event) => {
-    const newTitle = event.target.value;
-    if (newTitle === '') {
-      document.title = defaultTitleElements.join(' :: ');
-    } else {
-      document.title = `${newTitle} :: ${defaultTitleElements[1]} :: ${defaultTitleElements[2]}`;
+document.addEventListener("DOMContentLoaded", () => {
+    const titleInput = document.getElementById("id_title").value
+    if (titleInput !== "") {
+        document.title = `${titleInput} :: ${titleParts[1]} :: ${titleParts[2]}`
     }
-  });
+})
+
+if (titleParts.length !== 3) {
+    console.error(
+        "Could not parse site title while adding proposal title change listener.",
+    )
+} else {
+    document.getElementById("id_title").addEventListener("change", (event) => {
+        const newTitle = event.target.value
+        if (newTitle === "") {
+            document.title = titleParts.join(" :: ")
+        } else {
+            document.title = `${newTitle} :: ${titleParts[1]} :: ${titleParts[2]}`
+        }
+    })
 }

--- a/src/pretalx/static/cfp/js/proposalTabTitles.js
+++ b/src/pretalx/static/cfp/js/proposalTabTitles.js
@@ -1,23 +1,30 @@
-const titleParts = document.title.split("::")
+const titleParts = document.title.split("::");
 
-document.addEventListener("DOMContentLoaded", () => {
-    const titleInput = document.getElementById("id_title").value
-    if (titleInput !== "") {
-        document.title = `${titleInput} :: ${titleParts[1]} :: ${titleParts[2]}`
+function updateTitle(newTitle) {
+    if (newTitle === "") {
+        document.title = titleParts.join(" :: ");
+    } else {
+        document.title = `${newTitle} :: ${titleParts[1]} :: ${titleParts[2]}`;
     }
-})
+}
+
+function checkForTitle() {
+    const titleInput = document.getElementById("id_title").value;
+    updateTitle(titleInput);
+}
+
+function titleChangeHandler(event) {
+    const newTitle = event.target.value;
+    updateTitle(newTitle);
+}
 
 if (titleParts.length !== 3) {
     console.error(
-        "Could not parse site title while adding proposal title change listener.",
-    )
+        "Could not parse site title while adding proposal title change listener."
+    );
 } else {
-    document.getElementById("id_title").addEventListener("change", (event) => {
-        const newTitle = event.target.value
-        if (newTitle === "") {
-            document.title = titleParts.join(" :: ")
-        } else {
-            document.title = `${newTitle} :: ${titleParts[1]} :: ${titleParts[2]}`
-        }
-    })
+    document.addEventListener("DOMContentLoaded", checkForTitle);
+    document
+        .getElementById("id_title")
+        .addEventListener("change", titleChangeHandler);
 }

--- a/src/pretalx/static/cfp/js/proposalTabTitles.js
+++ b/src/pretalx/static/cfp/js/proposalTabTitles.js
@@ -1,11 +1,11 @@
 // Parse and store title from the server's render since it may have been translated.
-let defaultTitleElements = document.title.split('::');
+const defaultTitleElements = document.title.split('::');
 
 if (defaultTitleElements.length !== 3) {
   console.error('Could not parse site title while adding proposal title change listener.');
 } else {
   document.getElementById('id_title').addEventListener('change', (event) => {
-    let newTitle = event.target.value;
+    const newTitle = event.target.value;
     if (newTitle === '') {
       document.title = defaultTitleElements.join(' :: ');
     } else {


### PR DESCRIPTION
## Summary

This change was requested in #1761. This allows the proposal title entered into the proposal wizard to become the title of the page. That title is then populated in the browser tab to make identification of multiple proposal submissions easier across the browser.

## Changes

- Adds the `proposalTabTitles.js` script to the `submission_step.html` template.
  - The script takes the server rendered title and breaks it into its component pieces in order to save the translated "create proposal" prompt in the event the user deletes their title from the wizard and the default title needs to be restored.
  - When navigating to the proposal wizard it will quickly check for a proposal title that was placed into the wizard by the user session (in the case a user advances to the "Account" step, then navigates back to the "General" step).

## Feature Flow

1. User enters the proposal title into the proposal wizard and it becomes the title of the page and is populated in the browser tab.
![Screenshot 2024-05-22 064351](https://github.com/pretalx/pretalx/assets/43080273/251ccfe7-f18c-4a94-9210-60aa6fdb20f9)

2. If the user erases the proposal title from the proposal wizard, returning the original translated title prompt to the page and browser tab.
![Screenshot 2024-05-22 064409](https://github.com/pretalx/pretalx/assets/43080273/63363bf9-5311-4fde-b764-20e981613394)

3. User advances to the "Account" step, from then on the proposal title is no longer in the browser tab. (Due to limitation of the current approach of this PR)
![Screenshot 2024-05-22 064448](https://github.com/pretalx/pretalx/assets/43080273/ee4cc1a7-82f3-48ee-a57c-ee0005ae2ba5)

4. User navigates back to the "General" step where the title of the page again matches the proposal title.
![Screenshot 2024-05-22 064351](https://github.com/pretalx/pretalx/assets/43080273/251ccfe7-f18c-4a94-9210-60aa6fdb20f9)

### Thoughts

With the solution in this PR, the proposal title is only visible in the browser tab while the user is working on the "General" step of their proposal. I'm simply pulling the value from the input element, which is not present during the other steps. I'm fairly novice with Django but from what I was reading it looks like the form data is saved in the user's session, so if we want to have the title present across all of the proposal wizard steps we might want to look into pulling that info from the session. I figured I'd cut this PR just in case I'm moving out of scope, I'd be happy to look into getting the proposal title across all steps of the wizard if desired.

## How has this been tested?

This change was manually tested in the UI. I didn't happen to see frontend tests in the repo, if I missed them I'm happy to write tests for this feature.

## Checklist

- [ ] I have added tests to cover my changes. (Happy to add if there are frontend tests)
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
