### PR TITLE
Add html and forms signals for plugin integration

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`dev` Plugins can now inject additional form elements in the organisers area with the ``pretalx.person.signals.speaker_forms``, ``pretalx.mail.signals.mail_forms`` and ``pretalx.submission.signals.submission_forms`` signals.
 - :feature:`dev` Plugins can now inject HTML content into pages in the organisers area with the ``pretalx.person.signals.speaker_form_html``, ``pretalx.mail.signals.mail_form_html``, ``pretalx.submission.signals.submission_form_html`` and ``pretalx.submission.signals.submission_form_link`` signals.
 - :feature:`orga:submission` Organisers and reviewers can now leave comments on proposals. Comments are shown in chronological order, and users can of course comment multiple times, rather than leaving a single review.
 - :feature:`schedule` When you embed the pretalx widget on an external page, clicking on session links will open the session details (or speaker details) in a popup on the same page, instead of directing attendees to the pretalx schedule page.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,8 +3,8 @@
 Release Notes
 =============
 
-- :feature:`dev` Plugins can now inject additional form elements in the organisers area with the ``pretalx.person.signals.speaker_forms``, ``pretalx.mail.signals.mail_forms`` and ``pretalx.submission.signals.submission_forms`` signals.
-- :feature:`dev` Plugins can now inject HTML content into pages in the organisers area with the ``pretalx.person.signals.speaker_form_html``, ``pretalx.mail.signals.mail_form_html``, ``pretalx.submission.signals.submission_form_html`` and ``pretalx.submission.signals.submission_form_link`` signals.
+- :feature:`dev` Plugins can now inject additional form elements in the organisers area with the ``pretalx.person.signals.speaker_forms``, ``pretalx.mail.signals.mail_forms``, ``pretalx.submission.signals.review_forms`` and ``pretalx.submission.signals.submission_forms`` signals.
+- :feature:`dev` Plugins can now inject HTML content into pages in the organisers area with the ``pretalx.person.signals.speaker_form_html``, ``pretalx.mail.signals.mail_form_html``, ``pretalx.submission.signals.review_form_html``, ``pretalx.submission.signals.submission_form_html`` and ``pretalx.submission.signals.submission_form_link`` signals.
 - :feature:`orga:submission` Organisers and reviewers can now leave comments on proposals. Comments are shown in chronological order, and users can of course comment multiple times, rather than leaving a single review.
 - :feature:`schedule` When you embed the pretalx widget on an external page, clicking on session links will open the session details (or speaker details) in a popup on the same page, instead of directing attendees to the pretalx schedule page.
 - :feature:`schedule` Organisers can now configure additional links to show in the top menu next to "Schedule", "Sessions", "Speakers", handy for links back to the conference website, streams, etc.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`dev` Plugins can now inject HTML content into pages in the organisers area with the ``pretalx.person.signals.speaker_form_html``, ``pretalx.mail.signals.mail_form_html``, ``pretalx.submission.signals.submission_form_html`` and ``pretalx.submission.signals.submission_form_link`` signals.
 - :feature:`orga:submission` Organisers and reviewers can now leave comments on proposals. Comments are shown in chronological order, and users can of course comment multiple times, rather than leaving a single review.
 - :feature:`schedule` When you embed the pretalx widget on an external page, clicking on session links will open the session details (or speaker details) in a popup on the same page, instead of directing attendees to the pretalx schedule page.
 - :feature:`schedule` Organisers can now configure additional links to show in the top menu next to "Schedule", "Sessions", "Speakers", handy for links back to the conference website, streams, etc.

--- a/doc/developer/plugins/general.rst
+++ b/doc/developer/plugins/general.rst
@@ -14,7 +14,7 @@ Core
 
 .. automodule:: pretalx.common.signals
    :members: periodic_task, register_locales
-
+  
 .. automodule:: pretalx.submission.signals
    :members: submission_state_change
 
@@ -41,6 +41,15 @@ Organiser area
 .. automodule:: pretalx.common.signals
    :no-index:
    :members: activitylog_display, activitylog_object_link
