### PR TITLE
Translate for portuguese py229 and py232

### DIFF
--- a/src/pretalx/locale/pt_BR/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/pt_BR/LC_MESSAGES/django.po
@@ -219,12 +219,16 @@ msgid ""
 "Your favourites could not be loaded from the server, but they are stored "
 "locally in your browser."
 msgstr ""
+"Suas favoritas não puderam ser carregadas do servidor, mas elas estão "
+"armazenadas localmente no seu navegador."
 
 #: pretalx/agenda/views/schedule.py:232
 msgid ""
 "Your favourites could not be saved on the server, but they are stored "
 "locally in your browser."
 msgstr ""
+"Suas favoritas não puderam ser salvas no servidor, mas elas estão "
+"armazenadas localmente no seu navegador."
 
 #: pretalx/agenda/views/talk.py:119
 #, python-brace-format


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
This change is required to provide proper translation for Brazilian Portuguese. The previous implementation had only English messages, which were not accessible to Brazilian Portuguese-speaking users. This solve the message translate for portuguese.

<!--- If it fixes an open issue, please link to the issue here. -->
My changes are not associated with a bug (it is a problem but not a bug), but with the lack of text for translation into Portuguese.

This PR closes/references issue #XX. It does so by …

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
