### PR TITLE
Developer Docs: Add missing `cd doc`

### DIFF
--- a/doc/developer/setup.rst
+++ b/doc/developer/setup.rst
@@ -200,8 +200,9 @@ directory of your git repository, and then run::
 
     (env)$ pip install --upgrade-strategy eager -Ur doc/requirements.txt
 
-Then, to build the documentation, run the following command::
+Then, go to the ``doc`` directory and run ``make html`` to build the documentation::
 
+    (env)$ cd doc
     (env)$ make html
 
 You will now find the generated documentation in the ``doc/_build/html/`` subdirectory.


### PR DESCRIPTION
## Summary
The section [Working with the documentation](https://docs.pretalx.org/developer/setup/#working-with-the-documentation) in the developer docs contains code snippets for all major tasks, but does not mention that some snippets need to be executed from a subdirectory.

This PR adds `cd doc/`, so the docs can be built solely by copy-pasting the code snippets.

An alternative would be to add `doc/` to the commands:
* `make html` -> `make --directory doc/ html`
* `sphinx-autobuild . _build/html --port 8001` -> `sphinx-autobuild . doc/_build/html --port 8001`

## How has this been tested?
I tested the changes manually.

Before:
![image](https://github.com/user-attachments/assets/9d60ca59-a82f-43af-aab2-3ac4dc66fbe6)

After:
![image](https://github.com/user-attachments/assets/70b81cbd-9dea-4c79-b5d7-0d7491748135)

## Checklist
- [ ] I have added tests to cover my changes.
    - No, I tested the changes manually
- [x] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
    - No, I think the changes are too small to clutter the changelog