### PR TITLE
Add html and forms signals for plugin integration

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`dev` Plugins can now inject additional form elements or HTML in the organisers area with the ``pretalx.orga.signals.plugin_forms`` and ``pretalx.orga.signals.plugin_html`` signals.
 - :feature:`orga:submission` Organisers and reviewers can now leave comments on proposals. Comments are shown in chronological order, and users can of course comment multiple times, rather than leaving a single review.
 - :feature:`schedule` When you embed the pretalx widget on an external page, clicking on session links will open the session details (or speaker details) in a popup on the same page, instead of directing attendees to the pretalx schedule page.
 - :feature:`schedule` Organisers can now configure additional links to show in the top menu next to "Schedule", "Sessions", "Speakers", handy for links back to the conference website, streams, etc.

--- a/doc/developer/plugins/general.rst
+++ b/doc/developer/plugins/general.rst
@@ -36,7 +36,7 @@ Organiser area
 --------------
 
 .. automodule:: pretalx.orga.signals
-   :members: nav_event, nav_global, html_head, activate_event, nav_event_settings, event_copy_data
+   :members: nav_event, nav_global, html_head, activate_event, nav_event_settings, event_copy_data, plugin_forms, plugin_html
 
 .. automodule:: pretalx.common.signals
    :no-index:

--- a/src/pretalx/orga/signals.py
+++ b/src/pretalx/orga/signals.py
@@ -70,6 +70,28 @@ Additionally, the signal will be called with the ``request`` it is processing.
 The receivers are expected to return HTML.
 """
 
+plugin_forms = EventPluginSignal()
+"""
+This signal allows you to put additional form elements inside the forms on several pages
+in the organiser backend. You will get the request as the keyword argument ``request``
+and are expected to return plain HTML.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+Additionally, the signal will be called with the ``request`` it is processing.
+The receivers are expected to return one or more forms.
+"""
+
+plugin_html = EventPluginSignal()
+"""
+This signal allows you to put code inside the HTML body of several pages in the
+organiser backend. You will get the request as the keyword argument ``request`` and are
+expected to return plain HTML.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+Additionally, the signal will be called with the ``request`` it is processing.
+The receivers are expected to return HTML.
+"""
+
 event_copy_data = EventPluginSignal()
 """
 This signal is sent out when a new event is created as a clone of an existing event, i.e.

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -1,4 +1,5 @@
 {% extends "orga/mails/base.html" %}
+{% load plugin_signal %}
 {% load i18n %}
 {% load rich_text %}
 
@@ -18,6 +19,10 @@
 
         {% if not form.read_only %}
             {{ form }}
+            {% get_plugin_forms mail=form.instance as plugin_forms %}
+            {% for plugin_form in plugin_forms %}
+                {{ plugin_form }}
+            {% endfor %}
         {% else %}
             <div class="d-flex flex-column">
                 <div class="row form-group">
@@ -78,6 +83,10 @@
                     </div>
                     <div class="col col-md-9">{{ form.instance.text|rich_text }}</div>
                 </div>
+                {% get_plugin_forms mail=form.instance as plugin_forms %}
+                {% for plugin_form in plugin_forms %}
+                    {{ plugin_form }}
+                {% endfor %}
             </div>
         {% endif %}
 
@@ -98,6 +107,7 @@
                 {% endif %}
             {% endif %}
         </div>
