### PR TITLE
Removes text area max height

### DIFF
--- a/src/pretalx/static/common/scss/_forms.scss
+++ b/src/pretalx/static/common/scss/_forms.scss
@@ -265,9 +265,7 @@ table .action-column {
 }
 
 .markdown-wrapper {
-  max-height: 160px;
   textarea {
-    max-height: 160px;
     border-top: none;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
@@ -276,7 +274,6 @@ table .action-column {
     border: 1px solid #ced4da;
     border-top: none;
     min-height: 160px;
-    max-height: 160px;
     padding: 8px;
     overflow-y: auto;
     width: auto;


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
When overviewing submissions in edit, the max height imposed on the text creates an annoying user experience, requiring to view the submission through a small window that needs to be scrolled.

This solves the problem by removing that restriction.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
This was tested manually through editing CSS in browser.

<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->
![image](https://github.com/user-attachments/assets/97fbcbdd-3258-4ac6-992d-74380d9c7fe7)

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
