### PR TITLE
django settings variable can't start with _

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`common` _VITE_IGNORE -> VITE_IGNORE: django settings variable can't start with _.
 - :feature:`api` The submission API now has a filter for the ``is_featured`` field.
 - :feature:`cfp,1761` In the CfP submission multi-step form, the tab title now reflects the proposal title, to make it easier to work on multiple proposal submissions at the same time.
 - :bug:`orga:speaker,1768` When filtering the speaker list by only accepted/confirmed speakers, the listed proposal count would be incorrect (inflated).

--- a/src/pretalx/common/management/commands/rebuild.py
+++ b/src/pretalx/common/management/commands/rebuild.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         call_command(
             "collectstatic", verbosity=silent, interactive=False, clear=options["clear"]
         )
-        with override_settings(_VITE_IGNORE=True):
+        with override_settings(VITE_IGNORE=True):
             frontend_dir = (
                 Path(__file__).parent.parent.parent.parent / "frontend/schedule-editor/"
             )

--- a/src/pretalx/common/settings/test_settings.py
+++ b/src/pretalx/common/settings/test_settings.py
@@ -42,7 +42,7 @@ TEMPLATES[0]["OPTIONS"]["loaders"] = (  # NOQA
 
 DEBUG = False
 VITE_DEV_MODE = True
-_VITE_IGNORE = False
+VITE_IGNORE = False
 DEBUG_PROPAGATE_EXCEPTIONS = True
 
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]

--- a/src/pretalx/common/templatetags/vite.py
+++ b/src/pretalx/common/templatetags/vite.py
@@ -13,7 +13,7 @@ MANIFEST_PATH = settings.STATIC_ROOT / "pretalx-manifest.json"
 
 # We're building the manifest if we don't have a dev server running AND if we're
 # not currently running `rebuild` (which creates the manifest in the first place).
-if not settings.VITE_DEV_MODE and not settings._VITE_IGNORE:
+if not settings.VITE_DEV_MODE and not settings.VITE_IGNORE:
     try:
         with open(MANIFEST_PATH) as fp:
             _MANIFEST = json.load(fp)

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -585,7 +585,7 @@ STORAGES = {
 VITE_DEV_SERVER_PORT = 8080
 VITE_DEV_SERVER = f"http://localhost:{VITE_DEV_SERVER_PORT}"
 VITE_DEV_MODE = DEBUG
-_VITE_IGNORE = False  # Used to ignore `collectstatic`/`rebuild`
+VITE_IGNORE = False  # Used to ignore `collectstatic`/`rebuild`
 
 
 ## EXTERNAL APP SETTINGS


### PR DESCRIPTION
It's not possible to get `settings._VITE_IGNORE` variable.
It raises error:
```
    102     self._setup(name)
    103     _wrapped = self._wrapped
--> 104 val = getattr(_wrapped, name)
....

AttributeError: 'Settings' object has no attribute '_VITE_IGNORE'
```

Can be reproduced by:
```
$ python manage.py shell
$ from django.conf import settings
$ settings._VITE_IGNORE
```
This happens due to fact that django [uses dir()](https://github.com/django/django/blob/main/django/conf/__init__.py#L176) function to merge project_settings with global_settings. And dir() does not return non public attributes.

This PR closes/references issue #XX. It does so by …

## Checklist
- [x] My change is listed in the ``doc/changelog.rst``.
