### PR TITLE
Add additional signals and setting for auth plugins

### DIFF
--- a/src/pretalx/cfp/templates/cfp/event/user_profile.html
+++ b/src/pretalx/cfp/templates/cfp/event/user_profile.html
@@ -84,6 +84,8 @@
 
     {% include "common/user_api_token.html" %}
 
+    {% html_signal "pretalx.common.signals.profile_bottom_html" sender=request.event user=user %}
+
     <div>&nbsp;</div>
     <h3>{% translate "Account deletion" %}</h3>
     <form action="{{ request.event.urls.user_delete }}" method="post" class="form">

--- a/src/pretalx/common/signals.py
+++ b/src/pretalx/common/signals.py
@@ -237,7 +237,7 @@ Make sure that any user content in the HTML code you return is properly escaped!
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
-auth_html = EventPluginSignal()
+auth_html = django.dispatch.Signal()
 """
 To display additional HTML content on the login page, the ``pretalx.common.signals.auth_html``
 signal will be sent out.

--- a/src/pretalx/common/signals.py
+++ b/src/pretalx/common/signals.py
@@ -242,6 +242,10 @@ auth_html = django.dispatch.Signal()
 To display additional HTML content on the login page, the ``pretalx.common.signals.auth_html``
 signal will be sent out.
 """
+profile_bottom_html = django.dispatch.Signal()
+"""
+To display additional HTML content on the user profile/settings pages.
+"""
 register_locales = django.dispatch.Signal()
 """
 To provide additional languages via plugins, you will have to provide some settings in

--- a/src/pretalx/common/signals.py
+++ b/src/pretalx/common/signals.py
@@ -237,6 +237,11 @@ Make sure that any user content in the HTML code you return is properly escaped!
 
 As with all event-plugin signals, the ``sender`` keyword argument will contain the event.
 """
