### PR TITLE
Fix CSRF middleware

### DIFF
--- a/src/pretalx/common/middleware/domains.py
+++ b/src/pretalx/common/middleware/domains.py
@@ -193,7 +193,7 @@ class CsrfViewMiddleware(BaseCsrfMiddleware):
     depending on whether we are on the main domain or a custom domain.
     """
 
-    def _set_cookie_csrf(self, request, response):
+    def _set_csrf_cookie(self, request, response):
         # If CSRF_COOKIE is unset, then CsrfViewMiddleware.process_view was
         # never called, probably because a request middleware returned a response
         # (for example, contrib.auth redirecting to a login page).

--- a/src/pretalx/common/middleware/domains.py
+++ b/src/pretalx/common/middleware/domains.py
@@ -177,6 +177,7 @@ class SessionMiddleware(BaseSessionMiddleware):
                         path=settings.SESSION_COOKIE_PATH,
                         secure=request.scheme == "https",
                         httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+                        samesite=settings.SESSION_COOKIE_SAMESITE,
                     )
         return response
 
@@ -211,6 +212,7 @@ class CsrfViewMiddleware(BaseCsrfMiddleware):
                 path=settings.CSRF_COOKIE_PATH,
                 secure=request.scheme == "https",
                 httponly=settings.CSRF_COOKIE_HTTPONLY,
+                samesite=settings.CSRF_COOKIE_SAMESITE,
             )
             # Content varies with the CSRF cookie, so set the Vary header.
             patch_vary_headers(response, ("Cookie",))


### PR DESCRIPTION
In trying to get my head around what `common/middleware/domains.py` does on a local instance of pretalx, I found I was unable to login when using a custom local domain with http, as the CSRF cookie was being set with `secure=True`.

Some debugging made it clear that pretalx's `_set_cookie_csrf` is not actually being called, as the actual function in Django is `_set_csrf_cookie`.

I don't think this has any major impact on deployments as `get_cookie_domain` can only return None or `SESSION_COOKIE_DOMAIN`, and the Django implementation uses `CSRF_COOKIE_DOMAIN`, both of which are set to by the (as far as I can find) undocumented pretalx `site:cookie_domain` config.

It should make local development with http (unsing non-`localhost` hostnames) easier though as Secure won't be set.

I've also added the `samesite` argument to `set_cookie` for parity with the current Django implementations.