+
+.. automodule:: pretalx.mail.signals
+   :members: mail_form_html, mail_forms
+
+.. automodule:: pretalx.person.signals
+   :members: speaker_form_html, speaker_forms
+   
+.. automodule:: pretalx.submission.signals
+   :members: submission_form_html, submission_form_link, submission_forms
 
 Display
 -------

--- a/doc/developer/plugins/general.rst
+++ b/doc/developer/plugins/general.rst
@@ -49,7 +49,7 @@ Organiser area
    :members: speaker_form_html, speaker_forms
    
 .. automodule:: pretalx.submission.signals
-   :members: submission_form_html, submission_form_link, submission_forms
+   :members: review_forms, review_form_html, submission_form_html, submission_form_link, submission_forms
 
 Display
 -------

--- a/src/pretalx/mail/signals.py
+++ b/src/pretalx/mail/signals.py
@@ -37,3 +37,14 @@ As with all event-plugin signals, the ``sender`` keyword argument will
 contain the event. Additionally, the ``mail`` keyword argument contains
 the ``QueuedMail`` instance itself.
 """
+
+mail_form_html = EventPluginSignal()
+"""
+This signal is sent out to display additional information related to emails in
+the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``mail`` which is currently displayed.
+The receivers are expected to return HTML.
+"""

--- a/src/pretalx/mail/signals.py
+++ b/src/pretalx/mail/signals.py
@@ -48,3 +48,14 @@ event. Additionally, the signal will be called with the ``request`` it is
 processing, and the ``mail`` which is currently displayed.
 The receivers are expected to return HTML.
 """
+
+mail_forms = EventPluginSignal()
+"""
+This signal is sent out to inject additional form fields on the submission
+pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``mail`` which is currently displayed.
+The receivers are expected to return one or more forms.
+"""

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -19,6 +19,9 @@
 
         {% if not form.read_only %}
             {{ form }}
+            {% for plugin_form in plugin_forms %}
+                {{ plugin_form }}
+            {% endfor %}
         {% else %}
             <div class="d-flex flex-column">
                 <div class="row form-group">
@@ -79,6 +82,17 @@
                     </div>
                     <div class="col col-md-9">{{ form.instance.text|rich_text }}</div>
                 </div>
+
+                {% for plugin_form in plugin_forms %}
+                    {% for field in plugin_form %}
+                    <div class="row form-group">
+                        <div class="col col-md-3 flip text-right font-weight-bold">
+                            <div class="font-weight-bold">{{ field.label }}</div>
+                        </div>
+                        <div class="col col-md-9">{{ field.value }}</div>
+                    </div>
+                    {% endfor %}
+                {% endfor %}
             </div>
         {% endif %}
 

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -1,4 +1,5 @@
 {% extends "orga/mails/base.html" %}
+{% load html_signal %}
 {% load i18n %}
 {% load rich_text %}
 
@@ -98,6 +99,7 @@
                 {% endif %}
             {% endif %}
         </div>
+        {% html_signal "pretalx.mail.signals.mail_form_html" sender=request.event request=request mail=form.instance %}
     </form>
 
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -84,14 +84,7 @@
                 </div>
 
                 {% for plugin_form in plugin_forms %}