+        {% get_plugin_html mail=form.instance %}
     </form>
 
 {% endblock mail_content %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -1,6 +1,7 @@
 {% extends "orga/base.html" %}
 
 {% load compress %}
+{% load plugin_signal %}
 {% load i18n %}
 {% load rules %}
 {% load static %}
@@ -89,8 +90,14 @@
 
         {{ questions_form }}
 
+        {% get_plugin_forms speaker=form.instance.user as plugin_forms %}
+        {% for plugin_form in plugin_forms %}
+            {{ plugin_form }}
+        {% endfor %}
+
         {% include "orga/includes/submit_row.html" %}
 
+        {% get_plugin_html speaker=form.instance.user %}
     </form>
 
     <h3>{% translate "Emails" %}</h3>

--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -3,6 +3,7 @@
 {% load compress %}
 {% load filesize %}
 {% load formset_tags %}
+{% load plugin_signal %}
 {% load i18n %}
 {% load static %}
 {% load rules %}
@@ -88,6 +89,10 @@
                 <div><legend id="custom">{{ phrases.cfp.custom_fields }}</legend></div>
                 {{ questions_form }}
             {% endif %}
+            {% get_plugin_forms submission=submission as plugin_forms %}
+            {% for plugin_form in plugin_forms %}
+                {{ plugin_form }}
+            {% endfor %}
 
             {% if not form.read_only %}
                 <div class="submit-group panel">
@@ -100,6 +105,7 @@
                     </span>
                 </div>
             {% endif %}
+            {% get_plugin_html submission=submission %}
         </fieldset></form>
 
     <span id="vars" remoteUrl="{{ request.event.organiser.orga_urls.user_search }}"></span>

--- a/src/pretalx/orga/templates/orga/submission/review.html
+++ b/src/pretalx/orga/templates/orga/submission/review.html
@@ -1,6 +1,7 @@
 {% extends "orga/submission/base.html" %}
 
 {% load compress %}
+{% load plugin_signal %}
 {% load i18n %}
 {% load rich_text %}
 {% load rules %}
@@ -134,7 +135,7 @@
                 {% for speaker in profiles %}
                     <div class="form-group row">
                         <label class="col-md-3 col-form-label">
-                            {% translate "Biography" %}{% if profiles.count > 1 %}: {% include "orga/includes/user_name.html" with user=speaker.user lightbox=True %}{% endif %}
+                            {% translate "Biography" %}{% if profiles|length > 1 %}: {% include "orga/includes/user_name.html" with user=speaker.user lightbox=True %}{% endif %}
                         </label>
                         <div class="col-md-9 mt-2 markdown-mt-0">
                             {% if request.event.cfp.request_biography %}
@@ -154,6 +155,10 @@
                     </div>
                 {% endfor %}
             {% endif %}
+            {% get_plugin_forms submission=submission as plugin_forms %}
+            {% for plugin_form in plugin_forms %}
+                {{ plugin_form }}
+            {% endfor %}
 
             {% if not read_only %}
                 {% if tags_form %}{{ tags_form }}{% endif %}
@@ -234,6 +239,7 @@
                     </div>
                 </div>
             {% endif %}
+            {% get_plugin_html submission=submission %}
         </form>
     {% endif %}  {# endif: request.user in submission.speakers #}
 {% endblock submission_content %}

--- a/src/pretalx/orga/templatetags/plugin_signal.py
+++ b/src/pretalx/orga/templatetags/plugin_signal.py
@@ -1,0 +1,50 @@
+from django import template
+from django.utils.safestring import mark_safe
+
+from pretalx.orga.signals import plugin_forms, plugin_html
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def get_plugin_forms(context, **kwargs):
+    """Send a signal and return the concatenated list of all
+    returned form.
+
+    Usage::
+
+        {% get_plugin_forms submission=submission as plugin_forms %}
+        {% for plugin_form in plugin_forms %}
+            {{ plugin_form }}
+        {% endfor %}
+    """
+    forms = []
+    request = context.request
+    event = request.event
+    for __, response in plugin_forms.send(event, request=request, **kwargs):
+        if response:
+            if not response:
+                continue
+            if isinstance(response, (list, tuple)):
+                forms.extend(response)
+            else:
+                forms.append(response)
+    return forms
+
+
+@register.simple_tag(takes_context=True)
+def get_plugin_html(context, **kwargs):
+    """Send a signal and return the concatenated return values of all
+    responses.
+
+    Usage::
+
+        {% get_plugin_html %}
+    """
+    html = []
+    for __, response in plugin_html.send(
+        context.request.event, request=context.request, **kwargs
+    ):
+        if response:
+            html.append(response)
+    return mark_safe("".join(html))

--- a/src/pretalx/orga/views/mails.py
+++ b/src/pretalx/orga/views/mails.py
@@ -36,6 +36,7 @@ from pretalx.orga.forms.mails import (
     WriteSessionMailForm,
     WriteTeamsMailForm,
 )
+from pretalx.orga.views.plugins import PluginFormMixin
 
 
 class OutboxList(
@@ -283,7 +284,9 @@ class OutboxPurge(ActionConfirmMixin, OutboxList):
         return redirect(self.request.event.orga_urls.outbox)
 
 
-class MailDetail(PermissionRequired, ActionFromUrl, CreateOrUpdateView):
+class MailDetail(
+    PermissionRequired, ActionFromUrl, PluginFormMixin, CreateOrUpdateView
+):
     model = QueuedMail
     form_class = MailDetailForm
     template_name = "orga/mails/outbox_form.html"
@@ -314,6 +317,9 @@ class MailDetail(PermissionRequired, ActionFromUrl, CreateOrUpdateView):
                 ),
             )
         return result
+
+    def get_plugin_form_kwargs(self):
+        return {"mail": self.object}
 
 
 class MailCopy(PermissionRequired, View):

--- a/src/pretalx/orga/views/review.py
+++ b/src/pretalx/orga/views/review.py
@@ -30,6 +30,7 @@ from pretalx.orga.forms.review import (
 )
 from pretalx.orga.forms.submission import SubmissionStateChangeForm
 from pretalx.orga.permissions import reviews_are_open
+from pretalx.orga.views.plugins import PluginFormMixin
 from pretalx.orga.views.submission import BaseSubmissionList
 from pretalx.submission.forms import QuestionsForm, SubmissionFilterForm
 from pretalx.submission.models import Review, Submission, SubmissionStates
@@ -486,7 +487,9 @@ class ReviewViewMixin:
         )
 
 
