### PR TITLE
Correctly show number of submissions per track

### DIFF
--- a/src/pretalx/submission/forms/submission.py
+++ b/src/pretalx/submission/forms/submission.py
@@ -332,7 +332,17 @@ class SubmissionFilterForm(forms.Form):
             self.fields.pop("submission_type", None)
         if len(tracks) > 1:
             self.fields["track"].queryset = tracks.annotate(
-                count=Count("submissions", distinct=True, filter=Q(event=event))
+                count=Count(
+                    "submissions",
+                    distinct=True,
+                    filter=Q(event=event)
+                    & ~Q(
+                        submissions__state__in=[
+                            SubmissionStates.DELETED,
+                            SubmissionStates.DRAFT,
+                        ]
+                    ),
+                )
             ).order_by("-count")
         else:
             self.fields.pop("track", None)


### PR DESCRIPTION
Closes #1903 
Looks like count/annotate queries do not use the custom object manager.

## How has this been tested?
I've tested this manually only for now.

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