-                    {% for field in plugin_form %}
-                    <div class="row form-group">
-                        <div class="col col-md-3 flip text-right font-weight-bold">
-                            <div class="font-weight-bold">{{ field.label }}</div>
-                        </div>
-                        <div class="col col-md-9">{{ field.value }}</div>
-                    </div>
-                    {% endfor %}
+                    {{ plugin_form }}
                 {% endfor %}
             </div>
         {% endif %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -1,6 +1,7 @@
 {% extends "orga/base.html" %}
 
 {% load compress %}
+{% load html_signal %}
 {% load i18n %}
 {% load rules %}
 {% load static %}
@@ -91,6 +92,7 @@
 
         {% include "orga/includes/submit_row.html" %}
 
+        {% html_signal "pretalx.person.signals.speaker_form_html" sender=request.event request=request user=form.instance.user %}
     </form>
 
     <h3>{% translate "Emails" %}</h3>

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -90,6 +90,10 @@
 
         {{ questions_form }}
 
+        {% for plugin_form in plugin_forms %}
+            {{ plugin_form }}
+        {% endfor %}
+
         {% include "orga/includes/submit_row.html" %}
 
         {% html_signal "pretalx.person.signals.speaker_form_html" sender=request.event request=request user=form.instance.user %}

--- a/src/pretalx/orga/templates/orga/submission/base.html
+++ b/src/pretalx/orga/templates/orga/submission/base.html
@@ -2,6 +2,7 @@
 
 {% load compress %}
 {% load event_tags %}
+{% load html_signal %}
 {% load i18n %}
 {% load rules %}
 {% load static %}
@@ -123,6 +124,7 @@
                                     {% translate "Secret public link" %}
                                 </a>
                             {% endif %}
+                            {% html_signal "pretalx.submission.signals.submission_form_link" sender=request.event request=request submission=submission %}
                         </div>
                     </details>
                 {% endif %}

--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -89,7 +89,9 @@
                 <div><legend id="custom">{{ phrases.cfp.custom_fields }}</legend></div>
                 {{ questions_form }}
             {% endif %}
-
+            {% for plugin_form in plugin_forms %}
+                {{ plugin_form }}
+            {% endfor %}
             {% if not form.read_only %}
                 <div class="submit-group panel">
                     <span></span>

--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -3,6 +3,7 @@
 {% load compress %}
 {% load filesize %}
 {% load formset_tags %}
+{% load html_signal %}
 {% load i18n %}
 {% load static %}
 {% load rules %}
@@ -100,6 +101,7 @@
                     </span>
                 </div>
             {% endif %}
+            {% html_signal "pretalx.submission.signals.submission_form_html" sender=request.event request=request submission=submission %}
         </fieldset></form>
 
     <span id="vars" remoteUrl="{{ request.event.organiser.orga_urls.user_search }}"></span>

--- a/src/pretalx/orga/templates/orga/submission/review.html
+++ b/src/pretalx/orga/templates/orga/submission/review.html
@@ -1,6 +1,7 @@
 {% extends "orga/submission/base.html" %}
 
 {% load compress %}
+{% load html_signal %}
 {% load i18n %}
 {% load rich_text %}
 {% load rules %}
@@ -134,7 +135,7 @@
                 {% for speaker in profiles %}
                     <div class="form-group row">
                         <label class="col-md-3 col-form-label">
-                            {% translate "Biography" %}{% if profiles.count > 1 %}: {% include "orga/includes/user_name.html" with user=speaker.user lightbox=True %}{% endif %}
+                            {% translate "Biography" %}{% if profiles|length > 1 %}: {% include "orga/includes/user_name.html" with user=speaker.user lightbox=True %}{% endif %}
                         </label>
                         <div class="col-md-9 mt-2 markdown-mt-0">
                             {% if request.event.cfp.request_biography %}
@@ -154,6 +155,9 @@
                     </div>
                 {% endfor %}
             {% endif %}
+            {% for plugin_form in plugin_forms %}
+                {{ plugin_form }}
+            {% endfor %}
 
             {% if not read_only %}
                 {% if tags_form %}{{ tags_form }}{% endif %}
@@ -234,6 +238,7 @@
                     </div>
                 </div>
             {% endif %}
+            {% html_signal "pretalx.submission.signals.review_form_html" sender=request.event request=request submission=submission %}
         </form>
     {% endif %}  {# endif: request.user in submission.speakers #}
 {% endblock submission_content %}

--- a/src/pretalx/person/signals.py
+++ b/src/pretalx/person/signals.py
@@ -1,6 +1,17 @@
 from django.dispatch import receiver
 
-from pretalx.common.signals import register_data_exporters
+from pretalx.common.signals import EventPluginSignal, register_data_exporters
+
+speaker_form_html = EventPluginSignal()
+"""
+This signal is sent out to display additional information on the speaker
+pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``person`` which is currently displayed.
+The receivers are expected to return HTML.
+"""
 
 
 @receiver(register_data_exporters, dispatch_uid="exporter_builtin_csv_speaker")

--- a/src/pretalx/person/signals.py
+++ b/src/pretalx/person/signals.py
@@ -14,6 +14,18 @@ The receivers are expected to return HTML.
 """
 
 
+speaker_forms = EventPluginSignal()
+"""
+This signal is sent out to inject additional form fields on the submission
+pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``person`` which is currently displayed.
+The receivers are expected to return one or more forms.
+"""
+
+
 @receiver(register_data_exporters, dispatch_uid="exporter_builtin_csv_speaker")
 def register_speaker_csv_exporter(sender, **kwargs):
     from pretalx.person.exporters import CSVSpeakerExporter

--- a/src/pretalx/submission/signals.py
+++ b/src/pretalx/submission/signals.py
@@ -24,3 +24,14 @@ event. Additionally, the signal will be called with the ``request`` it is
 processing, and the ``submission`` which is currently displayed.
 The receivers are expected to return HTML.
 """
+
+submission_form_link = EventPluginSignal()
+"""
+This signal is sent out to display additional information on the submission
+pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``submission`` which is currently displayed.
+The receivers are expected to return HTML.
+"""

--- a/src/pretalx/submission/signals.py
+++ b/src/pretalx/submission/signals.py
@@ -13,3 +13,14 @@ and ``user`` (which may be ``None``).
 When the submission is created or submitted from a draft state, ``old_state`` will be
 ``None``.
 """
+
+submission_form_html = EventPluginSignal()
+"""
+This signal is sent out to display additional information on the submission
+pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``submission`` which is currently displayed.
+The receivers are expected to return HTML.
+"""

--- a/src/pretalx/submission/signals.py
+++ b/src/pretalx/submission/signals.py
@@ -46,3 +46,25 @@ event. Additionally, the signal will be called with the ``request`` it is
 processing, and the ``submission`` which is currently displayed.
 The receivers are expected to return one or more forms.
 """
+
+review_form_html = EventPluginSignal()
+"""
+This signal is sent out to display additional information on the review tab
+of the submission pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``submission`` which is currently displayed.
+The receivers are expected to return HTML.
+"""
+
+review_forms = EventPluginSignal()
+"""
+This signal is sent out to inject additional form fields on the review tab
+of the submission pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``submission`` which is currently displayed.
+The receivers are expected to return one or more forms.
+"""

--- a/src/pretalx/submission/signals.py
+++ b/src/pretalx/submission/signals.py
@@ -35,3 +35,14 @@ event. Additionally, the signal will be called with the ``request`` it is
 processing, and the ``submission`` which is currently displayed.
 The receivers are expected to return HTML.
 """
+
+submission_forms = EventPluginSignal()
+"""
+This signal is sent out to inject additional form fields on the submission
+pages in the internal organiser area.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing, and the ``submission`` which is currently displayed.
+The receivers are expected to return one or more forms.
+"""


### PR DESCRIPTION
This is an initial draft / a proposal:
I'd like to add some signals to be able to integrate information related to emails and submissions from a plugin.

I'd no longer call this a draft now but rather a proposal. ;-)

- The number of html_signals has now been reduced to one per domain (speaker, submission, mail). - Well actually there is one additional hook for a link where I'd love to see what people like to use more during the 38c3 before I decide if I'd better put a link to external systems within the form data or in the corner where other links live.
- The mail badges have been removed because of the performance impact of that approach.
- Additionally, form signals have been included for the same domain to allow extending the form including the possibility to edit data provided by plugins.

Is this going into the right direction? I'd really love to merge the changes in the plugins for RT, Frab, Zammad and Rocket which are in preparation as well...