### PR TITLE
hidden language field

### DIFF
--- a/src/pretalx/orga/forms/submission.py
+++ b/src/pretalx/orga/forms/submission.py
@@ -302,6 +302,8 @@ class AddSpeakerForm(forms.Form):
 
     def __init__(self, *args, event=None, form_renderer=None, **kwargs):
         super().__init__(*args, **kwargs)
+        if not event.named_locales or len(event.named_locales) < 2:
+            self.fields["locale"].widget = forms.HiddenInput()
         self.fields["locale"].choices = event.named_locales
         self.fields["locale"].initial = event.locale
 

--- a/src/pretalx/orga/templates/orga/submission/speakers.html
+++ b/src/pretalx/orga/templates/orga/submission/speakers.html
@@ -20,7 +20,7 @@
                 <div class="w-50">{{ form.name.as_field_group }}</div>
             </div>
             <div class="d-flex flex-row hide-optional">
-                <div class="w-50 hide-optional mr-4">{% if form.locale %}{{ form.locale.as_field_group }}{% endif %}</div>
+                <div class="w-50 hide-optional mr-4">{% if form.locale and form.locale|length > 1 %}{{ form.locale.as_field_group }}{% else %}{{ form.locale.as_hidden }}{% endif %}</div>
                 <div class="w-50 mt-4"><button type="submit" class="btn btn-sm btn-success btn-block btn-lg mt-2"><i class="fa fa-plus"></i> {% translate "Add speaker" %}</button></div>
             </div>
         </form>


### PR DESCRIPTION
Hello
This PR closes/references issue #1945
The language selection field in monolingual events is now hidden in two places: when creating a new proposal and when adding a new speaker to an existing proposal.
