### PR TITLE
Add timestamps to exported filenames

### DIFF
--- a/src/pretalx/common/exporter.py
+++ b/src/pretalx/common/exporter.py
@@ -5,6 +5,7 @@ import qrcode
 import qrcode.image.svg
 from defusedcsv import csv
 from defusedxml import ElementTree
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 
@@ -111,6 +112,18 @@ class BaseExporter:
             self.urls.base.full(), image_factory=qrcode.image.svg.SvgPathFillImage
         )
         return mark_safe(ElementTree.tostring(image.get_image()).decode())
+
+    def get_timestamp_filename(self, base_filename: str) -> str:
+        """Returns filename with -YYYY-MM-DD-HH-mm suffix.
+
+        File is timestamped in -YYYY-MM-DD-HH-mm format so that file system
+        sorting of the resulting files is possible.
+        """
+        timestamp = timezone.now().strftime("-%Y-%m-%d-%H-%M")
+        if "." in base_filename:
+            name, extension = base_filename.rsplit(".", 1)
+            return f"{name}{timestamp}.{extension}"
+        return f"{base_filename}{timestamp}"
 
 
 class CSVExporterMixin:

--- a/src/pretalx/orga/forms/export.py
+++ b/src/pretalx/orga/forms/export.py
@@ -4,6 +4,7 @@ from io import StringIO
 from defusedcsv import csv
 from django import forms
 from django.http import HttpResponse
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from i18nfield.utils import I18nJSONEncoder
@@ -50,6 +51,18 @@ class ExportForm(forms.Form):
     @property
     def filename(self):
         raise NotImplementedError
+
+    def get_timestamp_filename(self, base_filename: str) -> str:
+        """Returns filename with -YYYY-MM-DD-HH-mm suffix.
+
+        File is timestamped in -YYYY-MM-DD-HH-mm format so that file system
+        sorting of the resulting files is possible.
+        """
+        timestamp = timezone.now().strftime("-%Y-%m-%d-%H-%M")
+        if "." in base_filename:
+            name, extension = base_filename.rsplit(".", 1)
+            return f"{name}{timestamp}.{extension}"
+        return f"{base_filename}{timestamp}"
 
     @cached_property
     def question_field_names(self):

--- a/src/pretalx/orga/forms/review.py
+++ b/src/pretalx/orga/forms/review.py
@@ -353,7 +353,7 @@ class ReviewExportForm(ExportForm):
 
     @cached_property
     def filename(self):
-        return f"{self.event.slug}_reviews"
+        return self.get_timestamp_filename(f"{self.event.slug}_reviews")
 
     @cached_property
     def export_field_names(self):

--- a/src/pretalx/orga/forms/schedule.py
+++ b/src/pretalx/orga/forms/schedule.py
@@ -173,7 +173,7 @@ class ScheduleExportForm(ExportForm):
 
     @cached_property
     def filename(self):
-        return f"{self.event.slug}_sessions"
+        return self.get_timestamp_filename(f"{self.event.slug}_sessions")
 
     @cached_property
     def export_field_names(self):

--- a/src/pretalx/orga/forms/speaker.py
+++ b/src/pretalx/orga/forms/speaker.py
@@ -54,7 +54,7 @@ class SpeakerExportForm(ExportForm):
 
     @cached_property
     def filename(self):
-        return f"{self.event.slug}_speakers"
+        return self.get_timestamp_filename(f"{self.event.slug}_speakers")
 
     @cached_property
     def export_field_names(self):

--- a/src/pretalx/person/exporters.py
+++ b/src/pretalx/person/exporters.py
@@ -17,7 +17,8 @@ class CSVSpeakerExporter(CSVExporterMixin, BaseExporter):
 
     @property
     def filename(self):
-        return f"{self.event.slug}-speakers.csv"
+        base_filename = f"{self.event.slug}-speakers.csv"
+        return self.get_timestamp_filename(base_filename)
 
     def get_data(self, **kwargs):
         fieldnames = ["name", "email", "confirmed"]

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -130,7 +130,8 @@ class FrabXmlExporter(ScheduleData):
             "base_url": get_base_url(self.event),
         }
         content = get_template("agenda/schedule.xml").render(context=context)
-        return f"{self.event.slug}-schedule.xml", "text/xml", content
+        filename = self.get_timestamp_filename(f"{self.event.slug}-schedule.xml")
+        return filename, "text/xml", content
 
 
 class FrabXCalExporter(ScheduleData):
@@ -144,7 +145,8 @@ class FrabXCalExporter(ScheduleData):
         url = get_base_url(self.event)
         context = {"data": self.data, "url": url, "domain": urlparse(url).netloc}
         content = get_template("agenda/schedule.xcal").render(context=context)
-        return f"{self.event.slug}.xcal", "text/xml", content
+        filename = self.get_timestamp_filename(f"{self.event.slug}.xcal")
+        return filename, "text/xml", content
 
 
 class FrabJsonExporter(ScheduleData):
@@ -274,8 +276,9 @@ class FrabJsonExporter(ScheduleData):
 
     def render(self, **kwargs):
         content = self.get_data()
+        filename = self.get_timestamp_filename(f"{self.event.slug}.json")
         return (
-            f"{self.event.slug}.json",
+            filename,
             "application/json",
             json.dumps(
                 {
@@ -316,7 +319,9 @@ class ICalExporter(BaseExporter):
         for talk in talks:
             talk.build_ical(cal, creation_time=creation_time, netloc=netloc)
 
-        return f"{self.event.slug}.ics", "text/calendar", cal.serialize()
+        filename = self.get_timestamp_filename(f"{self.event.slug}.ics")
+
+        return filename, "text/calendar", cal.serialize()
 
 
 class FavedICalExporter(BaseExporter):
@@ -351,4 +356,5 @@ class FavedICalExporter(BaseExporter):
                 schedule=request.event.current_schedule
             ):
                 slot.build_ical(cal)
-        return f"{self.event.slug}-favs.ics", "text/calendar", cal.serialize()
+        filename = self.get_timestamp_filename(f"{self.event.slug}-favs.ics")
+        return filename, "text/calendar", cal.serialize()

--- a/src/pretalx/submission/exporters.py
+++ b/src/pretalx/submission/exporters.py
@@ -19,7 +19,7 @@ class SpeakerQuestionData(CSVExporterMixin, BaseExporter):
 
     @property
     def filename(self):
-        return f"{self.event.slug}-speaker-questions.csv"
+        return self.get_timestamp_filename(f"{self.event.slug}-speaker-questions")
 
     def get_data(self, **kwargs):
         field_names = ["code", "name", "email", "question", "answer"]
@@ -64,7 +64,7 @@ class SubmissionQuestionData(CSVExporterMixin, BaseExporter):
 
     @property
     def filename(self):
-        return f"{self.event.slug}-submission-questions.csv"
+        return self.get_timestamp_filename(f"{self.event.slug}-submission-questions")
 
     def get_data(self, **kwargs):
         field_names = ["code", "title", "question", "answer"]


### PR DESCRIPTION
- Add timestamps to all exports in YYYY-MM-DD-HH-MM format to have file system sorting of the resulting files.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR closes/references issue #1964 . It does so by creating a helper method in `get_timestamp_filename()` that formats all exports in a format `f"{base_filename}{timestamp}"` like `democon_speakers-2025-05-22-18-40.csv` 

## How has this been tested?
<!--- Did you test your changes manually? Ran existing tests or new ones? -->
<!--- If you did manual testing / were fixing a UI issue, please include screenshots! -->

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
