### PR TITLE
reduce DB queries in submissions api endpoint

### DIFF
--- a/src/pretalx/api/serializers/submission.py
+++ b/src/pretalx/api/serializers/submission.py
@@ -201,13 +201,11 @@ class SubmissionSerializer(FlexFieldsSerializerMixin, PretalxSerializer):
         schedule = self.context.get("schedule")
         if not schedule:
             return []
-        public_slots = self.context.get("public_slots", True)
-        qs = obj.slots.filter(schedule=schedule)
-        if public_slots:
-            qs = qs.filter(is_visible=True)
-        if serializer := self.get_extra_flex_field("slots", qs):
+        # slots are prefetched already
+        slots = obj.slots.all()
+        if serializer := self.get_extra_flex_field("slots", slots):
             return serializer.data
-        return qs.values_list("pk", flat=True)
+        return [slot.pk for slot in slots]
 
     class Meta:
         model = Submission


### PR DESCRIPTION
The `submissions` API endpoint currently generates a large number of database queries. This PR introduces the first round of optimisations and aims to reduce number of queries.
While there are still much more improvements can be done, this change already provides a noticeable performance boost. I will keep working on future PRs based on discussion and result of this PR.

**How to reproduce:**
1. install fresh [pretalx](https://docs.pretalx.org/developer/setup/#local-python-environment)
2. create test event by running `python manage.py create_test_event`
3. to be able seeing debug toolbar which shows number of sql queries edit settings.py file and add `rest_framework.renderers.BrowsableAPIRenderer` to `REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"]`
4. open url `http://127.0.0.1:8000/api/events/democon/submissions/` 

I have tested `submissions` endpoint with and without `expand` parameter:
1. api/events/democon/submissions/
2. api/events/democon/submissions/?expand=answers,answers.question,resources,slots,slots.room,speakers,speakers.answers,submission_type,tags,track

`create_test_event` command creates 36 submissions and here are numbers that are generated to fetch those submissions:
| branch | without expand | with expand|
|---|---|---|
| main | 189 | 373 |
| submission-api| 83 | 231 | 
