### PR TITLE
Add option to hide duration in submissiontype

### DIFF
--- a/src/pretalx/orga/templates/orga/cfp/text.html
+++ b/src/pretalx/orga/templates/orga/cfp/text.html
@@ -76,6 +76,7 @@
             {{ sform.present_multiple_times.as_field_group }}
             {{ sform.submission_public_review.as_field_group }}
             {{ sform.mail_on_new_submission.as_field_group }}
+            {{ sform.show_duration_in_submission_type.as_field_group }}
         </section>
 
         <section role="tabpanel" id="tabpanel-fields" aria-labelledby="tab-fields" tabindex="0" aria-hidden="true">

--- a/src/pretalx/submission/models/cfp.py
+++ b/src/pretalx/submission/models/cfp.py
@@ -48,7 +48,10 @@ def default_fields():
         "do_not_record": {"visibility": "optional"},
         "image": {"visibility": "optional"},
         "track": {"visibility": "do_not_ask"},
-        "duration": {"visibility": "do_not_ask"},
+        "duration": {
+            "visibility": "do_not_ask",
+            "required_duration": True,
+        },
         "content_locale": {"visibility": "required"},
         "additional_speaker": {"visibility": "optional"},
     }
@@ -62,9 +65,10 @@ def field_helper(cls):
         )
 
     def is_field_required(self, field):
-        return (
-            self.fields.get(field, default_fields()[field])["visibility"] == "required"
-        )
+        field_config = self.fields.get(field, default_fields()[field])
+        if field == "duration" and "required_duration" in field_config:
+            return field_config["required_duration"]
+        return field_config.get("visibility") == "required"
 
     for field in default_fields().keys():
         setattr(

--- a/src/pretalx/submission/models/type.py
+++ b/src/pretalx/submission/models/type.py
@@ -75,6 +75,13 @@ class SubmissionType(PretalxModel):
         """Used in choice drop downs."""
         if not self.default_duration:
             return str(self.name)
+
+        if hasattr(self, "event") and hasattr(self.event, "cfp"):
+            if not self.event.cfp.fields.get("duration", {}).get(
+                "required_duration", True
+            ):
+                return str(self.name)
+
         if self.default_duration > 60 * 24:
             return _("{name} ({duration} days)").format(
                 name=self.name,


### PR DESCRIPTION
- Adds a required_duration setting to the CfP duration field
- Modifies the SubmissionType.__str__ method to check this setting
- Adds a UI toggle in the CfP settings form
- Updates templates to display the new setting

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #1976. It does so by modifying the SubmissionType.__str__ method so that the user can have a toggle to show or not show duration in the submission type. 

![image](https://github.com/user-attachments/assets/b2356854-489d-47d3-87fa-9fbe8e476b42)


## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
