### PR TITLE
Resolve bs4 deprecation warnings

### DIFF
--- a/src/pretalx/orga/forms/mails.py
+++ b/src/pretalx/orga/forms/mails.py
@@ -165,7 +165,7 @@ class MailTemplateForm(ReadOnlyFlag, I18nHelpText, I18nModelForm):
                     )
                 )
                 doc = BeautifulSoup(preview_text, "lxml")
-                for link in doc.findAll("a"):
+                for link in doc.find_all("a"):
                     if link.attrs.get("href") in (None, "", "http://", "https://"):
                         raise forms.ValidationError(
                             _(


### PR DESCRIPTION
## PR Summary
The small PR fixes the bs4 deprecation warnings by replacing `findAll()` with `find_all()` The resolves the warnings found in the[ CI logs](https://github.com/pretalx/pretalx/actions/runs/14532991057/job/40776122378#step:12:188):
```python
  /home/runner/work/pretalx/pretalx/src/pretalx/orga/forms/mails.py:168: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
    for link in doc.findAll("a"):
```

## How has this been tested?
Run the tests in Python 3.12

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
