### PR TITLE
Correct false warning pretalx.I003 even with redis properly configured

### DIFF
--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -312,6 +312,7 @@ if HAS_REDIS:
         "LOCATION": config.get("redis", "location"),
         "TIMEOUT": 3600 * 24 * 30,
     }
+    REAL_CACHE_USED = True
     if config.getboolean("redis", "session"):
         SESSION_ENGINE = "django.contrib.sessions.backends.cache"
         SESSION_CACHE_ALIAS = "redis_sessions"


### PR DESCRIPTION
?: (pretalx.I003) You have no Redis server configured, which is strongly recommended in production.
	HINT: https://docs.pretalx.org/administrator/configure/#the-redis-section

This warning is triggered even with Redis properly configured because, along the way, when memcache was removed, REAL_CACHE_USED was not correctly updated.

<!--- Why is this change required? What problem does it solve? -->

It does not solve a problem in itself, but it corrects a false warning.