-class ReviewSubmission(ReviewViewMixin, PermissionRequired, CreateOrUpdateView):
+class ReviewSubmission(
+    ReviewViewMixin, PermissionRequired, PluginFormMixin, CreateOrUpdateView
+):
     form_class = ReviewForm
     model = Review
     template_name = "orga/submission/review.html"
@@ -623,6 +626,9 @@ class ReviewSubmission(ReviewViewMixin, PermissionRequired, CreateOrUpdateView):
         if self.tags_form:
             self.tags_form.save()
         return super().form_valid(form)
+
+    def get_plugin_form_kwargs(self):
+        return {"submission": self.submission}
 
     def post(self, request, *args, **kwargs):
         action = self.request.POST.get("review_submit") or "save"

--- a/src/pretalx/orga/views/speaker.py
+++ b/src/pretalx/orga/views/speaker.py
@@ -24,6 +24,7 @@ from pretalx.common.views.mixins import (
     Sortable,
 )
 from pretalx.orga.forms.speaker import SpeakerExportForm
+from pretalx.orga.views.plugins import PluginFormMixin
 from pretalx.person.forms import (
     SpeakerFilterForm,
     SpeakerInformationForm,
@@ -160,7 +161,9 @@ class SpeakerViewMixin(PermissionRequired):
 
 
 @method_decorator(csp_update(IMG_SRC="https://www.gravatar.com"), name="dispatch")
-class SpeakerDetail(SpeakerViewMixin, ActionFromUrl, CreateOrUpdateView):
+class SpeakerDetail(
+    SpeakerViewMixin, ActionFromUrl, PluginFormMixin, CreateOrUpdateView
+):
     template_name = "orga/speaker/form.html"
     form_class = SpeakerProfileForm
     model = User
@@ -220,6 +223,9 @@ class SpeakerDetail(SpeakerViewMixin, ActionFromUrl, CreateOrUpdateView):
             self.request.event.cache.set("rebuild_schedule_export", True, None)
         messages.success(self.request, phrases.base.saved)
         return result
+
+    def get_plugin_form_kwargs(self):
+        return {"speaker": self.object}
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -40,6 +40,7 @@ from pretalx.orga.forms.submission import (
     SubmissionForm,
     SubmissionStateChangeForm,
 )
+from pretalx.orga.views.plugins import PluginFormMixin
 from pretalx.person.models import User
 from pretalx.submission.forms import (
     QuestionsForm,
@@ -305,7 +306,11 @@ class SubmissionSpeakers(ReviewerSubmissionFilter, SubmissionViewMixin, FormView
 
 
 class SubmissionContent(
-    ActionFromUrl, ReviewerSubmissionFilter, SubmissionViewMixin, CreateOrUpdateView
+    ActionFromUrl,
+    ReviewerSubmissionFilter,
+    SubmissionViewMixin,
+    PluginFormMixin,
+    CreateOrUpdateView,
 ):
     model = Submission
     form_class = SubmissionForm
@@ -489,7 +494,11 @@ class SubmissionContent(
             action = "pretalx.submission." + ("create" if created else "update")
             form.instance.log_action(action, person=self.request.user, orga=True)
             self.request.event.cache.set("rebuild_schedule_export", True, None)
+        super().form_valid(form)
         return redirect(self.get_success_url())
+
+    def get_plugin_form_kwargs(self):
+        return {"submission": self.object}
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
This is an alernative proposal for #1885.

Instead of individual signals for several forms, this approach only defines two new signals: ``pretalx.orga.signals.plugin_forms`` and ``pretalx.orga.signals.plugin_html``.

``plugin_forms`` can be used by plugins to add form elements to existing forms in the orga views. It has been placed in the views for submissions (also on the review tab), speakers and mails. The forms can be used to add custom fields to these views which can also be edited. Fields can of course be made read-only. Additionally, by using custom renderers any kind of output can be placed in these views.

``plugin_forms`` can be used to render any custom HTML below the same forms without the need to create additional form elements.

## How has this been tested?

It has currently only been tested manually (but rather extensively) using modified versions of the plugins pretalx-signal-demo,  pretalx-rt, and pretalx-zammad which hda been developed against the other proposal. The necessary modifications in these plugins are light weight.

As far as I'm aware of, the previous approach had not yet been adopted by anyone else. I do like this version more than the previous.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
