### PR TITLE
Organisers can now mark speakers as 'arrived' in more places.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ David Ellis
 Dominik Helle
 Emmanouil Kampitakis
 Florian Klien
+Florian Mösch
 Frantisek Holop
 Franziska Kunsmann
 Hal Seki

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`orga,1892` Organisers can now mark speakers as "arrived" on the speakers detail page and on the speakers tab of accepted sessions.
 - :feature:`orga:submission` Organisers and reviewers can now leave comments on proposals. Comments are shown in chronological order, and users can of course comment multiple times, rather than leaving a single review.
 - :feature:`schedule` When you embed the pretalx widget on an external page, clicking on session links will open the session details (or speaker details) in a popup on the same page, instead of directing attendees to the pretalx schedule page.
 - :feature:`schedule` Organisers can now configure additional links to show in the top menu next to "Schedule", "Sessions", "Speakers", handy for links back to the conference website, streams, etc.

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -29,6 +29,7 @@
 
 {% block content %}
     {% has_perm "orga.change_speaker" request.user form.instance as can_edit_speaker %}
+    {% has_perm "orga.mark_speakers_arrived" request.user request.event as can_mark_speaker %}
     {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
     <h2 class="d-flex justify-content-between align-items-baseline">
         {% include "orga/includes/user_name.html" with user=form.instance.user lightbox=True %}
@@ -42,6 +43,11 @@
             {{ proposal_title }})
         </span>
         <div class="ml-auto mb-1">
+            {% if can_mark_speaker and accepted_submissions.count and not form.instance.has_arrived %}
+                <a class="btn btn-info" href="{{ form.instance.orga_urls.toggle_arrived }}">
+                    {% translate "Mark speaker as arrived" %}
+                </a>
+            {% endif %}
             <a href="{{ form.instance.orga_urls.password_reset }}" class="btn btn-info flip">{{ phrases.base.password_reset_heading }}</a>
             {% if can_send_mails %}
                 <a class="btn btn-outline-info ml-2" href="{{ request.event.orga_urls.compose_mails_sessions }}?speakers={{ form.instance.user.code }}">

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -43,7 +43,7 @@
             {{ proposal_title }})
         </span>
         <div class="ml-auto mb-1">
-            {% if can_mark_speaker and accepted_submissions.count %}
+            {% if can_mark_speaker and accepted_submissions.exists %}
             <a class="btn btn-{{ form.instance.has_arrived|yesno:"success,info" }}" href="{{ form.instance.orga_urls.toggle_arrived }}">
                 {% if form.instance.has_arrived %}
                     {% translate "Mark speaker as not arrived" %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -43,10 +43,14 @@
             {{ proposal_title }})
         </span>
         <div class="ml-auto mb-1">
-            {% if can_mark_speaker and accepted_submissions.count and not form.instance.has_arrived %}
-                <a class="btn btn-info" href="{{ form.instance.orga_urls.toggle_arrived }}">
+            {% if can_mark_speaker and accepted_submissions.count %}
+            <a class="btn btn-{{ form.instance.has_arrived|yesno:"success,info" }}" href="{{ form.instance.orga_urls.toggle_arrived }}">
+                {% if form.instance.has_arrived %}
+                    {% translate "Mark speaker as not arrived" %}
+                {% else %}
                     {% translate "Mark speaker as arrived" %}
-                </a>
+                {% endif %}
+            </a>
             {% endif %}
             <a href="{{ form.instance.orga_urls.password_reset }}" class="btn btn-info flip">{{ phrases.base.password_reset_heading }}</a>
             {% if can_send_mails %}

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -56,7 +56,7 @@
                             <td class="text-right">
                                 {% if profile.accepted_submission_count %}
                                     {% if can_mark_speaker %}
-                                        <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?from=list">
+                                        <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}">
                                             {% if profile.has_arrived %}
                                                 {% translate "Mark speaker as not arrived" %}
                                             {% else %}

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -56,7 +56,7 @@
                             <td class="text-right">
                                 {% if profile.accepted_submission_count %}
                                     {% if can_mark_speaker %}
-                                    <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?next={{ request.path }}">
+                                    <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?next={{ request.path|urlencode }}">
                                         {% if profile.has_arrived %}
                                                 {% translate "Mark speaker as not arrived" %}
                                             {% else %}

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -56,8 +56,8 @@
                             <td class="text-right">
                                 {% if profile.accepted_submission_count %}
                                     {% if can_mark_speaker %}
-                                        <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}">
-                                            {% if profile.has_arrived %}
+                                    <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?next={{ request.path }}">
+                                        {% if profile.has_arrived %}
                                                 {% translate "Mark speaker as not arrived" %}
                                             {% else %}
                                                 {% translate "Mark speaker as arrived" %}

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -61,9 +61,13 @@
                 {% endif %}
             </p>
             {% if can_edit_speakers %}
