### PR TITLE
feat: implement dark theme

### DIFF
--- a/src/pretalx/agenda/views/speaker.py
+++ b/src/pretalx/agenda/views/speaker.py
@@ -153,6 +153,16 @@ def empty_avatar_view(request, event):
     avatar_template = f"""<svg
    xmlns="http://www.w3.org/2000/svg"
    viewBox="0 0 100 100">
+  <style>
+    /* The head is filled with the page colour purely to mask the body outline
+       running behind it, so the fill has to follow the page, not stay white.
+       This is served as an image, so it cannot read the page's variables --
+       an internal media query is the only way to reach the reader's scheme. */
+    #heady {{ fill: #ffffff; }}
+    @media (prefers-color-scheme: dark) {{
+      #heady {{ fill: #121416; }}
+    }}
+  </style>
   <g>
     <path
        id="body"
@@ -164,7 +174,7 @@ def empty_avatar_view(request, event):
        cy="28"
        cx="50"
        id="heady"
-       style="fill:#ffffff;stroke:{color};stroke-width:1.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6.5, 8;stroke-dashoffset:4;stroke-opacity:0.87" />
+       style="stroke:{color};stroke-width:1.3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:6.5, 8;stroke-dashoffset:4;stroke-opacity:0.87" />
   </g>
 </svg>"""
     return FileResponse(

--- a/src/pretalx/agenda/views/widget.py
+++ b/src/pretalx/agenda/views/widget.py
@@ -152,7 +152,9 @@ def event_css(request, event):
         variable = "--color-primary"
         postfix = "-event" if is_orga else ""
         if request.event.primary_color_needs_dark_text:
-            rules.append(f" --color-text-on-primary{postfix}: var(--color-text);")
+            rules.append(
+                f" --color-text-on-primary{postfix}: var(--color-text-on-light);"
+            )
         rules.append(f"{variable}{postfix}: {color};")
     if rules:
         parts.append(":root { " + " ".join(rules) + " }")

--- a/src/pretalx/agenda/views/widget.py
+++ b/src/pretalx/agenda/views/widget.py
@@ -15,6 +15,7 @@ from i18nfield.utils import I18nJSONEncoder
 
 from pretalx.agenda.rules import is_widget_visible
 from pretalx.common.fonts import get_font_css
+from pretalx.common.ui import DARK_MODE_TEXT_DARK_MIX, dark_mode_text_override
 from pretalx.common.views.cache import conditional_cache_page
 from pretalx.schedule.interfaces.widget import build_widget_data
 
@@ -23,8 +24,16 @@ WIDGET_JS_CONTENT = None
 WIDGET_PATH = "agenda/js/pretalx-schedule.min.js"
 
 
+# Bump whenever event_css generates different output for unchanged event data.
+# The ETag is otherwise derived purely from that data, so without this a client
+# holding a previously cached event.css would revalidate, be told 304, and keep
+# the stale stylesheet forever -- each revalidation refreshes its freshness
+# without ever replacing the body.
+STYLE_VERSION = "2"
+
+
 def style_etag(request, event, **kwargs):
-    parts = []
+    parts = [STYLE_VERSION]
     if color := request.event.primary_color:
         parts.append(f"{color}:{request.event.primary_color_needs_dark_text}")
     heading_font = request.event.display_settings.get("heading_font", "")
@@ -33,7 +42,8 @@ def style_etag(request, event, **kwargs):
         parts.append(f"f:{heading_font}:{text_font}")
     if request.GET.get("target") != "orga" and request.event.custom_css:
         parts.append(f"c:{request.event.custom_css.name}")
-    return ":".join(parts) if parts else "none"
+    # STYLE_VERSION keeps this non-empty, so there is no "no styles" special case.
+    return ":".join(parts)
 
 
 def _load_widget_js():
@@ -158,6 +168,28 @@ def event_css(request, event):
         rules.append(f"{variable}{postfix}: {color};")
     if rules:
         parts.append(":root { " + " ".join(rules) + " }")
+
+    if color and not is_orga:
+        # The dark scheme derives its text tokens from --color-primary with a
+        # fixed mix toward white, which cannot keep an arbitrary brand colour
+        # legible (a dark brand lands around 1.5:1 on the dark background). CSS
+        # cannot branch on luminance, so we compute the lift here. This is
+        # dark-only on purpose: light mode mixes toward black and is unchanged
+        # from upstream, and lifting it would alter light-mode rendering.
+        # Orga pages are excluded because there the brand colour is emitted as
+        # --color-primary-event, which only paints a border, while
+        # --color-primary-text keeps deriving from the default pretalx colour.
+        dark_rules = []
+        if text_color := dark_mode_text_override(color):
+            dark_rules.append(f"--color-primary-text: {text_color};")
+        if text_dark := dark_mode_text_override(color, floor=DARK_MODE_TEXT_DARK_MIX):
+            dark_rules.append(f"--color-primary-text-dark: {text_dark};")
+        if dark_rules:
+            parts.append(
+                "@media (prefers-color-scheme: dark) { :root { "
+                + " ".join(dark_rules)
+                + " } }"
+            )
 
     if not is_orga:
         if font_css := get_font_css(request.event):

--- a/src/pretalx/common/ui.py
+++ b/src/pretalx/common/ui.py
@@ -151,6 +151,90 @@ def has_good_contrast(color, threshold=4.5):
     return contrast_with_white >= threshold
 
 
+# Primary-coloured text sits on two dark surfaces: --color-bg (#121416, e.g. the
+# footer) and --color-grey-lightest (e.g. the skip link). The latter is lighter,
+# so it decides legibility -- but it is itself brand-dependent, being
+# --color-offwhite tinted with 5% of the brand colour, so we derive it below
+# rather than hardcode it. Keep in sync with the dark block of _variables.css.
+DARK_MODE_OFFWHITE = "#1a1d20"
+DARK_MODE_SURFACE_TINT = 0.05
+# The mix toward white that the dark block already applies to --color-primary-text.
+DARK_MODE_TEXT_MIX = 0.1
+# ... and to --color-primary-text-dark, which feeds --highlight-color-text.
+DARK_MODE_TEXT_DARK_MIX = 0.4
+
+
+def _parse_hex(color):
+    hex_color = color.lstrip("#")
+    if len(hex_color) == 3:  # The colour field permits the short #abc form
+        hex_color = "".join(char * 2 for char in hex_color)
+    try:
+        return tuple(int(hex_color[i : i + 2], 16) / 255 for i in (0, 2, 4))
+    except (ValueError, IndexError):
+        return None
+
+
+def _contrast_ratio(rgb, other_rgb):
+    luminances = (_relative_luminance(*rgb), _relative_luminance(*other_rgb))
+    return (max(luminances) + 0.05) / (min(luminances) + 0.05)
+
+
+def _mix_with_white(rgb, ratio):
+    """Mirror CSS ``color-mix(in srgb, <colour>, white <ratio>)``.
+
+    The srgb colour space interpolates gamma-encoded channels, so this is a
+    plain lerp of the 0-255 values rather than a linear-light blend.
+    """
+    return tuple(channel * (1 - ratio) + ratio for channel in rgb)
+
+
+def _to_hex(rgb):
+    return "#" + "".join(f"{round(channel * 255):02x}" for channel in rgb)
+
+
+def _dark_mode_surface(rgb):
+    """The lightest dark surface this brand's text lands on, i.e.
+    --color-grey-lightest: color-mix(in srgb, #1a1d20 95%, var(--color-primary)).
+    """
+    offwhite = _parse_hex(DARK_MODE_OFFWHITE)
+    return tuple(
+        base * (1 - DARK_MODE_SURFACE_TINT) + tint * DARK_MODE_SURFACE_TINT
+        for base, tint in zip(offwhite, rgb)
+    )
+
+
+def dark_mode_text_override(color, floor=DARK_MODE_TEXT_MIX, threshold=4.5):
+    """Return the hex that a primary ``-text`` token has to be overridden with in
+    the dark colour scheme, or None if no override is needed.
+
+    CSS cannot branch on a colour's luminance, so the dark colour scheme lifts
+    every ``-text`` token toward white by a fixed amount. That is fine for the
+    tokens built on a hue we picked, but the event's brand colour is arbitrary:
+    a dark brand stays illegible however the stylesheet mixes it (#1a1a2e lifted
+    by the stylesheet's ``floor`` of 10% reaches only 1.45:1). So we compute the
+    required lift here, and event_css emits it as a dark-only override.
+
+    None means "leave the stylesheet alone": either the brand is already legible
+    at ``floor``, or it is unparseable. Emitting nothing rather than an equivalent
+    hex keeps those brands rendering exactly as they do today, to the pixel --
+    our hex is 8-bit, whereas the stylesheet's color-mix keeps full precision.
+    """
+    rgb = _parse_hex(color)
+    if rgb is None:
+        return None
+    # Clearing the lightest surface clears the darker ones too.
+    surface = _dark_mode_surface(rgb)
+    # Unrounded, because this is what the browser renders if we stay out of it.
+    if _contrast_ratio(_mix_with_white(rgb, floor), surface) >= threshold:
+        return None
+    for percent in range(round(floor * 100) + 1, 101):
+        # Compare the rounded hex, since that is what the browser will paint.
+        candidate = _to_hex(_mix_with_white(rgb, percent / 100))
+        if _contrast_ratio(_parse_hex(candidate), surface) >= threshold:
+            return candidate
+    return "#ffffff"
+
+
 def _lightness_for_luminance(hue, saturation, target):
     """Search the HSL lightness matching the luminance for the given hue.
 

--- a/src/pretalx/frontend/schedule-editor/src/App.vue
+++ b/src/pretalx/frontend/schedule-editor/src/App.vue
@@ -631,9 +631,9 @@ export default {
 		right: 0
 		width: 300px
 		z-index: 500
-		background-color: $clr-white
+		background-color: var(--color-bg)
 		padding: 8px 16px
-		box-shadow: 0 0 10px rgba(0, 0, 0, 0.3)
+		box-shadow: var(--shadow-wide)
 		border-top-left-radius: 8px
 		overflow-y: hidden
 		.collapse-content
@@ -683,9 +683,9 @@ export default {
 			padding-right: 8px
 		.timezone-label
 			cursor: default
-			color: $clr-secondary-text-light
+			color: var(--color-text-lighter)
 	.days
-		tabs-style(active-color: var(--pretalx-clr-primary), indicator-color: var(--pretalx-clr-primary), background-color: transparent)
+		tabs-style(color: var(--color-text-lighter), active-color: var(--pretalx-clr-primary), indicator-color: var(--pretalx-clr-primary), background-color: transparent)
 		overflow-x: auto
 		margin-bottom: 0
 		flex: auto
@@ -702,7 +702,7 @@ export default {
 				white-space: nowrap
 	#unassigned
 		margin-top: 35px
-		background-color: $clr-white
+		background-color: var(--color-bg)
 		width: 350px
 		flex: none
 		.session-list
@@ -713,8 +713,8 @@ export default {
 			padding 4px 0
 			font-size: 18px
 			text-align: center
-			background-color: $clr-white
-			border-bottom: 4px solid $clr-dividers-light
+			background-color: var(--color-bg)
+			border-bottom: 4px solid var(--color-card-border)
 			display: flex
 			align-items: flex-end
 			margin-left: 8px
@@ -731,29 +731,29 @@ export default {
 				border-radius: 4px
 				margin-bottom: 8px
 				margin-left: 4px
-				color: $clr-secondary-text-light
+				color: var(--color-text-lighter)
 				&:hover, &.active
 					opacity: 0.8
-					background-color: $clr-dividers-light
+					background-color: var(--pretalx-clr-subtle-fill)
 		.new-slot-row
 			display: flex
 			align-items: center
 			.slot-help-icon
 				margin-left: 8px
 				margin-right: 8px
-				color: $clr-secondary-text-light
+				color: var(--color-text-lighter)
 				cursor: help
 				font-size: 14px
 				&:hover
-					color: $clr-primary-text-light
+					color: var(--color-text)
 		.new-break.c-linear-schedule-session, .new-blocker.c-linear-schedule-session
 			min-height: 48px
 			flex: 1
 		#unassigned-sort-menu
-			color: $clr-primary-text-light
+			color: var(--color-text)
 			display: flex
 			flex-direction: column
-			background-color: white
+			background-color: var(--color-bg)
 			position: absolute
 			top: 53px
 			right: 15px
@@ -761,7 +761,7 @@ export default {
 			font-size: 16px
 			cursor: pointer
 			z-index: 1000
-			box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5)
+			box-shadow: var(--shadow-dialog)
 			text-align: left;
 			.sort-method
 				padding: 8px 16px
@@ -769,7 +769,7 @@ export default {
 				justify-content: space-between
 				align-items: center
 				&:hover
-					background-color: $clr-dividers-light
+					background-color: var(--pretalx-clr-subtle-fill)
 	.schedule-header
 		display: flex
 		justify-content: space-between
@@ -786,35 +786,35 @@ export default {
 				align-items: center
 				gap: 8px
 				padding: 8px 16px
-				background-color: $clr-white
-				border: 1px solid $clr-dividers-light
+				background-color: var(--color-bg)
+				border: 1px solid var(--color-border)
 				border-radius: 4px
 				cursor: pointer
 				font-size: 14px
-				color: $clr-primary-text-light
+				color: var(--color-text)
 				white-space: nowrap
 				transition: all 0.2s
 				&:hover
-					background-color: $clr-grey-100
+					background-color: var(--color-grey-lightest)
 					border-color: var(--pretalx-clr-primary)
 				&.active
 					background-color: var(--pretalx-clr-primary)
-					color: $clr-white
+					color: var(--pretalx-clr-text-on-primary)
 					border-color: var(--pretalx-clr-primary)
 				.fa
 					font-size: 16px
 			.grid-interval-select
 				padding: 8px 16px
-				background-color: $clr-white
-				border: 1px solid $clr-dividers-light
+				background-color: var(--color-bg)
+				border: 1px solid var(--color-border)
 				border-radius: 4px
 				font-family: var(--font-family-title)
 				font-size: 14px
-				color: $clr-primary-text-light
+				color: var(--color-text)
 				cursor: pointer
 				transition: all 0.2s
 				&:hover
-					background-color: $clr-grey-100
+					background-color: var(--color-grey-lightest)
 					border-color: var(--pretalx-clr-primary)
 				&:focus
 					outline: none
@@ -835,8 +835,8 @@ export default {
 		left: 0
 		top: 0
 		z-index: 30
-		background-color: $clr-white
-  #session-editor-wrapper
+		background-color: var(--color-bg)
+	#session-editor-wrapper
 		position: absolute
 		z-index: 1000
 		top: 0
@@ -846,7 +846,7 @@ export default {
 		background-color: rgba(0, 0, 0, 0.5)
 
 		#session-editor
-			background-color: $clr-white
+			background-color: var(--color-bg)
 			border-radius: 4px
 			padding: 32px 40px
 			position: absolute
@@ -901,11 +901,13 @@ export default {
 					border-radius: 4px
 					font-weight: 500
 					&.slot-type-break
-						background-color: $clr-grey-200
-						color: $clr-secondary-text-light
+						background-color: var(--color-grey-lighter)
+						color: var(--color-text-lighter)
 					&.slot-type-blocker
-						background-color: $clr-red-50
-						color: $clr-red-300
+						background-color: var(--pretalx-clr-blocker-bg)
+						// Scheme-independent ink: legible on the pale light fill and on the
+						// dark mix alike. Byte-identical to the previous $clr-red-300.
+						color: #e57373
 		.warning
-			color: #b23e65
+			color: var(--color-danger)
 </style>

--- a/src/pretalx/frontend/schedule-editor/src/components/GridSchedule.vue
+++ b/src/pretalx/frontend/schedule-editor/src/components/GridSchedule.vue
@@ -587,7 +587,7 @@ export default {
 .c-grid-schedule
 	flex: auto
 	.grid
-		background-color: $clr-grey-50
+		background-color: var(--color-offwhite)
 		display: grid
 		grid-template-columns: 78px repeat(var(--total-rooms), minmax(310px, 1fr)) auto
 		// grid-gap: 8px
@@ -604,62 +604,73 @@ export default {
 			justify-content: center
 			align-items: center
 			font-size: 18px
-			background-color: $clr-white
-			border-bottom: border-separator()
+			background-color: var(--color-bg)
+			border-bottom: 1px solid var(--color-card-border)
 			z-index: 20
 			.hide-room
-				color: $clr-secondary-text-light
+				color: var(--color-text-lighter)
 				font-size: 14px
 				margin-left: 16px
 				cursor: pointer
 				padding: 4px 8px
 				border-radius: 4px
 				&:hover
-					background-color: $clr-grey-200
+					background-color: var(--color-grey-lighter)
 		.c-linear-schedule-session
 			z-index: 10
 	.timeslice
-		color: $clr-secondary-text-light
+		color: var(--color-text-lighter)
 		padding: 8px 10px 0 10px
 		white-space: nowrap
 		position: sticky
 		left: 0
 		text-align: center
-		background-color: $clr-grey-50
-		border-top: 1px solid $clr-dividers-light
+		// Must stay identical to .grid: the gutter is visually continuous with
+		// the grid canvas and is only a separate rule to get position: sticky.
+		background-color: var(--color-offwhite)
+		border-top: 1px solid var(--color-card-border)
 		z-index: 20
 		font-size: 14px
 		.expand
 			display: none
 		&.datebreak
 			font-weight: 600
-			border-top: 3px solid $clr-dividers-light
+			// Must stay identical to .timeseparator.datebreak: one visual line
+			// drawn across both the gutter and the room columns.
+			border-top: 3px solid var(--color-card-border)
 			white-space: pre
 		&.expandable:hover
-			background-color: $clr-grey-200
+			background-color: var(--color-grey-lighter)
 			cursor: pointer
 			.expand
 				display: block
 				width: 20px
 				margin: 4px auto
 				path
-					fill: $clr-grey-500
+					fill: var(--color-grey-medium)
 
 	.timeseparator
 		height: 1px
-		background-color: $clr-dividers-light
+		background-color: var(--color-card-border)
 		position: absolute
 		// transform: translate(-16px, -8px)
 		width: 100%
 		&.datebreak
 			height: 3px
+	// Nested under .c-grid-schedule: .availability is a generic single-class
+	// selector that was emitted globally and painted an unconditional
+	// background on any element of that name. These elements are children of
+	// .grid, so nesting hits exactly the same nodes.
+	.availability
+		background-color: var(--color-bg)
+		pointer-events: none
+		&.active
+			// .active fully replaces the fill above rather than layering over
+			// it, so the token carries a higher alpha in dark, where it
+			// composites onto the dark canvas instead of white.
+			background-color: var(--pretalx-clr-availability-active)
 .bunt-scrollbar-rail-wrapper-x, .bunt-scrollbar-rail-wrapper-y
 	z-index: 30
-.availability
-	background-color: white
-	pointer-events: none
-	&.active
-		background-color: rgba(56, 158, 119, 0.1)
 .c-grid-schedule.condensed-grid
 	.grid
 		grid-template-columns: 58px repeat(var(--total-rooms), minmax(150px, 1fr)) auto
@@ -678,7 +689,7 @@ export default {
 			padding-top: 0
 #hiddenRooms.collapse-container
 	.room-entry
-		border-bottom: border-separator()
+		border-bottom: 1px solid var(--color-card-border)
 		display: flex
 		justify-content: space-between
 		align-items: center
@@ -686,13 +697,13 @@ export default {
 		padding: 4px 0
 		cursor: pointer
 		.show-room
-			color: $clr-secondary-text-light
+			color: var(--color-text-lighter)
 			font-size: 14px
 			margin-left: 16px
 			padding: 4px 8px
 			border-radius: 4px
 		&:hover
-			background-color: $clr-grey-100
+			background-color: var(--color-grey-lightest)
 
 .condensed-mode #hiddenRooms
 	right: 345px  // 350px unassigned panel - 5px spacing to not overlap the rounded column

--- a/src/pretalx/frontend/schedule-editor/src/components/Session.vue
+++ b/src/pretalx/frontend/schedule-editor/src/components/Session.vue
@@ -136,7 +136,7 @@ export default {
 @import 'session'
 .c-linear-schedule-session
 	session-layout()
-	color: $clr-primary-text-light
+	color: var(--color-text)
 	cursor: pointer
 	user-select: none
 	-webkit-user-select: none
@@ -148,49 +148,49 @@ export default {
 		filter: opacity(0.3)
 		cursor: inherit
 	&.isbreak
-		background-color: $clr-grey-200
+		background-color: var(--color-grey-lighter)
 		border-radius: 6px
 		.time-box
-			background-color: $clr-grey-500
+			background-color: var(--pretalx-clr-break-time-bg)
 			.start
-				color: $clr-primary-text-dark
+				color: var(--pretalx-clr-text-on-fill)
 			.duration
-				color: $clr-secondary-text-dark
+				color: var(--pretalx-clr-text-on-fill-secondary)
 		.info
 			justify-content: center
 			align-items: center
 			.title
 				font-size: 20px
-				color: $clr-secondary-text-light
+				color: var(--color-text-lighter)
 				text-align: center
 	&.isblocker
-		background-color: $clr-red-50
+		background-color: var(--pretalx-clr-blocker-bg)
 		border-radius: 6px
 		.time-box
-			background-color: $clr-red-200
+			background-color: var(--pretalx-clr-blocker-time-bg)
 			.start
-				color: $clr-primary-text-dark
+				color: var(--pretalx-clr-text-on-fill)
 			.duration
-				color: $clr-secondary-text-dark
+				color: var(--pretalx-clr-text-on-fill-secondary)
 		.info
 			justify-content: center
 			align-items: center
 			.title
 				font-size: 20px
-				color: $clr-red-300
+				color: var(--color-danger-text)
 				text-align: center
 	&.istalk
 		.time-box
 			background-color: var(--track-color)
 			.start
-				color: $clr-primary-text-dark
+				color: var(--pretalx-clr-text-on-fill)
 			.duration
-				color: $clr-secondary-text-dark
+				color: var(--pretalx-clr-text-on-fill-secondary)
 		.info
-			border: border-separator()
+			border: 1px solid var(--color-card-border)
 			border-left: none
 			border-radius: 0 6px 6px 0
-			background-color: $clr-white
+			background-color: var(--color-bg)
 			.title
 				font-size: 16px
 				margin-bottom: 4px
@@ -204,7 +204,7 @@ export default {
 		.time-box
 			opacity: 0.5
 		.info
-			background-image: repeating-linear-gradient(-38deg, $clr-grey-100, $clr-grey-100 10px, $clr-white 10px, $clr-white 20px)
+			background-image: repeating-linear-gradient(-38deg, var(--color-grey-lightest), var(--color-grey-lightest) 10px, var(--color-bg) 10px, var(--color-bg) 20px)
 		&:hover
 			.info
 				border: 1px solid var(--track-color)
@@ -222,17 +222,17 @@ export default {
 			color: var(--pretalx-clr-primary)
 			margin-left: 6px
 		.bottom-info .signup-icon.full
-			color: $clr-danger
+			color: var(--color-danger)
 		.bottom-info .track
 			margin-right: 0
 		.speakers
-			color: $clr-secondary-text-light
+			color: var(--color-text-lighter)
 	.pending-line
-		color: $clr-warning
+		color: var(--color-warning-text)
 		.fa
 			margin-right: 4px
 	.warning
-		color: #b23e65
+		color: var(--color-danger)
 		font-size: 16px
 		flex: none
 		margin-left: auto

--- a/src/pretalx/frontend/schedule/src/App.vue
+++ b/src/pretalx/frontend/schedule/src/App.vue
@@ -905,17 +905,17 @@ export default {
 	text-align: center
 	padding: 32px
 	&.error
-		color: $clr-error
+		color: var(--color-danger)
 	&.info
-		color: $clr-grey-600
+		color: var(--color-grey-medium)
 	&.filtered-empty
-		color: $clr-grey-600
+		color: var(--color-grey-medium)
 		padding-top: 48px
 		.clear-filters-button
 			margin-top: 16px
 			padding: 10px 20px
 			background-color: var(--pretalx-clr-primary)
-			color: white
+			color: var(--pretalx-clr-text-on-primary)
 			border: none
 			border-radius: 6px
 			font-size: 14px
@@ -927,7 +927,7 @@ export default {
 		margin-top: 16px
 
 .pretalx-schedule, dialog.pretalx-modal
-	color: rgb(13 15 16)
+	color: var(--color-text)
 
 .pretalx-schedule
 	display: flex
@@ -935,8 +935,7 @@ export default {
 	min-height: 0
 	height: 100%
 	font-size: 14px
-	background-color: $clr-grey-50
-	--pretalx-clr-text: rgb(13,15,16)
+	background-color: var(--color-offwhite)
 	&.grid-schedule
 		min-width: min-content
 		max-width: var(--schedule-max-width)
@@ -944,14 +943,14 @@ export default {
 	&.list-schedule
 		min-width: 0
 	.days-wrapper
-		background-color: $clr-white
+		background-color: var(--color-bg)
 		width: 100%
 		position: sticky
 		top: var(--pretalx-sticky-top-offset, 0px)
 		z-index: 30
 	.days
-		background-color: $clr-white
-		tabs-style(active-color: var(--pretalx-clr-primary), indicator-color: var(--pretalx-clr-primary), background-color: transparent)
+		background-color: var(--color-bg)
+		tabs-style(active-color: var(--pretalx-clr-primary), indicator-color: var(--pretalx-clr-primary), background-color: transparent, color: var(--color-text-lighter))
 		overflow-x: auto
 		left: 0
 		margin: 0 auto
@@ -977,15 +976,15 @@ export default {
 	z-index: 1000
 	.error-message
 		padding: 8px
-		color: $clr-danger
-		background-color: $clr-white
-		border: 2px solid $clr-danger
+		color: var(--color-danger)
+		background-color: var(--color-bg)
+		border: 2px solid var(--color-danger)
 		border-radius: 6px
-		box-shadow: 0 2px 4px rgba(0,0,0,0.2)
+		box-shadow: var(--shadow-light)
 		margin-top: 8px
 		position: relative
 		.btn
-			border: 1px solid $clr-danger
+			border: 1px solid var(--color-danger)
 			border-radius: 2px
 			box-shadow: 1px 1px 2px rgba(0,0,0,0.2)
 			width: 18px
@@ -1001,16 +1000,16 @@ export default {
 			margin-right: 22px
 .powered-by
 	text-align: center
-	color: $clr-grey-600
+	color: var(--color-grey-medium)
 	font-size: 12px
 	margin-top: 16px
 	margin-bottom: 16px
 	a
 		transition: all 0.1s ease-in
 		font-weight: bold
-		color: $clr-grey-600
+		color: var(--color-grey-medium)
 		text-decoration: none
 	a:hover
-		color: #3aa57c
+		color: var(--pretalx-clr-success)
 
 </style>

--- a/src/pretalx/frontend/schedule/src/components/FavButton.vue
+++ b/src/pretalx/frontend/schedule/src/components/FavButton.vue
@@ -44,7 +44,7 @@ svg.star
 		animation: rotate-star 0.4s
 .faved
 	svg.star
-		filter: drop-shadow(0 0 1px rgba(0 0 0 0.17))
+		filter: drop-shadow(0 0 1px var(--pretalx-clr-star-shadow))
 		path
 			fill: #ffa000
 @keyframes rotate-star

--- a/src/pretalx/frontend/schedule/src/components/FilterBar.vue
+++ b/src/pretalx/frontend/schedule/src/components/FilterBar.vue
@@ -71,7 +71,9 @@ SPDX-License-Identifier: Apache-2.0
 	//- Right side: Timezone selector only
 	.timezone-container
 		template(v-if="!inEventTimezone")
-			bunt-select.timezone-select(name="timezone", :options="timezoneOptions", v-model="timezoneModel", @blur="$emit('saveTimezone')")
+			//- dropdown-class: the dropdown menu is teleported to #bunt-teleport-target
+			//- (a sibling of .filter-bar), so a descendant selector cannot reach it.
+			bunt-select.timezone-select(name="timezone", dropdown-class="timezone-dropdown", :options="timezoneOptions", v-model="timezoneModel", @blur="$emit('saveTimezone')")
 		template(v-else-if="scheduleTimezone")
 			.timezone-label {{ scheduleTimezone }}
 </template>
@@ -244,7 +246,7 @@ export default {
 	width: 100%
 	max-width: var(--schedule-max-width)
 	align-self: center
-	background-color: $clr-white
+	background-color: var(--color-bg)
 
 	&.two-rows
 		flex-direction: column-reverse
@@ -286,8 +288,22 @@ export default {
 		.timezone-select
 			max-width: 200px
 
+			// buntpapier emits select()/input() unconditionally and this app never
+			// calls select-style(style: 'dark'), so these inks are hardcoded light.
+			// Scoped to .timezone-container so other bunt-selects are unaffected.
+			.open-indicator
+				color: var(--color-text-lighter)
+
+			.bunt-input
+				input
+					color: var(--color-text-input)
+
+				// input() strokes the outline with a 38%-black that vanishes on #121416.
+				.outline
+					stroke: var(--pretalx-clr-subtle-ink)
+
 		.timezone-label
-			color: $clr-secondary-text-light
+			color: var(--color-text-lighter)
 			font-size: 14px
 			white-space: nowrap
 
@@ -295,18 +311,38 @@ export default {
 		flex-shrink: 0
 
 		&.clear-all-trigger
-			border-color: $clr-danger
+			border-color: var(--color-danger)
 			background-color: transparent
-			color: $clr-danger
+			color: var(--color-danger-text)
 
 			@media (hover: hover)
 				&:hover
-					border-color: $clr-danger
-					background-color: $clr-danger
-					color: $clr-white
+					border-color: var(--color-danger)
+					background-color: var(--color-danger)
+					// Ink on a hue-fixed rose fill that does not follow the
+					// scheme, so it must stay scheme-independent.
+					color: var(--pretalx-clr-text-on-fill)
 
 		.filter-icon
 			width: 18px
 			height: 18px
 			fill: currentColor
+
+// The timezone dropdown is teleported to #bunt-teleport-target, a sibling of
+// .filter-bar, so it cannot be nested in the block above. buntpapier styles it
+// with card(), which hardcodes background-color: $clr-white and emits no colour,
+// leaving near-white ink on a white card in dark mode. The .timezone-dropdown
+// class (passed via the dropdown-class prop) keeps this off other bunt-selects.
+.bunt-select-dropdown-menu.timezone-dropdown
+	background-color: var(--color-bg)
+	color: var(--color-text)
+	border: 1px solid var(--color-border)
+	// card() is shadow-only and select.styl removes the top border so the menu
+	// reads as attached to the input; keep that while adding an edge for dark.
+	border-top: none
+
+	li.highlight
+		// $highlight-color falls through to buntpapier's $clr-blue, which is never
+		// overridden here; var(--color-grey-lightest) flips with the card surface.
+		background-color: var(--color-grey-lightest)
 </style>

--- a/src/pretalx/frontend/schedule/src/components/FilterBottomSheet.vue
+++ b/src/pretalx/frontend/schedule/src/components/FilterBottomSheet.vue
@@ -261,9 +261,9 @@ export default {
 		bottom: 0
 		width: 100vw
 		max-height: 70vh
-		background-color: $clr-white
+		background-color: var(--color-bg)
 		border-radius: 16px 16px 0 0
-		box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15)
+		box-shadow: var(--pretalx-shadow-sheet)
 		z-index: 1000
 		display: flex
 		flex-direction: column
@@ -274,7 +274,7 @@ export default {
 			align-items: center
 			justify-content: space-between
 			padding: 16px 20px 8px
-			border-bottom: 1px solid $clr-grey-200
+			border-bottom: 1px solid var(--color-border)
 			flex-shrink: 0
 			gap: 12px
 
@@ -288,13 +288,13 @@ export default {
 				border: none
 				cursor: pointer
 				padding: 8px
-				color: $clr-grey-600
+				color: var(--color-text-muted)
 				font-size: 20px
 				font-weight: bold
 				line-height: 1
 				&:hover
 					background: none
-					color: $clr-grey-900
+					color: var(--color-text)
 
 		.sheet-content
 			flex: 1
@@ -303,7 +303,7 @@ export default {
 
 		.sheet-footer
 			padding: 16px 20px
-			border-top: 1px solid $clr-grey-200
+			border-top: 1px solid var(--color-border)
 			flex-shrink: 0
 			display: flex
 			flex-direction: column
@@ -313,7 +313,7 @@ export default {
 		width: 100%
 		padding: 12px 20px
 		background-color: var(--pretalx-clr-primary)
-		color: $clr-white
+		color: var(--pretalx-clr-text-on-primary)
 		border: none
 		border-radius: 8px
 		font-size: 16px
@@ -323,7 +323,7 @@ export default {
 
 		&:hover
 			background-color: var(--pretalx-clr-primary)
-			color: $clr-white
+			color: var(--pretalx-clr-text-on-primary)
 			opacity: 0.9
 
 	.clear-all-button
@@ -341,7 +341,7 @@ export default {
 		@media (hover: hover)
 			&:hover
 				background-color: var(--pretalx-clr-primary)
-				color: $clr-white
+				color: var(--pretalx-clr-text-on-primary)
 
 	#filter-bottom-sheet-dialog
 		position: fixed
@@ -390,7 +390,7 @@ export default {
 		.dialog-footer
 			margin-top: 20px
 			padding-top: 16px
-			border-top: 1px solid $clr-grey-200
+			border-top: 1px solid var(--color-border)
 			display: flex
 			flex-direction: column
 			gap: 8px

--- a/src/pretalx/frontend/schedule/src/components/FilterPill.vue
+++ b/src/pretalx/frontend/schedule/src/components/FilterPill.vue
@@ -53,38 +53,56 @@ export default {
 	font-size: 14px
 	font-weight: 500
 	cursor: pointer
-	transition: all 0.2s ease
-	border: 1.5px solid $clr-grey-300
+	transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease
+	border: 1.5px solid var(--pretalx-clr-border)
 	background-color: transparent
-	color: $clr-grey-700
+	color: var(--color-grey-dark, #495057)
 	white-space: nowrap
+
+	@media (prefers-reduced-motion: reduce)
+		transition: none
 
 	@media (hover: hover)
 		&:hover
-			border-color: $clr-grey-400
-			background-color: $clr-grey-100
-			color: $clr-grey-700
+			// Hover border stays more prominent than the resting --color-border in
+			// both schemes: #6c757d is darker than #ced4da, #adb5bd lighter than #495057.
+			border-color: var(--color-grey-medium, #6c757d)
+			background-color: var(--color-grey-lightest, #f8f9fa)
 
 	&.active
 		border-color: var(--pill-color, var(--pretalx-clr-primary))
 		background-color: var(--pill-color, var(--pretalx-clr-primary))
-		color: $clr-white
+		// Colourless pills fall back to the brand fill, whose ink event_css may
+		// override; coloured pills carry a fixed track/tag colour instead.
+		color: var(--pretalx-clr-text-on-primary)
+
+		&.has-color
+			color: var(--pretalx-clr-text-on-fill)
 
 		@media (hover: hover)
 			&:hover
-				background-color: var(--pill-color, var(--pretalx-clr-primary))
-				color: $clr-white
 				opacity: 0.9
 
-	&.has-color:not(.active)
-		border-color: var(--pill-color)
-		color: var(--pill-color)
+	&.has-color
+		// Declared here, not in tokens.styl: --pill-color is set inline per pill,
+		// so a declaration on html/body would substitute an absent --pill-color.
+		--pretalx-clr-pill-ink: var(--pill-color)
 
-		@media (hover: hover)
-			&:hover
-				background-color: var(--pill-color)
-				color: $clr-white
-				opacity: 0.85
+		&:not(.active)
+			border-color: var(--pretalx-clr-pill-ink)
+			color: var(--pretalx-clr-pill-ink)
+
+			@media (hover: hover)
+				&:hover
+					background-color: var(--pill-color)
+					color: var(--pretalx-clr-text-on-fill)
+					opacity: 0.85
+
+	@media (prefers-color-scheme: dark)
+		// Track/tag colours are authored against a white schedule, so dark hues are
+		// common; lift them for use as ink on #121416. Fills keep the raw colour.
+		&.has-color
+			--pretalx-clr-pill-ink: unquote('color-mix(in srgb, var(--pill-color), white 45%)')
 
 	.label
 		line-height: 1.2

--- a/src/pretalx/frontend/schedule/src/components/FilterSections.vue
+++ b/src/pretalx/frontend/schedule/src/components/FilterSections.vue
@@ -168,7 +168,7 @@ export default {
 			display: block
 			font-size: 13px
 			font-weight: 600
-			color: $clr-grey-600
+			color: var(--color-text-muted)
 			margin-bottom: 8px
 			text-transform: uppercase
 			letter-spacing: 0.5px
@@ -188,19 +188,25 @@ export default {
 				left: 12px
 				width: 18px
 				height: 18px
-				color: $clr-grey-400
+				color: var(--color-grey)
 				pointer-events: none
 
 			.search-input
 				width: 100%
 				padding: 10px 14px 10px 38px
-				border: 1.5px solid $clr-grey-300
+				background-color: var(--color-bg)
+				color: var(--color-text-input)
+				border: 1.5px solid var(--color-border)
 				border-radius: 8px
 				font-size: 14px
 				outline: none
 				transition: border-color 0.2s ease
 				box-sizing: border-box
 
+				&::placeholder
+					color: var(--color-grey)
+
 				&:focus
 					border-color: var(--pretalx-clr-primary)
+					box-shadow: var(--shadow-focus)
 </style>

--- a/src/pretalx/frontend/schedule/src/components/GridSchedule.vue
+++ b/src/pretalx/frontend/schedule/src/components/GridSchedule.vue
@@ -376,53 +376,68 @@ export default {
 			justify-content: center
 			align-items: center
 			font-size: 18px
-			background-color: $clr-white
-			border-bottom: border-separator()
+			background-color: var(--color-bg)
+			border-bottom: 1px solid var(--color-card-border)
 			z-index: 20
 			.room-description
-				border: 2px solid $clr-grey-400
+				border: 2px solid var(--color-border)
 				border-radius: 100%
 				height: 20px
 				width: 20px
 				padding: 0
 				font-weight: bold
 				min-width: 0
+				// The mixin emits the structure and state rules; a CSS var cannot be
+				// passed as its `color` (build-time darken() throws on a non-colour),
+				// so call it verbatim and override only the colour-bearing literals.
 				button-style(color: $clr-white, text-color: $clr-grey-500)
+				background-color: var(--color-bg)
+				color: var(--color-grey-medium)
+				&:hover
+					background-color: var(--color-grey-light)
+				// Both selectors are required: a bare &:focus loses to the mixin's
+				// body[modality="keyboard"] .room-description:focus.
+				&.autofocus:focus, body[modality="keyboard"] &:focus
+					background-color: var(--color-grey-light)
+					outline-color: var(--color-border)
+				.bunt-progress-circular svg circle
+					stroke: var(--color-grey-medium)
 				margin-left: 8px
 				.bunt-tooltip
 					height: auto
 					width: 200px
 					white-space: normal
+		// .break is co-styled by Session.vue, whose <style> block is unscoped and
+		// whose selector list is `.c-linear-schedule-session, .break`. The .start /
+		// .duration ink on this chip comes from there: the fill below is
+		// scheme-independent, so that ink stays the on-fill (white) tokens and must
+		// not be pointed at --color-text*.
 		.break
 			.time-box
-				background-color: $clr-grey-500
-				.start
-					color: $clr-primary-text-dark
-				.duration
-					color: $clr-secondary-text-dark
+				background-color: var(--pretalx-clr-break-time-bg)
 			.info
-				background-color: $clr-grey-200
+				background-color: var(--color-grey-lighter)
 				border: none
 				justify-content: center
 				align-items: center
 				.title
 					font-size: 16px
 					font-weight: 500
-					color: $clr-secondary-text-light
+					color: var(--color-text-lighter)
 					align: center
 	.timeslice
-		color: $clr-secondary-text-light
+		color: var(--color-text-lighter)
 		padding: 8px 10px 0 16px
 		white-space: nowrap
 		position: sticky
 		left: 0
 		text-align: center
-		background-color: $clr-grey-50
-		border-top: 1px solid $clr-dividers-light
+		background-color: var(--color-offwhite)
+		border-top: 1px solid var(--color-card-border)
 		z-index: 20
 		&.datebreak
 			font-weight: 600
-			border-top: 3px solid $clr-dividers-light
+			border-top: 3px solid var(--color-card-border)
 			white-space: pre
 		&.gap
 			&::before
@@ -433,14 +448,14 @@ export default {
 				position: absolute
 				top: 30px
 				left: 50%
-				background-image: radial-gradient(circle closest-side, $clr-grey-500 calc(100% - .5px), transparent 100%)
+				background-image: radial-gradient(circle closest-side, var(--color-grey-medium) calc(100% - .5px), transparent 100%)
 				background-position: 0 0
 				background-size: 5px 15px
 				background-repeat: repeat-y
 
 	.timeline
 		height: 1px
-		background-color: $clr-dividers-light
+		background-color: var(--color-card-border)
 		position: absolute
 		width: 100%
 		&.datebreak
@@ -453,18 +468,18 @@ export default {
 			content: ''
 			display: block
 			height: 2px
-			background-color: $clr-red
+			background-color: var(--pretalx-clr-now)
 			position: absolute
 			top: calc(var(--offset) * 100%)
 			width: 100%
 		&.on-daybreak::before
-			background: repeating-linear-gradient(to right, transparent, transparent 5px, $clr-red 5px, $clr-red 10px)
+			background: repeating-linear-gradient(to right, transparent, transparent 5px, var(--pretalx-clr-now) 5px, var(--pretalx-clr-now) 10px)
 		svg
 			position: absolute
 			top: calc(var(--offset) * 100% - 11px)
 			height: 24px
 			width: 24px
-			fill: $clr-red
+			fill: var(--pretalx-clr-now)
 	.bunt-scrollbar-rail-wrapper-x, .bunt-scrollbar-rail-wrapper-y
 		z-index: 30
 </style>

--- a/src/pretalx/frontend/schedule/src/components/LinearSchedule.vue
+++ b/src/pretalx/frontend/schedule/src/components/LinearSchedule.vue
@@ -164,7 +164,7 @@ export default {
 		.bucket-label
 			font-size: 14px
 			font-weight: 500
-			color: $clr-secondary-text-light
+			color: var(--pretalx-clr-text-lighter)
 			padding-left: 16px
 			.day
 				font-weight: 600
@@ -173,12 +173,12 @@ export default {
 			margin: 8px
 			padding: 8px
 			border-radius: 4px
-			background-color: $clr-grey-200
+			background-color: var(--color-grey-lighter, #eeeeee)
 			display: flex
 			justify-content: center
 			align-items: center
 			.title
 				font-size: 20px
 				font-weight: 500
-				color: $clr-secondary-text-light
+				color: var(--pretalx-clr-text-lighter)
 </style>

--- a/src/pretalx/frontend/schedule/src/components/Session.vue
+++ b/src/pretalx/frontend/schedule/src/components/Session.vue
@@ -31,10 +31,10 @@ a.c-linear-schedule-session(:class="{faved, 'signed-up': signedUp, 'signup-full'
 			i.fa.fa-user-times.signup-icon.full(v-if="isFull && !signedUp", :title="translationMessages?.signup_full || 'This session is full'", :aria-label="translationMessages?.signup_full || 'This session is full'")
 			i.fa.fa-calendar-check-o.signed-up-icon(v-if="signedUp", :title="translationMessages?.signup_signed_up || 'You are signed up for this session'", :aria-label="translationMessages?.signup_signed_up || 'You are signed up for this session'")
 			svg.do-not-record(v-if="session.do_not_record", viewBox="0 0 116.59076 116.59076", fill="none", xmlns="http://www.w3.org/2000/svg", role="img", :aria-label="translationMessages?.not_recorded || 'Not recorded'")
-				g(transform="translate(-9.3465481,-5.441411)")
-					rect(style="fill:#000000;fill-opacity;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
-					path(style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
-					path(style="fill:none;stroke:#b23e65;stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
+				g(transform="translate(-9.3465481,-5.441411)", fill="currentColor")
+					rect(style="fill-opacity:1;stroke:none;stroke-width:11.2589;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", width="52.753284", height="39.619537", x="35.496307", y="43.927021", rx="5.5179553", ry="7.573648")
+					path(style="fill-opacity:1;stroke:none;stroke-width:18.7997;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="M 99.787546,47.04792 V 80.425654 L 77.727407,63.736793 Z")
+					path(style="fill:none;stroke:var(--color-danger);stroke-width:12;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill", d="m 35.553146,95.825578 64.177559,-64.17757 m 16.294055,32.08879 A 48.382828,48.382828 0 0 1 67.641925,112.11961 48.382828,48.382828 0 0 1 19.259099,63.736798 48.382828,48.382828 0 0 1 67.641925,15.353968 48.382828,48.382828 0 0 1 116.02476,63.736798 Z")
 	.session-icons
 		fav-button(@toggleFav="toggleFav")
 
@@ -160,17 +160,22 @@ export default {
 .c-linear-schedule-session, .break
 	session-layout()
 	z-index: 10
-	color: rgb(13 15 16)
+	// elements.styl sets `a.c-linear-schedule-session { color: var(--pretalx-clr-text) }`
+	// at higher specificity, so this has to use the same token to have any effect.
+	color: var(--pretalx-clr-text)
 	font-size: 14px
 	.time-box
 		background-color: var(--track-color)
+		// .start and .duration are siblings on one --track-color fill, which is a
+		// DB colour (or the event brand colour) and does not follow the scheme.
+		// Both inks must stay scheme-independent white: keep this pair in step.
 		.start
-			color: $clr-primary-text-dark
+			color: var(--pretalx-clr-text-on-fill)
 			.date
 				margin-bottom: 4px
 				white-space: nowrap
 		.duration
-			color: $clr-secondary-text-dark
+			color: var(--pretalx-clr-text-on-fill-secondary)
 		.buffer
 			flex: auto
 		.is-live
@@ -180,21 +185,23 @@ export default {
 			padding: 2px 4px
 			border-radius: 4px
 			margin: 0 -10px 0 -6px // HACK
-			background-color: $clr-danger
-			color: $clr-primary-text-dark
+			background-color: var(--color-danger)
+			// The badge fill is a saturated hue in both themes, so the ink stays
+			// white rather than any flipping --color-text* token.
+			color: var(--pretalx-clr-text-on-fill)
 			letter-spacing: 0.5px
 			text-transform: uppercase
 	.info
-		border: border-separator()
+		border: 1px solid var(--color-card-border)
 		border-left: none
 		border-radius: 0 6px 6px 0
-		background-color: $clr-white
+		background-color: var(--color-bg)
 		.title
 			font-size: 16px
 			margin-bottom: 4px
 			margin-right: 20px
 		.speakers
-			color: $clr-secondary-text-light
+			color: var(--color-text-lighter)
 			display: flex
 			.avatars
 				flex: none
@@ -202,7 +209,9 @@ export default {
 				> *:not(:first-child)
 					margin-left: -20px
 				img
-					background-color: $clr-white
+					// Opaque backing that punches each overlapped avatar circle out
+					// of the one behind it: must match the .info surface exactly.
+					background-color: var(--color-bg)
 					border-radius: 50%
 					height: 24px
 					width: @height
@@ -222,7 +231,7 @@ export default {
 			.room
 				flex: 1
 				text-align: right
-				color: $clr-secondary-text-light
+				color: var(--color-text-lighter)
 				ellipsis()
 				padding-right: 12px
 			.signup-icon
@@ -232,7 +241,7 @@ export default {
 				color: var(--pretalx-clr-primary)
 				margin-left: 6px
 			.signup-icon.full
-				color: $clr-danger
+				color: var(--color-danger)
 			.signed-up-icon
 				flex: none
 				font-size: 18px
@@ -243,6 +252,9 @@ export default {
 				flex: none
 				width: 20px
 				height: 20px
+				// Drives the camera body/lens via currentColor; the slash keeps its
+				// own var(--color-danger) stroke.
+				color: var(--color-text)
 				margin-left: 6px
 	.session-icons
 		position: absolute
@@ -252,7 +264,17 @@ export default {
 		.btn-fav-container
 			margin-top: 2px
 			display: inline-flex
-			icon-button-style(style: clear)
+			// The mixin's default colour arg is $clr-primary-text-light (dark ink),
+			// so the card ink has to be passed in. The `clear` branch only assigns
+			// the arg straight to color/fill, so a CSS var is safe here.
+			icon-button-style(var(--color-text), style: clear)
+			// The mixin hardcodes its hover/focus wash as alpha(black, .1), which is
+			// invisible on a dark card, so override it after the expansion. Same
+			// selectors, later source order. Alpha .1 matches byte-for-byte in light.
+			body[modality="keyboard"] &:focus,
+			&:hover:not(.disabled),
+			&.dropdown-open
+				background-color: var(--pretalx-clr-subtle-fill)
 			padding: 2px
 			width: 32px
 			height: 32px

--- a/src/pretalx/frontend/schedule/src/components/SessionModal.vue
+++ b/src/pretalx/frontend/schedule/src/components/SessionModal.vue
@@ -233,6 +233,7 @@ export default {
 	padding: 0
 	border-radius: 8px
 	border: 0
+	background-color: var(--pretalx-clr-surface)
 	box-shadow: 0 -2px 4px rgba(0,0,0,0.06),
 		0 1px 3px rgba(0,0,0,0.12),
 		0 8px 24px rgba(0,0,0,0.15),
@@ -255,12 +256,12 @@ export default {
 		border: none
 		cursor: pointer
 		padding: 8px
-		color: $clr-grey-600
+		color: var(--pretalx-clr-text-lighter)
 		font-size: 22px
 		font-weight: bold
 		&:hover
 			background: none
-			color: $clr-grey-900
+			color: var(--pretalx-clr-text)
 
 	h3
 		margin: 8px 0
@@ -273,9 +274,9 @@ export default {
 	.facts
 		display: flex
 		flex-wrap: wrap
-		color: $clr-grey-600
+		color: var(--pretalx-clr-text-lighter)
 		margin-bottom: 8px
-		border-bottom: 1px solid $clr-grey-300
+		border-bottom: 1px solid var(--pretalx-clr-border)
 		&>*
 			margin-right: 4px
 			margin-bottom: 8px
@@ -289,8 +290,8 @@ export default {
 		padding: 8px 12px
 		margin-bottom: 12px
 		border-radius: 6px
-		background-color: rgba(46, 125, 50, 0.1)
-		color: $clr-success
+		background-color: unquote('color-mix(in srgb, var(--color-success, #3aa57c) 10%, transparent)')
+		color: var(--pretalx-clr-success-text)
 		font-size: 14px
 		.fa
 			font-size: 16px
@@ -303,8 +304,8 @@ export default {
 			&:hover
 				text-decoration: none
 		&.full
-			background-color: rgba(178, 62, 101, 0.1)
-			color: $clr-danger
+			background-color: unquote('color-mix(in srgb, var(--color-danger, #b23e65) 10%, transparent)')
+			color: var(--pretalx-clr-danger-text)
 
 	.card-content
 			display: flex
@@ -317,10 +318,10 @@ export default {
 			p
 				font-size: 16px
 			hr
-				color: #ced4da
+				color: var(--pretalx-clr-border)
 				height: 0
 				border: 0
-				border-top: 1px solid #e0e0e0
+				border-top: 1px solid var(--pretalx-clr-border)
 				margin: 16px 0
 
 	.answers
@@ -403,7 +404,7 @@ export default {
 		border-radius: 6px
 		padding: 12px
 		border-radius: 6px
-		border: 1px solid #ced4da
+		border: 1px solid var(--pretalx-clr-border)
 		min-height: 96px
 		align-items: flex-start
 		padding: 8px
@@ -441,14 +442,14 @@ export default {
 			object-fit: cover
 
 		.avatar-placeholder
-			background: rgba(0,0,0,0.1)
+			background: var(--pretalx-clr-subtle-fill)
 			display: flex
 			align-items: center
 			justify-content: center
 			svg
 				width: 60%
 				height: 60%
-				color: rgba(0,0,0,0.3)
+				color: var(--pretalx-clr-subtle-ink)
 
 	.speaker-details
 		h3
@@ -479,10 +480,10 @@ export default {
 
 			.answers
 				hr
-					color: #ced4da
+					color: var(--pretalx-clr-border)
 					height: 0
 					border: 0
-					border-top: 1px solid #e0e0e0
+					border-top: 1px solid var(--pretalx-clr-border)
 					margin: 8px 0
 
 				.icon-group

--- a/src/pretalx/frontend/shared/styles/elements.styl
+++ b/src/pretalx/frontend/shared/styles/elements.styl
@@ -18,8 +18,11 @@ html, body
 		&:hover
 			color: var(--pretalx-clr-primary-text-dark)
 			text-decoration: none
+	// Undo the link colour above without inheriting the app's ink: these
+	// buttons sit on a --highlight-color fill that does not follow the
+	// scheme, so inheriting puts near-white text on a green fill.
 	a.btn
-		color: inherit
+		color: var(--color-text-on-light, inherit)
 	a.c-linear-schedule-session
 		color: var(--pretalx-clr-text)
 

--- a/src/pretalx/frontend/shared/styles/elements.styl
+++ b/src/pretalx/frontend/shared/styles/elements.styl
@@ -58,7 +58,7 @@ html, body
 			line-height: 1.27em
 			margin-top: 0
 		> cite, > footer, > figcaption
-			color: $clr-grey-600
+			color: var(--pretalx-clr-text-lighter)
 			&:before
 				content: '\2014'
 

--- a/src/pretalx/frontend/shared/styles/tokens.styl
+++ b/src/pretalx/frontend/shared/styles/tokens.styl
@@ -1,11 +1,104 @@
 // SPDX-FileCopyrightText: 2020-present Tobias Kunze
 // SPDX-License-Identifier: Apache-2.0
 
+// Bridge between pretalx's CSS custom properties (common/css/_variables.css,
+// loaded by the Django page both Vue apps mount into) and the stylus in the
+// components. buntpapier's $clr- palette is hardcoded light, so nothing
+// colour-bearing may use it.
+//
+// When editing:
+//
+// 1. unquote(): stylus parses `in srgb` as an operator and rejects a bare
+//    color-mix() value, so emit these literally.
+//
+// 2. A token may only resolve to a flipping --color-* token when the background
+//    it sits on also flips. Where the background is fixed (event brand colour,
+//    track colour from the database, hue-fixed red/orange/green fills), the ink
+//    has to be scheme-independent. The "fixed" group below must never gain an
+//    entry in the dark block.
+//
+// 3. --color-white stays literally white in dark mode. The surface token is
+//    --color-bg.
+//
+// 4. Scrims and shadows occlude, so they darken in both themes. They must not
+//    use --color-card-border or --color-card-header, which invert to white.
+//
+// The literal fallbacks keep the embeddable widget usable on third-party pages
+// that never load _variables.css.
+
 html, body
 	--pretalx-clr-primary: var(--color-primary, #3aa57c)
-	// unquote(): stylus parses `in srgb` as an operator and rejects a bare
-	// color-mix() value, so emit these literally.
+
+	--pretalx-clr-surface: var(--color-bg, #fff)
+	--pretalx-clr-text: var(--color-text, rgb(13, 15, 16))
+	// rgba(), not rgb(0 0 0 / .6): stylus does not understand the space-separated
+	// syntax and silently drops the alpha, leaving an opaque fallback.
+	--pretalx-clr-text-lighter: var(--color-text-lighter, rgba(0, 0, 0, 0.6))
+	--pretalx-clr-border: var(--color-border, #ced4da)
+
+	// Ink on a tinted alert surface, which composites over the page and so
+	// flips with it. Mirrors .alert-success/.alert-danger in common/css/base.css.
+	--pretalx-clr-success-text: var(--color-success-text-dark, #235e47)
+	--pretalx-clr-danger-text: var(--color-danger-text-dark, #6b253d)
+
+	// Wash over a page or card surface: hover affordances, and the resting fill
+	// of the avatar placeholder. Alpha .1 matches buntpapier's alpha(black, .1)
+	// byte for byte in light mode.
+	--pretalx-clr-subtle-fill: rgba(0, 0, 0, 0.1)
+	--pretalx-clr-subtle-ink: rgba(0, 0, 0, 0.3)
+
+	// Fills that composite over the page surface and therefore flip with it.
+	--pretalx-clr-blocker-bg: #ffebee
+	--pretalx-clr-availability-active: rgba(58, 165, 124, 0.1)
+
+	// Occluding shadows: darker in both themes, never inverted.
+	--pretalx-clr-star-shadow: rgba(0, 0, 0, 0.17)
+	--pretalx-shadow-sheet: 0 -4px 20px rgba(0, 0, 0, 0.15)
+
+	// --- fixed: ink and fills whose background does not follow the scheme ---
+
+	// Ink on a fill that is the same in both themes: .time-box chips filled with
+	// var(--track-color), the break and blocker chips, the live badge, coloured
+	// filter pills. Never map these to --color-text*: two inks of opposite
+	// polarity on one chip is what makes .start and .duration unreadable.
+	--pretalx-clr-text-on-fill: rgba(255, 255, 255, 1)
+	--pretalx-clr-text-on-fill-secondary: rgba(255, 255, 255, 0.7)
+	// Ink on a --pretalx-clr-primary fill. Follows the upstream token, which
+	// event_css overrides when an event picks a pale brand colour.
+	--pretalx-clr-text-on-primary: var(--color-text-on-primary, #fff)
+	// Break .time-box fill, carrying --pretalx-clr-text-on-fill. #757575 rather
+	// than buntpapier's #9e9e9e lifts white ink from 2.6:1 to 4.6:1.
+	--pretalx-clr-break-time-bg: #757575
+	// Blocker .time-box fill, same reason.
+	--pretalx-clr-blocker-time-bg: #ef9a9a
+	// The "now" marker. Deliberately not --color-danger: "now" is not an error,
+	// and --color-danger would restyle the marker in light mode too.
+	--pretalx-clr-now: #f44336
+	// Fixed pretalx brand green.
+	--pretalx-clr-success: #3aa57c
+
+// Derived from --pretalx-clr-primary, so these have to be re-declared on every
+// element the templates may set --pretalx-clr-primary on inline (see
+// agenda/templates/agenda/schedule.html and orga/templates/orga/settings/widget.html).
+// Custom properties substitute var() at the element that declares them, so
+// declaring these on html alone computes them against html's primary and
+// silently ignores the per-event override on the mount node.
+html, body, pretalx-schedule, #pretalx-schedule, .pretalx-schedule
 	--pretalx-clr-primary-text: unquote('color-mix(in srgb, var(--pretalx-clr-primary), black 10%)')
 	--pretalx-clr-primary-text-dark: unquote('color-mix(in srgb, var(--pretalx-clr-primary), black 40%)')
-	// Fixed pretalx brand green
-	--pretalx-clr-success: #3aa57c
+
+@media (prefers-color-scheme: dark)
+	html, body
+		--pretalx-clr-subtle-fill: rgba(255, 255, 255, 0.1)
+		--pretalx-clr-subtle-ink: rgba(255, 255, 255, 0.3)
+		--pretalx-clr-blocker-bg: unquote('color-mix(in srgb, var(--color-danger), var(--color-bg) 85%)')
+		// The alpha rises because the fill composites onto a dark canvas.
+		--pretalx-clr-availability-active: rgba(58, 165, 124, 0.22)
+		--pretalx-clr-star-shadow: rgba(0, 0, 0, 0.5)
+		--pretalx-shadow-sheet: 0 -4px 20px rgba(0, 0, 0, 0.6)
+
+	// The -text variants exist to stay legible against the page background, so
+	// they mix toward white here, as --color-primary-text does in _variables.css.
+	html, body, pretalx-schedule, #pretalx-schedule, .pretalx-schedule
+		--pretalx-clr-primary-text: unquote('color-mix(in srgb, var(--pretalx-clr-primary), white 10%)')
+		--pretalx-clr-primary-text-dark: unquote('color-mix(in srgb, var(--pretalx-clr-primary), white 40%)')

--- a/src/pretalx/static/agenda/css/base.css
+++ b/src/pretalx/static/agenda/css/base.css
@@ -44,7 +44,7 @@
   font-size: 14px;
   &.break {
     .pretalx-session-info .title {
-      color: rgb(0 0 0 / 0.54);
+      color: var(--color-text-lighter);
     }
   }
   &:hover {
@@ -64,7 +64,7 @@
     align-items: center;
     &.avatar {
       width: auto;
-      background-color: white;
+      background-color: var(--color-bg);
       border: 1px solid;
       border-color: var(--color-border);
       border-right: none;
@@ -104,16 +104,16 @@
     border: 1px solid var(--color-border);
     border-left: none;
     border-radius: 0 6px 6px 0;
-    background-color: #fff;
+    background-color: var(--color-bg);
     min-width: 0;
-    color: rgb(0 0 0 / 0.87);
+    color: var(--color-text);
     .title {
       font-size: 16px;
       font-weight: 500;
       margin-bottom: 4px;
     }
     .speakers {
-      color: rgb(0 0 0 / 0.54);
+      color: var(--color-text-lighter);
     }
     .abstract {
       margin: 8px 0 12px 0;
@@ -142,7 +142,7 @@
       }
       .room {
         text-align: right;
-        color: rgb(0 0 0 / 0.54);
+        color: var(--color-text-lighter);
         padding-right: 12px;
       }
       .signup-icon {

--- a/src/pretalx/static/agenda/css/base.css
+++ b/src/pretalx/static/agenda/css/base.css
@@ -153,7 +153,7 @@
         margin-left: 6px;
       }
       .signup-icon.signup-full {
-        color: var(--color-danger);
+        color: var(--color-danger-ink);
       }
       .signed-up-icon {
         flex: none;
@@ -174,7 +174,7 @@
   }
 }
 .do-not-record {
-  color: var(--color-danger);
+  color: var(--color-danger-ink);
 }
 article .pretalx-session .pretalx-session-info .abstract {
   display: block;

--- a/src/pretalx/static/agenda/css/feedback.css
+++ b/src/pretalx/static/agenda/css/feedback.css
@@ -8,7 +8,7 @@
 
   .quote {
     font-size: 1.5rem;
-    color: rgb(0 0 0 / 0.56);
+    color: var(--color-text-lighter);
     border: var(--color-border) 1px solid;
     border-radius: var(--size-border-radius);
     padding: 20px;

--- a/src/pretalx/static/agenda/css/schedule_nojs.css
+++ b/src/pretalx/static/agenda/css/schedule_nojs.css
@@ -59,7 +59,7 @@
 }
 .pretalx-list-day {
   .bucket-time {
-    color: rgb(0 0 0 / 0.54);
+    color: var(--color-text-lighter);
     font-size: 14px;
     font-weight: 500;
   }

--- a/src/pretalx/static/common/css/_variables.css
+++ b/src/pretalx/static/common/css/_variables.css
@@ -53,6 +53,12 @@
   --color-danger: #b23e65;
   --color-danger-text: color-mix(in srgb, var(--color-danger), black 10%);
   --color-danger-text-dark: color-mix(in srgb, var(--color-danger), black 40%);
+  /* --color-danger plays two roles: a fill that carries white text, and ink
+     drawn straight onto the page. On white both roles work from one value, so
+     this is deliberately identical to --color-danger here. In dark they cannot
+     share a value (see the dark block), and only the ink role moves. Use this
+     token wherever danger is applied with `color:`. */
+  --color-danger-ink: var(--color-danger);
 
   --color-white: #fff;
   --color-offwhite: #f8f9fa;
@@ -134,8 +140,19 @@
        .color-secondary highlights), so it must not follow the grey ramp up. */
     --color-secondary: #6c757d;
 
-    --color-danger: #e05c86;
-    --color-danger-text: color-mix(in srgb, var(--color-danger), white 10%);
+    /* --color-danger keeps its light value here. It is the one semantic colour
+       that is both a fill under white text and ink on the page, and in dark the
+       two roles are irreconcilable: a fill carrying white text needs luminance
+       <= 0.1833, ink on --color-bg (#121416) needs >= 0.2059. That window is
+       empty, so no single value can pass both. The fill role wins the base token
+       (#b23e65 under white = 5.57:1); the ink role moves to --color-danger-ink.
+       Lightening the base to #e05c86 instead, as an earlier revision did, drops
+       white-on-danger fills to 3.47:1. */
+    --color-danger-ink: color-mix(in srgb, var(--color-danger), white 25%);
+    /* Unlike its siblings, danger needs more than a 10% lift to clear AA as ink:
+       #b23e65 is much darker than --color-info/--color-warning, so white 10%
+       reaches only 3.97:1 on #121416, where the others already pass. */
+    --color-danger-text: color-mix(in srgb, var(--color-danger), white 25%);
     --color-danger-text-dark: color-mix(
       in srgb,
       var(--color-danger),

--- a/src/pretalx/static/common/css/_variables.css
+++ b/src/pretalx/static/common/css/_variables.css
@@ -23,6 +23,9 @@
   --color-primary-light: color-mix(in srgb, var(--color-primary), white 45%);
   --color-primary-lighter: color-mix(in srgb, var(--color-primary), white 72%);
   --color-text-on-primary: white;
+  /* Ink for text sitting on a light surface whose colour does not follow the
+     colour scheme (event brand colours, fixed coloured fills). Never flipped. */
+  --color-text-on-light: rgb(13, 15, 16);
   --color-secondary: var(--color-grey-medium);
 
   --color-success: var(--color-pretalx);
@@ -82,4 +85,84 @@
   --breakpoint-md: 768px;
   --breakpoint-lg: 992px;
   --breakpoint-xl: 1200px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Tells the UA to render scrollbars, form controls and native pickers dark */
+    color-scheme: dark;
+
+    --color-text: rgb(240, 240, 240);
+    --color-code: #ff8db3;
+    --color-text-lighter: rgb(255 255 255 / 0.6);
+
+    /* The -text variants exist to stay legible against the page background, so
+       they mix toward white here rather than black. */
+    --color-primary-text: color-mix(in srgb, var(--color-primary), white 10%);
+    --color-primary-text-dark: color-mix(
+      in srgb,
+      var(--color-primary),
+      white 40%
+    );
+    /* -light/-lighter are used as fills and borders, not as text */
+    --color-primary-light: color-mix(in srgb, var(--color-primary), black 45%);
+    --color-primary-lighter: color-mix(
+      in srgb,
+      var(--color-primary),
+      black 72%
+    );
+
+    --color-success-text: color-mix(in srgb, var(--color-success), white 10%);
+    --color-success-text-dark: color-mix(
+      in srgb,
+      var(--color-success),
+      white 40%
+    );
+    --color-success-light: color-mix(in srgb, var(--color-success), black 10%);
+
+    --color-info-text: color-mix(in srgb, var(--color-info), white 10%);
+    --color-info-text-dark: color-mix(in srgb, var(--color-info), white 40%);
+
+    --color-warning-text: color-mix(in srgb, var(--color-warning), white 10%);
+    --color-warning-text-dark: color-mix(
+      in srgb,
+      var(--color-warning),
+      white 50%
+    );
+
+    /* Always a surface that carries white text (file selector buttons,
+       .color-secondary highlights), so it must not follow the grey ramp up. */
+    --color-secondary: #6c757d;
+
+    --color-danger: #e05c86;
+    --color-danger-text: color-mix(in srgb, var(--color-danger), white 10%);
+    --color-danger-text-dark: color-mix(
+      in srgb,
+      var(--color-danger),
+      white 40%
+    );
+
+    /* --color-white stays white: it is the literal colour, and --color-on-highlight
+       relies on it for text on coloured surfaces. Only the page surface flips. */
+    --color-bg: #121416;
+    --color-offwhite: #1a1d20;
+    --color-grey-lightest: color-mix(in srgb, #1a1d20 95%, var(--color-primary));
+    --color-grey-lighter: color-mix(in srgb, #23272b 95%, var(--color-primary));
+    --color-grey-light: color-mix(in srgb, #3c4248 90%, var(--color-primary));
+    --color-grey-medium-lighter: #b8c5c6;
+    --color-grey-medium-light: #b5bbc0;
+    --color-grey-medium: #adb5bd;
+    --color-grey-dark: #ced4da;
+    --color-grey: color-mix(in srgb, #adb5bd 90%, var(--color-primary));
+
+    --color-card-border: rgb(255 255 255 / 0.125);
+    --color-card-header: rgb(255 255 255 / 0.03);
+    --color-border: #495057;
+
+    --shadow-lightest: 0 1px 2px rgb(0 0 0 / 0.5);
+    --shadow-lighter: 0 1px 3px rgb(0 0 0 / 0.3), var(--shadow-lightest);
+    --shadow-light: 0 0 6px 1px rgb(0 0 0 / 0.2), var(--shadow-lighter);
+    --shadow-wide: 0 0 10px 1px rgb(0 0 0 / 0.3), var(--shadow-lighter);
+    --shadow-dialog: 0 0 10px rgb(0 0 0 / 0.7), var(--shadow-lightest);
+  }
 }

--- a/src/pretalx/static/common/css/base.css
+++ b/src/pretalx/static/common/css/base.css
@@ -339,7 +339,11 @@ summary.btn {
   &.btn-outline-warning,
   &.btn-outline-danger {
     background: var(--color-bg);
-    color: var(--highlight-color);
+    /* Outline buttons draw the highlight colour as ink, then flip it to a fill
+       under white text on hover. Danger is the one colour that cannot do both in
+       dark, so it sets --highlight-color-ink; every other variant resets that token
+       to initial and falls back to the fill value here, unchanged. */
+    color: var(--highlight-color-ink, var(--highlight-color));
     &:hover {
       background: var(--highlight-color);
       color: var(--color-on-highlight, white);
@@ -625,7 +629,10 @@ a, .fake-link {
 }
 ::selection {
   background-color: var(--color-primary);
-  color: white;
+  /* Selected text sits on the brand colour, so it takes the brand's ink. A
+     near-white brand previously painted white-on-white: selecting text made it
+     vanish. */
+  color: var(--color-text-on-primary, white);
   text-shadow: none;
 }
 
@@ -653,6 +660,7 @@ a, .fake-link {
 .btn-danger,
 .alert-danger {
   --highlight-color: var(--color-danger);
+  --highlight-color-ink: var(--color-danger-ink);
   --highlight-color-text: var(--color-danger-text-dark);
 }
 .color-primary,
@@ -680,20 +688,30 @@ a, .fake-link {
   content: "";
 }
 
+/* Each non-danger variant resets --highlight-color-ink on itself. Custom properties
+   inherit, so an outline button inside a danger container (.alert-danger, .color-danger)
+   would otherwise pick up that container's ink and paint itself danger-pink instead of
+   its own colour. A declaration on the element always beats an inherited value, so the
+   reset belongs here, next to --highlight-color. */
 .btn-outline-success {
   --highlight-color: var(--color-success);
+  --highlight-color-ink: initial;
 }
 .btn-outline-primary {
   --highlight-color: var(--color-primary);
+  --highlight-color-ink: initial;
 }
 .btn-outline-info {
   --highlight-color: var(--color-info);
+  --highlight-color-ink: initial;
 }
 .btn-outline-warning {
   --highlight-color: var(--color-warning);
+  --highlight-color-ink: initial;
 }
 .btn-outline-danger {
   --highlight-color: var(--color-danger);
+  --highlight-color-ink: var(--color-danger-ink);
 }
 
 .text-success {
@@ -706,7 +724,7 @@ a, .fake-link {
   color: var(--color-warning) !important;
 }
 .text-danger {
-  color: var(--color-danger) !important;
+  color: var(--color-danger-ink) !important;
 }
 .text-muted {
   color: var(--color-grey-medium) !important;
@@ -754,7 +772,12 @@ a, .fake-link {
 .submission-state-rejected {
   --submission-color-primary: var(--color-danger);
   --submission-color-secondary: var(--color-danger);
+  /* The dropdown paints this seed as ink on the page and as a hover fill under
+     white text; danger needs a lighter value for the former in dark. Other
+     states leave this unset and fall back to the primary seed. */
+  --submission-color-ink: var(--color-danger-ink);
   --highlight-color: var(--color-danger);
+  --highlight-color-ink: var(--color-danger-ink);
 }
 .submission-state-dropdown.submission-state-pending-rejected {
   --submission-color-secondary: var(--color-danger);

--- a/src/pretalx/static/common/css/base.css
+++ b/src/pretalx/static/common/css/base.css
@@ -23,7 +23,7 @@
 body {
   margin: 0;
   color: var(--color-text);
-  background-color: white;
+  background-color: var(--color-bg);
 
   font-size: 1rem;
   font-weight: normal;
@@ -153,7 +153,7 @@ pre {
   word-break: break-all;
   word-wrap: break-word;
   overflow: auto;
-  color: #333;
+  color: var(--color-text);
   background-color: var(--color-grey-lightest);
   border: 1px solid var(--color-border);
   border-radius: var(--size-border-radius);
@@ -238,7 +238,7 @@ table:not(.no-hover) tr:hover {
   .table-submission-info {
     margin: 0;
     width: 100%;
-    background: white;
+    background: var(--color-bg);
 
     th,
     td {

--- a/src/pretalx/static/common/css/error.css
+++ b/src/pretalx/static/common/css/error.css
@@ -24,7 +24,7 @@ body {
 }
 
 .error-card {
-  background: rgba(255, 255, 255, 0.85);
+  background: color-mix(in srgb, var(--color-bg) 85%, transparent);
   color: var(--color-text);
   padding: 1.5rem 2rem;
   border-radius: 0.5rem;

--- a/src/pretalx/static/common/css/forms/base.css
+++ b/src/pretalx/static/common/css/forms/base.css
@@ -95,7 +95,7 @@ small.form-text {
 }
 .invalid-feedback {
   font-size: 0.875rem;
-  color: var(--color-danger);
+  color: var(--color-danger-ink);
   font-weight: normal;
   font-family: var(--font-family);
 }

--- a/src/pretalx/static/common/css/forms/image.css
+++ b/src/pretalx/static/common/css/forms/image.css
@@ -12,19 +12,19 @@
   background-image:
     linear-gradient(
       45deg,
-      #efefef 25%,
-      rgb(239 239 239 / 0) 25%,
-      rgb(239 239 239 / 0) 75%,
-      #efefef 75%,
-      #efefef
+      var(--color-grey-lighter) 25%,
+      transparent 25%,
+      transparent 75%,
+      var(--color-grey-lighter) 75%,
+      var(--color-grey-lighter)
     ),
     linear-gradient(
       45deg,
-      #efefef 25%,
-      rgb(239 239 239 / 0) 25%,
-      rgb(239 239 239 / 0) 75%,
-      #efefef 75%,
-      #efefef
+      var(--color-grey-lighter) 25%,
+      transparent 25%,
+      transparent 75%,
+      var(--color-grey-lighter) 75%,
+      var(--color-grey-lighter)
     );
   border-radius: 6px;
   a {

--- a/src/pretalx/static/common/css/forms/markdown.css
+++ b/src/pretalx/static/common/css/forms/markdown.css
@@ -4,14 +4,14 @@
  */
 
 .markdown-wrapper {
-  border: 1px solid #ced4da;
+  border: 1px solid var(--color-border);
   border-radius: var(--size-border-radius);
-  background: white;
+  background: var(--color-bg);
 
   .markdown-header {
     display: flex;
     align-items: center;
-    border-bottom: 1px solid #ced4da;
+    border-bottom: 1px solid var(--color-border);
   }
   .markdown-nav[role="tablist"] {
     margin-bottom: 0;
@@ -69,7 +69,7 @@
     margin: 8px;
     width: calc(100% - 16px);
     border-radius: var(--size-border-radius);
-    background-color: white;
+    background-color: var(--color-bg);
   }
   .markdown-preview {
     border-bottom-left-radius: var(--size-border-radius);
@@ -88,7 +88,7 @@
     }
     .preview-footer {
       height: 28px;
-      border-top: 1px solid #ced4da;
+      border-top: 1px solid var(--color-border);
       background-color: var(--color-offwhite);
       padding: 0.1rem 0.375rem;
       border-bottom-left-radius: var(--size-border-radius);

--- a/src/pretalx/static/common/css/forms/select.css
+++ b/src/pretalx/static/common/css/forms/select.css
@@ -112,6 +112,10 @@
     border-bottom-right-radius: var(--size-border-radius);
     border-bottom-left-radius: var(--size-border-radius);
     border-color: var(--color-border);
+    /* choices.min.css hardcodes a white panel and a #f2f2f2 highlight. The item
+       ink follows the page, so on a dark page the panel has to follow too or the
+       options are light-on-white. Both tokens are the vendored colours in light. */
+    background-color: var(--color-bg);
     /* Make the corner radius look slightly less silly */
     margin-top: -2px;
     margin-bottom: -2px;
@@ -119,6 +123,10 @@
     .choices__item {
       font-size: 1rem;
       color: var(--color-text-input);
+
+      &.is-highlighted {
+        background-color: var(--color-grey-lightest);
+      }
 
       &.choice-item-color:before {
         margin-right: 5px;

--- a/src/pretalx/static/common/css/forms/select.css
+++ b/src/pretalx/static/common/css/forms/select.css
@@ -38,7 +38,7 @@
 
       &.choices__item--selectable {
         button {
-          color: var(--color-danger) !important;
+          color: var(--color-danger-ink) !important;
         }
       }
 

--- a/src/pretalx/static/common/css/ui/dialog.css
+++ b/src/pretalx/static/common/css/ui/dialog.css
@@ -5,7 +5,7 @@
 
 dialog {
   border: none;
-  background: #fff;
+  background: var(--color-bg);
   padding: 0;
   box-shadow: var(--shadow-dialog);
   border-radius: 0.3rem;
@@ -44,7 +44,7 @@ dialog {
     top: -4px;
     right: 0;
     cursor: pointer;
-    color: rgb(0 0 0 / 0.7);
+    color: var(--color-text-lighter);
     font-size: 20px;
     border: none;
     background: transparent;
@@ -52,7 +52,7 @@ dialog {
     &:hover,
     &:active {
       background: transparent;
-      color: rgb(0 0 0 / 0.7);
+      color: var(--color-text-lighter);
     }
   }
 }

--- a/src/pretalx/static/common/css/ui/dropdown.css
+++ b/src/pretalx/static/common/css/ui/dropdown.css
@@ -34,7 +34,7 @@ details.dropdown {
     padding: 0;
     margin-top: 2px;
     list-style: none;
-    background: white;
+    background: var(--color-bg);
     border: 1px var(--grey-lighter) solid;
     border-radius: 0.25rem;
     z-index: 1000;
@@ -53,7 +53,7 @@ details.dropdown {
     }
     &::after {
       border: 7px solid transparent;
-      border-bottom-color: white;
+      border-bottom-color: var(--color-bg);
     }
 
     .dropdown-item,
@@ -123,7 +123,7 @@ details.dropdown {
     right: -14px;
     left: auto;
     border-color: transparent;
-    border-left-color: #fff;
+    border-left-color: var(--color-bg);
   }
   .dropdown-content-e {
     top: 0;
@@ -142,7 +142,7 @@ details.dropdown {
     top: 11px;
     left: -14px;
     border-color: transparent;
-    border-right-color: #fff;
+    border-right-color: var(--color-bg);
   }
   .dropdown-content-ne {
     top: auto;
@@ -166,7 +166,7 @@ details.dropdown {
   .dropdown-content-ne::after {
     bottom: -7px;
     left: 10px;
-    border-top: 7px solid #fff;
+    border-top: 7px solid var(--color-bg);
     border-right: 7px solid transparent;
     border-bottom: 0;
     border-left: 7px solid transparent;

--- a/src/pretalx/static/common/css/ui/progress.css
+++ b/src/pretalx/static/common/css/ui/progress.css
@@ -17,7 +17,7 @@ progress {
   background-color: var(--color-grey-lighter);
   border-radius: var(--size-border-radius);
   &::after {
-    color: black;
+    color: var(--color-text);
     content: attr(title);
     position: absolute;
     text-align: center;

--- a/src/pretalx/static/common/css/ui/stages.css
+++ b/src/pretalx/static/common/css/ui/stages.css
@@ -43,7 +43,10 @@
       .step-icon {
         border: 1px solid var(--color, var(--color-primary));
         background: var(--color, var(--color-primary));
-        color: white;
+        /* The disc is filled with the event brand colour, so the glyph on it
+           follows the brand's own ink rather than assuming white: a near-white
+           brand (#f5f5f5) rendered a white glyph at 1.09:1 — invisible. */
+        color: var(--color-text-on-primary, white);
       }
       .step-label {
         color: var(--color, var(--color-primary));

--- a/src/pretalx/static/common/css/ui/stages.css
+++ b/src/pretalx/static/common/css/ui/stages.css
@@ -71,7 +71,7 @@
       border-radius: 20px;
       color: var(--color-text-muted);
       z-index: 150;
-      background: white;
+      background: var(--color-bg);
       position: relative;
     }
     .step-label {

--- a/src/pretalx/static/orga/css/forms/email.css
+++ b/src/pretalx/static/orga/css/forms/email.css
@@ -7,7 +7,7 @@
   margin-bottom: -15px;
 }
 div.mail-preview {
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border);
   border-top-width: 1px;
   border-radius: 3px;
   padding: 4px 36px;
@@ -91,7 +91,7 @@ div.mail-preview {
   box-shadow: var(--shadow-wide);
 
   legend {
-    background: white;
+    background: var(--color-bg);
     position: sticky;
     top: 0;
     z-index: 100;

--- a/src/pretalx/static/orga/css/forms/search.css
+++ b/src/pretalx/static/orga/css/forms/search.css
@@ -42,7 +42,7 @@
   }
   #pending label {
     display: inline-block;
-    color: #6c757d;
+    color: var(--color-text-muted);
   }
 }
 .filter-form {
@@ -80,5 +80,5 @@
 }
 #fulltext-toggle label {
   display: inline-block;
-  color: #6c757d;
+  color: var(--color-text-muted);
 }

--- a/src/pretalx/static/orga/css/ui/cfp-editor.css
+++ b/src/pretalx/static/orga/css/ui/cfp-editor.css
@@ -100,7 +100,8 @@
 .field-preview-edit-hint {
     position: absolute;
     opacity: 0;
-    background: var(--color-grey-dark);
+    /* Fixed dark chip: does not follow the colour scheme, so the ink stays white */
+    background: #495057;
     color: white;
     padding: 0.375rem 0.875rem;
     border-radius: var(--size-border-radius);
@@ -166,7 +167,7 @@
 .field-auto-hidden-notice {
     position: absolute;
     background: var(--color-warning);
-    color: var(--color-grey-darkest);
+    color: var(--color-text-on-light);
     padding: 0.375rem 0.875rem;
     border-radius: var(--size-border-radius);
     font-size: 80%;
@@ -278,7 +279,7 @@ dialog textarea {
     content: "";
     position: absolute;
     inset: 0;
-    background: rgba(255, 255, 255, 0.7);
+    background: color-mix(in srgb, var(--color-bg) 70%, transparent);
     z-index: 100;
 }
 #step-content-inner {

--- a/src/pretalx/static/orga/css/ui/dashboard.css
+++ b/src/pretalx/static/orga/css/ui/dashboard.css
@@ -55,19 +55,19 @@
           text-decoration: none;
         }
         &.dashboard-block-addon-success {
-          color: var(--color-grey-lightest);
+          color: white;
           background-color: var(--color-success);
         }
         &.dashboard-block-addon-info {
-          color: var(--color-grey-lightest);
+          color: white;
           background-color: var(--color-info);
         }
         &.dashboard-block-addon-error {
-          color: var(--color-grey-lightest);
+          color: white;
           background-color: var(--color-danger);
         }
         &.dashboard-block-addon-secondary {
-          color: var(--color-grey-lightest);
+          color: white;
           background-color: var(--color-secondary);
         }
       }

--- a/src/pretalx/static/orga/css/ui/featured.css
+++ b/src/pretalx/static/orga/css/ui/featured.css
@@ -22,6 +22,6 @@
   }
 
   .fail {
-    color: var(--color-danger);
+    color: var(--color-danger-ink);
   }
 }

--- a/src/pretalx/static/orga/css/ui/reviews.css
+++ b/src/pretalx/static/orga/css/ui/reviews.css
@@ -22,9 +22,11 @@
         background-color: var(--color-primary);
       }
       /* rSlider.min.css hardcodes #333 on the scale labels, which vanishes
-         against a dark page. Vendored files are not edited, so override here. */
+         against a dark page. Vendored files are not edited, so override here.
+         Match the surrounding controls: --color-text-muted is too pale to keep
+         AA against the light scale background. */
       ins {
-        color: var(--color-text-muted);
+        color: var(--color-text-input);
       }
     }
   }

--- a/src/pretalx/static/orga/css/ui/reviews.css
+++ b/src/pretalx/static/orga/css/ui/reviews.css
@@ -28,6 +28,44 @@
       ins {
         color: var(--color-text-input);
       }
+      /* rSlider.min.css hardcodes its light surfaces too: an #eee track, #fff
+         handles lit by an inner glow, and #ededed scale ticks. All three glare
+         against the dark filter card. Vendored files are not edited, so override
+         here as well.
+
+         Scoped to dark deliberately. The vendored greys are not byte-identical to
+         the light token ramp (#eee vs --color-grey-lighter, #fff vs
+         --color-white), so swapping in tokens unconditionally would nudge light
+         mode; confining this to dark leaves light untouched.
+
+         The values mirror the light design rather than merely darkening it: there
+         the track is a recess a hair off the card (1.05:1) and the handle carries
+         almost no fill contrast (1.11:1), reading through its rim and grips
+         instead. Same relationship here, against a card of --color-grey-lightest. */
+      @media (prefers-color-scheme: dark) {
+        .rs-bg {
+          background-color: var(--color-offwhite);
+          border-color: var(--color-border);
+        }
+        .rs-scale span::before {
+          background-color: var(--color-border);
+        }
+        .rs-pointer {
+          background-color: var(--color-grey-light);
+          border-color: var(--color-grey-medium);
+          /* The vendored `inset 0 1px 6px #ebebeb` washes the handle near-white
+             whatever its background-color, so it has to go: keep the geometry,
+             swap the glow for a hairline highlight and a shadow that reads on
+             a dark surface. */
+          box-shadow:
+            inset 0 0 1px rgb(255 255 255 / 0.15),
+            1px 1px 4px rgb(0 0 0 / 0.4);
+          &::before,
+          &::after {
+            background-color: var(--color-grey-medium);
+          }
+        }
+      }
     }
   }
   #column-select {

--- a/src/pretalx/static/orga/css/ui/reviews.css
+++ b/src/pretalx/static/orga/css/ui/reviews.css
@@ -12,12 +12,12 @@
     flex-direction: column;
     align-items: center;
     label {
-      color: #495057;
+      color: var(--color-text-input);
       font-size: 1rem;
     }
     .rs-container {
       font-family: inherit;
-      color: #495057;
+      color: var(--color-text-input);
       .rs-selected {
         background-color: var(--color-primary);
       }
@@ -53,7 +53,7 @@
         &:before {
           font-family: FontAwesome;
           font-weight: bold;
-          color: rgb(0 0 0 / 0.3);
+          color: var(--color-text-lighter);
           text-align: center;
           position: absolute;
         }

--- a/src/pretalx/static/orga/css/ui/reviews.css
+++ b/src/pretalx/static/orga/css/ui/reviews.css
@@ -21,6 +21,11 @@
       .rs-selected {
         background-color: var(--color-primary);
       }
+      /* rSlider.min.css hardcodes #333 on the scale labels, which vanishes
+         against a dark page. Vendored files are not edited, so override here. */
+      ins {
+        color: var(--color-text-muted);
+      }
     }
   }
   #column-select {

--- a/src/pretalx/static/orga/css/ui/submission.css
+++ b/src/pretalx/static/orga/css/ui/submission.css
@@ -16,7 +16,8 @@ details.submission-state-dropdown {
   padding: 3px;
 
   summary {
-    color: var(--submission-color-primary);
+    /* Ink on --color-bg, so it reads the ink seed; see .submission-state-rejected. */
+    color: var(--submission-color-ink, var(--submission-color-primary));
     background-color: var(--color-bg);
     padding: 0.5rem;
     h4 {
@@ -47,8 +48,16 @@ details.submission-state-dropdown {
   .dropdown-content {
     width: fit-content;
     z-index: 1000;
+    /* Custom properties inherit, so a rejected dropdown's --submission-color-ink
+       would otherwise leak from the <details> down onto every menu item and paint
+       them all danger-pink instead of their own state colour. Reset it here, on the
+       parent: each item that needs an ink of its own carries the state class that
+       sets the token on the item itself, which beats this inherited value. Putting
+       the reset on a.dropdown-item instead would outrank .submission-state-rejected
+       (0,1,1 vs 0,1,0) and break the one item that does need it. */
+    --submission-color-ink: initial;
     a.dropdown-item {
-      color: var(--submission-color-primary);
+      color: var(--submission-color-ink, var(--submission-color-primary));
       &:hover {
         background-color: var(--submission-color-primary);
         color: white;

--- a/src/pretalx/static/orga/css/ui/submission.css
+++ b/src/pretalx/static/orga/css/ui/submission.css
@@ -17,7 +17,7 @@ details.submission-state-dropdown {
 
   summary {
     color: var(--submission-color-primary);
-    background-color: white;
+    background-color: var(--color-bg);
     padding: 0.5rem;
     h4 {
       font-size: 0.875rem;

--- a/src/pretalx/static/orga/css/ui/tables.css
+++ b/src/pretalx/static/orga/css/ui/tables.css
@@ -57,7 +57,7 @@ td.answer {
   display: none;
   position: absolute;
   inset: 0;
-  background: rgba(255, 255, 255, 0.7);
+  background: color-mix(in srgb, var(--color-bg) 70%, transparent);
   z-index: 10;
 }
 .table-loading-overlay .loading-spinner {

--- a/src/tests/agenda/views/integration/test_widget.py
+++ b/src/tests/agenda/views/integration/test_widget.py
@@ -149,7 +149,9 @@ def test_event_css_with_color(client, color, expect_dark_text):
     content = response.content.decode()
     assert f"--color-primary: {color}" in content
     if expect_dark_text:
-        assert "--color-text-on-primary: var(--color-text)" in content
+        # Dark text on a light brand fill has to stay dark in both schemes, so
+        # this is the scheme-independent token, not the one that follows the page.
+        assert "--color-text-on-primary: var(--color-text-on-light)" in content
     else:
         assert "--color-text-on-primary" not in content
 
@@ -170,7 +172,9 @@ def test_event_css_orga_target(client, color, expect_dark_text):
     content = response.content.decode()
     assert f"--color-primary-event: {color}" in content
     if expect_dark_text:
-        assert "--color-text-on-primary-event: var(--color-text)" in content
+        assert (
+            "--color-text-on-primary-event: var(--color-text-on-light)" in content
+        )
     else:
         assert "--color-text-on-primary-event" not in content
 

--- a/src/tests/agenda/views/unit/test_widget.py
+++ b/src/tests/agenda/views/unit/test_widget.py
@@ -5,6 +5,7 @@ from django_scopes import scope
 
 import pretalx.agenda.views.widget as widget_module
 from pretalx.agenda.views.widget import (
+    STYLE_VERSION,
     is_public_and_versioned,
     style_etag,
     version_prefix,
@@ -22,7 +23,7 @@ def test_style_etag_no_color(event):
 
     result = style_etag(request, event)
 
-    assert result == "none"
+    assert result == STYLE_VERSION
 
 
 @pytest.mark.parametrize(
@@ -40,7 +41,19 @@ def test_style_etag_with_color(color, expected):
 
     result = style_etag(request, event)
 
-    assert result == expected
+    assert result == f"{STYLE_VERSION}:{expected}"
+
+
+def test_style_etag_changes_when_style_version_is_bumped(monkeypatch):
+    # Without this, clients cached before a change to event_css's output would
+    # revalidate, get a 304, and keep the stale stylesheet indefinitely.
+    event = EventFactory(primary_color="#000000")
+    request = make_request(event)
+    before = style_etag(request, event)
+
+    monkeypatch.setattr(widget_module, "STYLE_VERSION", "next")
+
+    assert style_etag(request, event) != before
 
 
 def test_widget_js_etag_returns_checksum(event, django_assert_num_queries):

--- a/src/tests/common/test_ui.py
+++ b/src/tests/common/test_ui.py
@@ -8,12 +8,16 @@ import pytest
 
 from pretalx.common.text.phrases import phrases
 from pretalx.common.ui import (
+    DARK_MODE_TEXT_DARK_MIX,
+    DARK_MODE_TEXT_MIX,
     Button,
     LinkButton,
     _channel_luminance,
+    _dark_mode_surface,
     _relative_luminance,
     api_buttons,
     back_button,
+    dark_mode_text_override,
     delete_button,
     delete_link,
     generate_contrast_color,
@@ -27,6 +31,12 @@ pytestmark = pytest.mark.unit
 def _hex_to_rgb_unit(hex_color):
     h = hex_color.lstrip("#")
     return tuple(int(h[i : i + 2], 16) / 255 for i in (0, 2, 4))
+
+
+def _mix_hex(hex_color, ratio):
+    """Independent restatement of CSS color-mix(in srgb, <colour>, white <r>)."""
+    channels = (c * (1 - ratio) + ratio for c in _hex_to_rgb_unit(hex_color))
+    return "#" + "".join(f"{round(c * 255):02x}" for c in channels)
 
 
 def _contrast(rgb_a, rgb_b):
@@ -92,6 +102,66 @@ def test_has_good_contrast_invalid_input_returns_true(invalid_color):
     has good contrast with white, and swapping button colours on a parse
     error would be worse."""
     assert has_good_contrast(invalid_color) is True
+
+
+@pytest.mark.parametrize(
+    "color",
+    (
+        "#000000",
+        "#1a1a2e",
+        "#003366",
+        "#8b0000",
+        "#2c3e50",
+        "#4a4a4a",
+        "#7b1fa2",
+        "#9a86a4",
+        "#3aa57c",
+        "#ffdd00",
+    ),
+)
+def test_dark_mode_text_is_legible_for_every_brand(color):
+    """Every brand colour, however dark, must end up legible in dark mode.
+
+    A fixed mix toward white cannot do this: #1a1a2e only reaches 1.45:1.
+    """
+    for floor in (DARK_MODE_TEXT_MIX, DARK_MODE_TEXT_DARK_MIX):
+        # What the browser paints: our override, or the stylesheet's own mix.
+        rendered = dark_mode_text_override(color, floor=floor) or _mix_hex(color, floor)
+        # --color-bg is the darkest surface this text lands on and
+        # --color-grey-lightest the lightest, so checking both brackets the rest.
+        surfaces = (
+            _hex_to_rgb_unit("#121416"),
+            _dark_mode_surface(_hex_to_rgb_unit(color)),
+        )
+        for surface in surfaces:
+            ratio = _contrast(_hex_to_rgb_unit(rendered), surface)
+            assert ratio >= 4.5, f"{color} -> {rendered} is {ratio:.2f}"
+
+
+@pytest.mark.parametrize("color", ("#3aa57c", "#9a86a4", "#ffdd00", "#f5f5f5"))
+def test_dark_mode_text_override_is_skipped_for_already_legible_brands(color):
+    """No override at all, so these brands keep rendering exactly as they do
+    today -- an equivalent 8-bit hex would still shift anti-aliased pixels."""
+    assert dark_mode_text_override(color) is None
+
+
+@pytest.mark.parametrize("color", ("#000000", "#1a1a2e", "#003366", "#2c3e50"))
+def test_dark_mode_text_override_lifts_illegible_brands_past_the_floor(color):
+    override = dark_mode_text_override(color)
+
+    assert override is not None
+    assert override != _mix_hex(color, DARK_MODE_TEXT_MIX)
+
+
+def test_dark_mode_text_override_accepts_short_hex():
+    assert dark_mode_text_override("#013") == dark_mode_text_override("#001133")
+
+
+@pytest.mark.parametrize("invalid_color", ("not-a-color", "#gggggg", "rgb(0,0,0)", ""))
+def test_dark_mode_text_override_invalid_input_returns_none(invalid_color):
+    """event_css skips the override entirely rather than emit a broken value,
+    leaving the stylesheet's own mix in charge."""
+    assert dark_mode_text_override(invalid_color) is None
 
 
 def test_button_defaults():


### PR DESCRIPTION
This commit implements simple dark theme with
additional overrides based on the vendored code.

There still might be some leftovers due to outside library css, but it should hopefully be easy to
catch now.

Additionally, this PR replaces all the Buntpapier colors with the proper globally defined app variables.
This __might__ not be a perfect replacement, but from my testing I think it's mostly right?
There are some minor color changes for a11y and readability, but generally should be kept as it was before.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #1560 . It does so by implementing a simple dark theme.
There's no switch for it implemented yet, but that's a good first step.


## How has this been tested?
The dark theme has been manually tested by going into a few admin views and checking if the controls look a-ok.

It has since also been tested with a scripted-browser contrast sweep across all six brand-colour cases in both schemes, compared against `main` to confirm light mode doesn't regress — see the follow-up comment below for the numbers and screenshots.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.


Note: I'd love someone to additionally properly test it, as I'm not a typical end-user. Wanted to implement it for one of the events I'm co-organizing and I'd hate having light theme on a dark-themed page. 😆 

