### PR TITLE
Fix line break after SVG icon

### DIFF
--- a/src/pretalx/common/exceptions.py
+++ b/src/pretalx/common/exceptions.py
@@ -29,7 +29,7 @@ class PretalxExceptionReporter(ExceptionReporter):
             if frame.get("filename"):
                 location = f"{frame.get('filename')}:{frame.get('lineno')}"
             else:
-                location = f"an unknown location. Here is what we know:\n"
+                location = "an unknown location. Here is what we know:\n"
                 location += f"  - exc_type: {self.exc_type}\n"
                 location += f"  - exc_value: {self.exc_value}\n"
                 location += f"  - tb: {self.tb}\n"

--- a/src/pretalx/orga/templates/orga/includes/sidebar_nav.html
+++ b/src/pretalx/orga/templates/orga/includes/sidebar_nav.html
@@ -4,7 +4,7 @@
         <span class="has-children">
             <a class="nav-link nav-link-inner" href="{{ nav_element.url }}">
                 {% if nav_element.icon and "." in nav_element.icon %}
-                    <img loading="lazy" src="{% static nav_element.icon %}" class="fa-img" alt="{{ nav_element.label }}">
+                    <i class="fa"><img loading="lazy" src="{% static nav_element.icon %}" class="fa-img" alt="{{ nav_element.label }}"></i>
                 {% elif nav_element.icon %}
                     <i class="fa fa-{{ nav_element.icon }}"></i>
                 {% endif %}


### PR DESCRIPTION
This PR closes/references issue https://github.com/F30/samaware/issues/5. It does so by wrapping navigation icons in the appropriate `<i class="fa">` tag; the img tag itself already hat the corresponding `class="fa-img"` attribute.

## How has this been tested?
Lacal installation with samaware plugin.