+auth_html = EventPluginSignal()
+"""
+To display additional HTML content on the login page, the ``pretalx.common.signals.auth_html``
+signal will be sent out.
+"""
 register_locales = django.dispatch.Signal()
 """
 To provide additional languages via plugins, you will have to provide some settings in

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -58,5 +58,5 @@
         {% endif %}
     </div>
 {% endif %}
-{% html_signal "pretalx.common.signals.auth_html" sender=request.event %}
+{% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request %}
 {% if no_form %}</div>{% else %}</form>{% endif %}

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -1,6 +1,7 @@
 {% load compress %}
 {% load i18n %}
 {% load static %}
+{% load html_signal %}
 
 {% include "common/forms/errors.html" %}
 {% if no_form %}
@@ -57,4 +58,5 @@
         {% endif %}
     </div>
 {% endif %}
+{% html_signal "pretalx.common.signals.auth_html" sender=request.event %}
 {% if no_form %}</div>{% else %}</form>{% endif %}

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -58,5 +58,5 @@
         {% endif %}
     </div>
 {% endif %}
-{% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request %}
+{% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request next_url=next_url %}
 {% if no_form %}</div>{% else %}</form>{% endif %}

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -40,6 +40,7 @@
                 {{ phrases.base.password_reset_heading }}
             </a>
         {% endif %}
+        {% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request next_url=next_url %}
     </div>
 {% endif %}
 {% if not hide_register %}
@@ -58,5 +59,4 @@
         {% endif %}
     </div>
 {% endif %}
-{% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request next_url=next_url %}
 {% if no_form %}</div>{% else %}</form>{% endif %}

--- a/src/pretalx/common/templates/common/auth.html
+++ b/src/pretalx/common/templates/common/auth.html
@@ -40,7 +40,7 @@
                 {{ phrases.base.password_reset_heading }}
             </a>
         {% endif %}
-        {% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request next_url=next_url %}
+        {% html_signal "pretalx.common.signals.auth_html" sender=request.event request=request next_url=next_url|default:get_success_url %}
     </div>
 {% endif %}
 {% if not hide_register %}

--- a/src/pretalx/common/views/generic.py
+++ b/src/pretalx/common/views/generic.py
@@ -61,6 +61,7 @@ class GenericLoginView(FormView):
             return url + params
         return fallback + params
 
+    @context
     def get_success_url(self, ignore_next=False):
         return self.get_next_url_or_fallback(
             self.request, self.success_url, ignore_next=ignore_next

--- a/src/pretalx/orga/templates/orga/user.html
+++ b/src/pretalx/orga/templates/orga/user.html
@@ -26,5 +26,5 @@
 
     {% include "common/user_api_token.html" with orga="true" %}
 
-    {% html_signal "pretalx.common.signals.profile_bottom_html" sender=request.event user=user %}
+    {% html_signal "pretalx.common.signals.profile_bottom_html" sender=request.event user=user orga="true" %}
 {% endblock content %}

--- a/src/pretalx/orga/templates/orga/user.html
+++ b/src/pretalx/orga/templates/orga/user.html
@@ -3,6 +3,7 @@
 {% load compress %}
 {% load i18n %}
 {% load static %}
+{% load html_signal %}
 
 {% block scripts %}
     {% compress js %}
@@ -25,4 +26,5 @@
 
     {% include "common/user_api_token.html" with orga="true" %}
 
+    {% html_signal "pretalx.common.signals.profile_bottom_html" sender=request.event user=user %}
 {% endblock content %}

--- a/src/pretalx/person/models/user.py
+++ b/src/pretalx/person/models/user.py
@@ -28,6 +28,8 @@ from pretalx.common.models.mixins import FileCleanupMixin, GenerateCode
 from pretalx.common.text.path import path_with_hash
 from pretalx.common.urls import build_absolute_uri
 
+from ..signals import deactivate_user as deactivate_user_signal
+
 
 def avatar_path(instance, filename):
     if instance.code:
@@ -279,6 +281,7 @@ class User(PermissionsMixin, GenerateCode, FileCleanupMixin, AbstractBaseUser):
             answer.delete()  # Iterate to delete answer files, too
         for team in self.teams.all():
             team.members.remove(self)
+        deactivate_user_signal.send(None, user=self)
 
     deactivate.alters_data = True
 

--- a/src/pretalx/person/signals.py
+++ b/src/pretalx/person/signals.py
@@ -1,4 +1,4 @@
-from django.dispatch import receiver
+from django.dispatch import Signal, receiver
 
 from pretalx.common.signals import register_data_exporters
 
@@ -8,3 +8,13 @@ def register_speaker_csv_exporter(sender, **kwargs):
     from pretalx.person.exporters import CSVSpeakerExporter
 
     return CSVSpeakerExporter
+
+
+deactivate_user = Signal()
+"""
+This signal is sent out when a user is deactivated (i.e. deleted on the
+frontend).
+
+You will get the user as a keyword argument ``user``. Receivers are expected to
+delete any personal information they might have stored about this user.
+"""

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -481,12 +481,13 @@ DEFAULT_EVENT_PRIMARY_COLOR = "#3aa57c"
 ## AUTHENTICATION SETTINGS
 AUTH_USER_MODEL = "person.User"
 LOGIN_URL = "/orga/login"
-AUTHENTICATION_BACKENDS = (
+DEFAULT_AUTHENTICATION_BACKENDS = [
     "rules.permissions.ObjectPermissionBackend",
     "django.contrib.auth.backends.ModelBackend",
     "pretalx.common.auth.AuthenticationTokenBackend",
-    'social_core.backends.microsoft.MicrosoftOAuth2',
-)
+]
+EXTRA_AUTH_BACKENDS = [backend for backend in config.get("authentication", "additional_auth_backends", fallback="").split(",") if backend]
+AUTHENTICATION_BACKENDS = DEFAULT_AUTHENTICATION_BACKENDS + EXTRA_AUTH_BACKENDS
 AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -485,6 +485,7 @@ AUTHENTICATION_BACKENDS = (
     "rules.permissions.ObjectPermissionBackend",
     "django.contrib.auth.backends.ModelBackend",
     "pretalx.common.auth.AuthenticationTokenBackend",
+    'social_core.backends.microsoft.MicrosoftOAuth2',
 )
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
I'd like to add a few signals to allow the addition of extra login methods by plugins (such as [pretalx-social-auth](https://github.com/adamskrz/pretalx-social-auth)). I've created two html signals for adding to the login page, and for adding to the user profile page. Additionally, there's a signal that's called when a user's account is deactivated, allowing plugins to delete any personal information stored in their own models.

I've also added an `additional_auth_backends` setting to the config file.

Happy to receive any feedback as I'm sure these aren't necessarily the best ways to achieve this!

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
