### PR TITLE
Add big button for organiser area if allowed

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/index.html
+++ b/src/pretalx/cfp/templates/cfp/event/index.html
@@ -31,6 +31,11 @@
                     {{ phrases.cfp.go_to_cfp }}
                 </a>
             {% endif %}
+          {% if can_see_orga_area %}
+            <a class="btn btn-info btn-lg btn-block" href="{{ request.event.orga_urls.base }}">
+                    {% translate "Go To Organiser Area" %}
+            </a>
+          {% endif %}
         </div>
     {% endwith %}
 {% endblock content %}


### PR DESCRIPTION
As an organiser, there is usually little point in going to the CfP, and it it is not very clear you can go to the organiser area by clicking your username(I've had people asking it). This PR proposes to a big button, which is convenient.

## How has this been tested?
- we used this last year for our event
![image](https://github.com/user-attachments/assets/37c75027-9939-430f-a6b1-3935381fb779)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
