### PR TITLE
submission_state_change is also sent on initial submitssion

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`schedule,1883` The event `submission_state_change` is also sent when a speaker first submits a proposal.
 - :bug:`schedule,1874` The calendar parts of the public schedule (day of week, month) were always in English, even if another language was selected.
 - :bug:`orga` Dragging and dropping questions and other elements to change their order was broken in Google Chrome.
 - :bug:`orga:schedule` The HTML export did not work and exported only 404 pages.


### PR DESCRIPTION
This PR closes/references issue #1883. It does so by sending the appropriate event even
before notifications are sent out to the submitting speaker.

## How has this been tested?
Thest have been made with the pretalx-rt plugin which is under development.

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
