### PR TITLE
rewrite relative paths in HTML export

### DIFF
--- a/src/pretalx/agenda/management/commands/export_schedule_html.py
+++ b/src/pretalx/agenda/management/commands/export_schedule_html.py
@@ -145,7 +145,9 @@ def dump_content(destination, path, getter):
     # that won't be found when the export is served by a web server.
     file_path = urllib.parse.unquote(path)
     if file_path.endswith("/"):
-        file_path += "index.html"
+        file_path += "index.js.html"
+    if file_path.endswith("/nojs"):
+        file_path = file_path.rstrip("nojs") + "index.html"
     file_path = (destination / file_path.lstrip("/")).resolve()
     if destination not in file_path.parents:
         raise CommandError("Path traversal detected, aborting.")
@@ -154,7 +156,9 @@ def dump_content(destination, path, getter):
     content = getter(path)
 
     with open(file_path, "wb") as output_file:
-        if b"DOCTYPE html" in content:
+        if path.endswith("/nojs"):
+            output_file.write(make_relative(path.rstrip("/nojs"), content))
+        elif b"DOCTYPE html" in content:
             output_file.write(make_relative(path, content))
         else:
             output_file.write(content)

--- a/src/pretalx/agenda/templates/agenda/schedule_nojs.html
+++ b/src/pretalx/agenda/templates/agenda/schedule_nojs.html
@@ -15,6 +15,7 @@
 {% block agenda_content %}
     <div id="fahrplan" class="list">
 
+        {% if not is_html_export %}
         <div class="alert alert-info">
             <div></div>
             <div>
@@ -23,6 +24,7 @@
                 {% endblocktranslate %}
             </div>
         </div>
+        {% endif %}
         {% if schedule != schedule.event.current_schedule %}
             <div class="alert alert-warning m-3">
                 <span>


### PR DESCRIPTION
This PR addresses issue #1900. It does so by rewriting absolute paths in exported HTML files.
Additional absolute paths still exist e.g. in exported javascript and must be rewritten as well.

This is missing (at least):
- [x] move `schedule/nojs` to `schedule/nojs/index.html`
- [ ] make paths in javascript files for schedule.json relative paths
- [ ] make paths in javascript files for ForkAwesome fonts relative paths
- [x] use nojs pages by default