### PR TITLE
API Docs: Fix typos and reference

### DIFF
--- a/doc/api/schema.yml
+++ b/doc/api/schema.yml
@@ -69,7 +69,7 @@ paths:
             enum:
             - submission_type
             - track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - name: page
         required: false
         in: query
@@ -141,7 +141,7 @@ paths:
             enum:
             - submission_type
             - track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -262,7 +262,7 @@ paths:
             - question
             - question.submission_types
             - question.tracks
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - name: page
         required: false
         in: query
@@ -352,7 +352,7 @@ paths:
             - question
             - question.submission_types
             - question.tracks
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -647,7 +647,7 @@ paths:
             - question
             - question.submission_types
             - question.tracks
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - name: page
         required: false
         in: query
@@ -724,7 +724,7 @@ paths:
             - question
             - question.submission_types
             - question.tracks
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -846,7 +846,7 @@ paths:
             - options
             - submission_types
             - tracks
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: query
         name: is_public
         schema:
@@ -968,7 +968,7 @@ paths:
             - options
             - submission_types
             - tracks
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -1098,7 +1098,7 @@ paths:
             - submission.tags
             - submission.track
             - user
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - name: page
         required: false
         in: query
@@ -1186,7 +1186,7 @@ paths:
             - scores.category
             - submission
             - user
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -1525,7 +1525,7 @@ paths:
             - slots.submission.speakers
             - slots.submission.submission_type
             - slots.submission.track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -1667,7 +1667,7 @@ paths:
             - submission.speakers
             - submission.submission_type
             - submission.track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: query
         name: is_visible
         schema:
@@ -1746,7 +1746,7 @@ paths:
             - submission.speakers
             - submission.submission_type
             - submission.track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -1875,7 +1875,7 @@ paths:
             enum:
             - limit_tracks
             - limit_types
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - name: page
         required: false
         in: query
@@ -1947,7 +1947,7 @@ paths:
             enum:
             - limit_tracks
             - limit_types
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:
@@ -2067,7 +2067,7 @@ paths:
             - answers
             - answers.question
             - submissions
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - name: page
         required: false
         in: query
@@ -2116,7 +2116,7 @@ paths:
             - answers
             - answers.question
             - submissions
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: user__code__iexact
         schema:
@@ -2394,7 +2394,7 @@ paths:
             - submission_type
             - tags
             - track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: query
         name: is_featured
         schema:
@@ -2515,7 +2515,7 @@ paths:
             - submission_type
             - tags
             - track
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       tags:
       - submissions
       responses:
@@ -3252,7 +3252,7 @@ paths:
             - invites
             - limit_tracks
             - members
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: organiser
         schema:
@@ -3325,7 +3325,7 @@ paths:
             - invites
             - limit_tracks
             - members
-        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.
+        description: Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.
       - in: path
         name: id
         schema:

--- a/doc/api/schema.yml
+++ b/doc/api/schema.yml
@@ -6445,7 +6445,7 @@ tags:
     This is the only API endpoint that does not use the event setting on your access
     token, as teams exist outside the event structure.
 - name: submissions
-  description: Submissions are the central component of pretalx. The subissions available
+  description: Submissions are the central component of pretalx. The submissions available
     to an authenticated user via the API depend on their permissions within the event,
     the current review phase, and so on. To a non-authenticated user, only submissions
     that are a part of the current public schedule will be visible. Note that changing
@@ -6468,7 +6468,7 @@ tags:
     redirect offered at ``by-version/?version=latest`` to check for a new release.
 - name: slots
   description: Every block in a published pretalx schedule is a talk slot. Note that
-    there are talk slots without associalted submission (e.g. breaks). Each slot belongs
+    there are talk slots without associated submission (e.g. breaks). Each slot belongs
     to a schedule version – refer to the schedule endpoint for further documentation.
     Note that slots cannot be created or deleted via the API – this happens automatically
     when a submission’s state changes.

--- a/src/pretalx/api/documentation.py
+++ b/src/pretalx/api/documentation.py
@@ -5,7 +5,7 @@ from pretalx.mail.models import MailTemplateRoles
 
 
 def build_expand_docs(*params):
-    description = 'Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expansion">expand</a>.'
+    description = 'Select fields to <a href="https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources">expand</a>.'
     return OpenApiParameter(
         name="expand",
         type=OpenApiTypes.STR,

--- a/src/pretalx/api/documentation.py
+++ b/src/pretalx/api/documentation.py
@@ -66,7 +66,7 @@ def postprocess_schema(result, generator, request, public):
             "name": "submissions",
             "description": (
                 "Submissions are the central component of pretalx. "
-                "The subissions available to an authenticated user via the API depend on their permissions within the event, "
+                "The submissions available to an authenticated user via the API depend on their permissions within the event, "
                 "the current review phase, and so on. "
                 "To a non-authenticated user, only submissions that are a part of the current public schedule will be visible. "
                 "Note that changing the speakers and state of a submission requires you to use the individual action endpoints rather than a plain update."
@@ -93,7 +93,7 @@ def postprocess_schema(result, generator, request, public):
         {
             "name": "slots",
             "description": (
-                "Every block in a published pretalx schedule is a talk slot. Note that there are talk slots without associalted submission (e.g. breaks). "
+                "Every block in a published pretalx schedule is a talk slot. Note that there are talk slots without associated submission (e.g. breaks). "
                 "Each slot belongs to a schedule version – refer to the schedule endpoint for further documentation. "
                 "Note that slots cannot be created or deleted via the API – this happens automatically when a submission’s state changes."
             ),


### PR DESCRIPTION
# Summary
I stumbled across a few very minor issues with the API docs:

Typos:
* subission -> sub**m**ission
* associa**l**ted -> associated

Reference:
* Old: https://docs.pretalx.org/api/fundamentals/#expansion
* New: https://docs.pretalx.org/api/fundamentals/#expanding-linked-resources

## How has this been tested?
I built the docs as documented [here](https://docs.pretalx.org/developer/setup/#working-with-the-documentation) and checked if it worked.

## Checklist
- [ ] I have added tests to cover my changes.
    - No, I tested the changes manually
- [x] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
    - No, I think the changes are too small to clutter the changelog