### PR TITLE
Including tags in schedule.json response

### DIFF
--- a/src/pretalx/schedule/models/schedule.py
+++ b/src/pretalx/schedule/models/schedule.py
@@ -673,6 +673,7 @@ class Schedule(PretalxModel):
                         "updated": talk.updated.isoformat(),
                         "state": talk.submission.state if all_talks else None,
                         "do_not_record": talk.submission.do_not_record,
+                        "tags": talk.submission.get_tag(),
                     }
                 )
             else:

--- a/src/pretalx/submission/models/submission.py
+++ b/src/pretalx/submission/models/submission.py
@@ -334,6 +334,12 @@ class Submission(GenerateCode, PretalxModel):
             return self.submission_type.default_duration
         return self.duration
 
+    def get_tag(self):
+        tags = []
+        for tag in self.tags.all():
+            tags.append({"id": tag.id, "tag": tag.tag, "color": tag.color})
+        return tags
+
     def update_duration(self):
         """Apply the submission's duration to its currently scheduled.
 


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
This change is about including tags in schedule.json data response, in order to showing on calendar and session view.
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
