### PR TITLE
Replace public_name with name

### DIFF
--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -225,7 +225,7 @@ class FrabJsonExporter(ScheduleData):
                                             "guid": person.guid,
                                             "id": person.id,
                                             "code": person.code,
-                                            "public_name": person.get_display_name(),
+                                            "name": person.get_display_name(),
                                             "avatar": person.get_avatar_url(self.event)
                                             or None,
                                             "biography": getattr(


### PR DESCRIPTION
# Replace `public_name` with `name` in schedule export

<!--- Why is this change required? What problem does it solve? -->
The `public_name` field in the schedule export JSON is marked as deprecated in the schema and should be replaced with the `name` field for schema compliance. 

This PR closes issue #1910. It does so by updating the schedule export logic to use the `name` field instead of the deprecated `public_name`.

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->


<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an x in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] I have added tests to cover my changes.
- [x] I have updated the documentation.
- [ ] My change is listed in the `doc/changelog.rst`.
