### PR TITLE
Add missing migration dependency on submission.0061_cfp_settings for event.0034_fix_language_codes

### DIFF
--- a/src/pretalx/event/migrations/0034_fix_language_codes.py
+++ b/src/pretalx/event/migrations/0034_fix_language_codes.py
@@ -129,6 +129,7 @@ class Migration(migrations.Migration):
         ("person", "0014_speakerinformation"),
         ("schedule", "0013_auto_20191107_1748"),
         ("submission", "0052_auto_20201010_1307"),
+        ("submission", "0061_cfp_settings"),
         ("mail", "0009_queuedmail_locale"),
     ]
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
This PR fixes migration from relatively old pretalx versions, which fails due to a missing dependency (or alternatively, an incorrect check for existence of a class attribute).

## How has this been tested?

This was tested by migrating an old Pretalx instance to a newer one. The migration would fail with the following error:
```
  File "pretalx/event/migrations/0034_fix_language_codes.py", line 98, in fix_language_codes
    if not cfp.settings or "flow" not in cfp.settings or not cfp.settings["flow"]:
AttributeError: 'CfP' object has no attribute 'settings'
```

Code review / inspection also reveals the issue.

This could alternatively fixed by using code such as
```
    if not hasattr(cfp, "settings") or "flow" not in cfp.settings or not cfp.settings["flow"]:
```
in `pretalx/event/migrations/0034_fix_language_codes.py`.


## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.

Tests and documentation changes appear to not be applicable to this bug fix. I'm not certain of the preferred format of `doc/changelog.rst`.