### PR TITLE
fix: move export qrcode image into window

### DIFF
--- a/src/pretalx/static/common/css/_pretalx.css
+++ b/src/pretalx/static/common/css/_pretalx.css
@@ -7,6 +7,7 @@
   width: 160px;
   height: 160px;
   position: absolute;
+  right: 0px;
   background: white;
   box-shadow: var(--shadow-light);
   svg {


### PR DESCRIPTION
The qrcode image for exporting the schedule overlaps the window and is only displayed half, as shown in the following screenshot:

![image](https://github.com/user-attachments/assets/b9fd7f56-5396-423f-8af3-001a731a3d8f)

This PR sets `right: 0px`  on the `absolute` positioned container, moving the qr code into the window. 

## How has this been tested?
I tested only manually in the browser, see screenshot:

![image](https://github.com/user-attachments/assets/2508e562-f13a-40cc-8d37-f4d505653101)


## Checklist
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