-                {% if can_mark_speaker and submission.state in 'accepted,confirmed' and not speaker.profile.has_arrived %}
-                    <a class="btn btn-info" href="{{ speaker.profile.orga_urls.toggle_arrived }}">
-                        {% translate "Mark speaker as arrived" %}
+                {% if can_mark_speaker and submission.state in 'accepted,confirmed' %}
+                    <a class="btn btn-{{ speaker.profile.has_arrived|yesno:"success,info" }}" href="{{ speaker.profile.orga_urls.toggle_arrived }}">
+                        {% if speaker.profile.has_arrived %}
+                            {% translate "Mark speaker as not arrived" %}
+                        {% else %}
+                            {% translate "Mark speaker as arrived" %}
+                        {% endif %}
                     </a>
                 {% endif %}
                 {% if can_send_mails %}

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -62,7 +62,7 @@
             </p>
             {% if can_edit_speakers %}
                 {% if can_mark_speaker and submission.state in 'accepted,confirmed' %}
-                    <a class="btn btn-{{ speaker.profile.has_arrived|yesno:"success,info" }}" href="{{ speaker.profile.orga_urls.toggle_arrived }}">
+                    <a class="btn btn-{{ speaker.profile.has_arrived|yesno:"success,info" }}" href="{{ speaker.profile.orga_urls.toggle_arrived }}?next={{ request.path }}">
                         {% if speaker.profile.has_arrived %}
                             {% translate "Mark speaker as not arrived" %}
                         {% else %}

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -11,6 +11,7 @@
 
 {% block submission_content %}
     {% has_perm "submission.edit_speaker_list" request.user submission as can_edit_speakers %}
+    {% has_perm "orga.mark_speakers_arrived" request.user request.event as can_mark_speaker %}
     {% has_perm "orga.send_mails" request.user request.event as can_send_mails %}
     {% if can_edit_speakers %}<div class="alert">
         <form method="POST" class="form d-flex w-100 flex-column">
@@ -60,6 +61,11 @@
                 {% endif %}
             </p>
             {% if can_edit_speakers %}
+                {% if can_mark_speaker and submission.state in 'accepted,confirmed' and not speaker.profile.has_arrived %}
+                    <a class="btn btn-info" href="{{ speaker.profile.orga_urls.toggle_arrived }}">
+                        {% translate "Mark speaker as arrived" %}
+                    </a>
+                {% endif %}
                 {% if can_send_mails %}
                     <a class="btn btn-outline-info" href="{{ request.event.orga_urls.compose_mails_sessions }}?speakers={{ speaker.user.code }}">
                         <i class="fa fa-envelope"></i>

--- a/src/pretalx/orga/views/speaker.py
+++ b/src/pretalx/orga/views/speaker.py
@@ -3,8 +3,10 @@ from django.contrib import messages
 from django.db import transaction
 from django.db.models import Count, Exists, OuterRef, Q
 from django.shortcuts import get_object_or_404, redirect
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, FormView, ListView, View
 from django_context_decorator import context
@@ -282,8 +284,9 @@ class SpeakerToggleArrived(SpeakerViewMixin, View):
             person=self.request.user,
             orga=True,
         )
-        if referer := request.META.get("HTTP_REFERER"):
-            return redirect(referer)
+        if url := self.request.GET.get("next"):
+            if url and url_has_allowed_host_and_scheme(url, allowed_hosts=None):
+                return redirect(url)
         return redirect(self.profile.orga_urls.base)
 
 

--- a/src/pretalx/orga/views/speaker.py
+++ b/src/pretalx/orga/views/speaker.py
@@ -3,7 +3,6 @@ from django.contrib import messages
 from django.db import transaction
 from django.db.models import Count, Exists, OuterRef, Q
 from django.shortcuts import get_object_or_404, redirect
-from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from django.utils.http import url_has_allowed_host_and_scheme


### PR DESCRIPTION
This PR closes/references issue #1892. It does so by adding the `Mark speaker as arrived`-button on the speakers detail page and on the speakers tab of the submissions pages of accepted submissions.

The button is only shown if the `orga.mark_speakers_arrived` permission is present. Thus it is in particular not shown when the event is not yet running.
No button is shown when the speaker was already marked as attending. To undo the flag, the user list must be used (which is unchanged). This is to avoid cluttering the UI wit additional buttons when they are typically not needed.

The `SpeakerToggleArrived`-view now redirects to the referring page if the referer is present in the HTTP request or to the speaker details page if the referer is not know.

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [X] My change is listed in the ``doc/changelog.rst``.
