### PR TITLE
Update installation.rst

### DIFF
--- a/doc/administrator/installation.rst
+++ b/doc/administrator/installation.rst
@@ -158,6 +158,7 @@ pull in the appropriate dependencies. Please note that you should also use
 We also need to create a data directory::
 
     $ mkdir -p /var/pretalx/data/media
+    $ chmod 775 -R /var/pretalx
 
 We compile static files and translation data and create the database structure::
 


### PR DESCRIPTION
Add command to change permissions /var/pretalx to enable reverse proxy read directory.

When a reverse proxy is used, such as nginx, it must be allowed to read the static files and return them in the requests. I have validated this configuration in two productive deployments.

- [ ] I have added tests to cover my changes.
- [X ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
