### PR TITLE
Add quotes around the schedule ETag value

### DIFF
--- a/src/pretalx/agenda/views/schedule.py
+++ b/src/pretalx/agenda/views/schedule.py
@@ -122,7 +122,7 @@ class ExporterView(EventPermissionRequired, ScheduleMixin, TemplateView):
             raise Http404()
         if request.headers.get("If-None-Match") == etag:
             return HttpResponseNotModified()
-        headers = {"ETag": etag}
+        headers = {"ETag": f'"{etag}"'}
         if file_type not in ("application/json", "text/xml"):
             headers["Content-Disposition"] = (
                 f'attachment; filename="{safe_filename(file_name)}"'

--- a/src/tests/agenda/test_agenda_schedule_export.py
+++ b/src/tests/agenda/test_agenda_schedule_export.py
@@ -92,7 +92,7 @@ def test_schedule_frab_xml_export(
                 "agenda:export.schedule.xml",
                 kwargs={"event": slot.submission.event.slug},
             ),
-            HTTP_IF_NONE_MATCH=response["ETag"],
+            HTTP_IF_NONE_MATCH=response["ETag"].strip('"'),
             follow=True,
         )
     assert response.status_code == 304


### PR DESCRIPTION
Fixes the value of the ETag field, that is currently being stripped by nginx, because it considers its value invalid per RFC2616¹, as it is missing the required quotation marks.

See also https://forum.nginx.org/read.php?2,286645,286647.

[1] https://datatracker.ietf.org/doc/html/rfc2616#section-14.19

cc @johnjohndoe

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->
Tested in production on talks.mrmcd.net.

```
# curl --unix-socket /run/pretalx/pretalx.sock http://talks.mrmcd.net/2024/schedule/export/schedule.xml -I
HTTP/1.1 200 OK
Server: gunicorn
[...]
ETag: "08ed860b1ef6cd0578399766e8794c8fbaf02c40"

$ curl https://talks.mrmcd.net/2024/schedule/export/schedule.xml -I
HTTP/2 200 
server: nginx
[...]
etag: "08ed860b1ef6cd0578399766e8794c8fbaf02c40"

$ curl https://talks.mrmcd.net/2024/schedule/export/schedule.xml -I --compressed
HTTP/2 200 
server: nginx
[...]
etag: W/"08ed860b1ef6cd0578399766e8794c8fbaf02c40"
```

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
