### PR TITLE
Chore/improve test coverage

### DIFF
--- a/src/tests/api/test_api_answers.py
+++ b/src/tests/api/test_api_answers.py
@@ -260,3 +260,4 @@ def test_objects_do_not_exist(event, orga_client, answer, is_detail, method):
     )
     assert response.data.get("review")[0] == 'Invalid pk "5" - object does not exist.'
     assert response.data.get("question")[0] == 'Invalid pk "4" - object does not exist.'
+    assert response.status_code == 400, response.content.decode()

--- a/src/tests/api/test_api_answers.py
+++ b/src/tests/api/test_api_answers.py
@@ -125,3 +125,138 @@ def test_reviewer_cannot_edit_answer(event, review_client, answer):
     with scope(event=event):
         answer.refresh_from_db()
         assert answer.answer != "ohno.png"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("required_field", ("answer", "question"))
+def test_fields_required_on_create(event, orga_client, required_field):
+    response = orga_client.post(
+        event.api_urls.answers,
+        {},
+        content_type="application/json",
+    )
+    assert response.data.get(required_field)[0] == "This field is required."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("required_field", ("answer", "question"))
+def test_fields_required_on_update(event, orga_client, answer, required_field):
+    response = orga_client.put(
+        event.api_urls.answers + f"{answer.pk}/",
+        {},
+        content_type="application/json",
+    )
+    assert response.data.get(required_field)[0] == "This field is required."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_question_may_not_be_null(event, orga_client, answer, is_detail, method):
+    url = event.api_urls.answers
+    if is_detail:
+        url += f"{answer.pk}/"
+
+    response = getattr(orga_client, method)(
+        url, {"question": ""}, content_type="application/json"
+    )
+    assert response.data.get("question")[0] == "This field may not be null."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_answer_may_not_be_blank(event, orga_client, answer, is_detail, method):
+    url = event.api_urls.answers
+    if is_detail:
+        url += f"{answer.pk}/"
+
+    response = getattr(orga_client, method)(
+        url, {"answer": ""}, content_type="application/json"
+    )
+    assert response.data.get("answer")[0] == "This field may not be blank."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_question_must_be_valid_pk(event, orga_client, answer, is_detail, method):
+    url = event.api_urls.answers
+    if is_detail:
+        url += f"{answer.pk}/"
+
+    response = getattr(orga_client, method)(
+        url, {"question": "invalid_pk"}, content_type="application/json"
+    )
+    assert (
+        response.data.get("question")[0]
+        == "Incorrect type. Expected pk value, received str."
+    )
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_review_must_be_valid_pk(event, orga_client, answer, is_detail, method):
+    url = event.api_urls.answers
+    if is_detail:
+        url += f"{answer.pk}/"
+
+    response = getattr(orga_client, method)(
+        url, {"review": "invalid_pk"}, content_type="application/json"
+    )
+    assert (
+        response.data.get("review")[0]
+        == "Incorrect type. Expected pk value, received str."
+    )
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_objects_do_not_exist(event, orga_client, answer, is_detail, method):
+    url = event.api_urls.answers
+    if is_detail:
+        url += f"{answer.pk}/"
+
+    response = getattr(orga_client, method)(
+        url, {"review": 5, "question": 4}, content_type="application/json"
+    )
+    assert response.data.get("review")[0] == 'Invalid pk "5" - object does not exist.'
+    assert response.data.get("question")[0] == 'Invalid pk "4" - object does not exist.'

--- a/src/tests/api/test_api_questions.py
+++ b/src/tests/api/test_api_questions.py
@@ -176,3 +176,215 @@ def test_reviewer_cannot_edit_question(event, review_client, question):
         question.refresh_from_db()
         assert question.target != "speaker"
         assert question.help_text != "hellllp"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("is_detail, method", ((False, "post"), (True, "put")))
+def test_field_question_required(event, orga_client, question, is_detail, method):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(url, {}, content_type="application/json")
+    assert response.data.get("question")[0] == "This field is required."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_question_required_valid_choice(
+    event, orga_client, question, is_detail, method
+):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"question_required": "invalid_choice"}, content_type="application/json"
+    )
+    assert (
+        response.data.get("question_required")[0]
+        == '"invalid_choice" is not a valid choice.'
+    )
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_deadline_valid_date(event, orga_client, question, is_detail, method):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"deadline": "invalid_date"}, content_type="application/json"
+    )
+
+    # Using in check because response error is to long
+    assert "Datetime has wrong format" in response.data.get("deadline")[0]
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_freeze_after_valid_date(event, orga_client, question, is_detail, method):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"freeze_after": "invalid_date"}, content_type="application/json"
+    )
+
+    # Using in check because response error is to long
+    assert "Datetime has wrong format" in response.data.get("freeze_after")[0]
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_variant_valid_choice(event, orga_client, question, is_detail, method):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"variant": "invalid_choice"}, content_type="application/json"
+    )
+    assert response.data.get("variant")[0] == '"invalid_choice" is not a valid choice.'
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_max_length_valid_integer(
+    event, orga_client, question, is_detail, method
+):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"max_length": "not_an_integer"}, content_type="application/json"
+    )
+    assert response.data.get("max_length")[0] == "A valid integer is required."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_min_length_valid_integer(
+    event, orga_client, question, is_detail, method
+):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"min_length": "not_an_integer"}, content_type="application/json"
+    )
+    assert response.data.get("min_length")[0] == "A valid integer is required."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_is_public_valid_boolean(event, orga_client, question, is_detail, method):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url, {"is_public": "not_an_boolean"}, content_type="application/json"
+    )
+    assert response.data.get("is_public")[0] == "Must be a valid boolean."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_is_visible_to_reviewers_valid_boolean(
+    event, orga_client, question, is_detail, method
+):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url,
+        {"is_visible_to_reviewers": "not_an_boolean"},
+        content_type="application/json",
+    )
+    assert response.data.get("is_visible_to_reviewers")[0] == "Must be a valid boolean."
+    assert response.status_code == 400, response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "is_detail, method",
+    (
+        (False, "post"),
+        (True, "put"),
+        (True, "patch"),
+    ),
+)
+def test_field_contains_personal_data_valid_boolean(
+    event, orga_client, question, is_detail, method
+):
+    url = event.api_urls.questions
+    if is_detail:
+        url += f"{question.pk}/"
+    response = getattr(orga_client, method)(
+        url,
+        {"contains_personal_data": "not_an_boolean"},
+        content_type="application/json",
+    )
+    assert response.data.get("contains_personal_data")[0] == "Must be a valid boolean."
+    assert response.status_code == 400, response.content.decode()


### PR DESCRIPTION
This PR adds test coverage for required fields in the API payload, verifying that they are present, contain valid values, and are not null. It ensures stricter validation and improves the reliability of API requests.

- [X] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
