### PR TITLE
pretalx-information should consider the override_settings configuration

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`admin` intial pretalx-information should consider the override_settings configuration
 - :feature:`orga,1346` Organisers can now completely disable speaker editing of proposals with a new toggle in the CfP settings. When disabled, speakers cannot edit their proposals once submitted (draft proposals remain editable while the CfP is open). This setting overrides review phase settings, and provides a long-requested way of preventing even accepted and confirmed speakers from editing their proposals.
 - :bug:`schedule` Fixed dates wrapping incorrectly in schedule session boxes.
 - :bug:`cfp` Fixed users being able to clear their profile picture when they shouldn’t be able to.

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -690,11 +690,6 @@ if DEBUG:
             .strip()
         )
 
-if "--no-pretalx-information" in sys.argv:
-    sys.argv.remove("--no-pretalx-information")
-elif not os.environ.get("PRETALX_NO_INITIAL_LOG"):
-    log_initial()
-
 SILENCED_SYSTEM_CHECKS = [
     "security.W003",  # CsrfMiddleware modified but in use
     "security.W004",  # HSTS belongs to the proxy, not Django
@@ -705,3 +700,8 @@ SILENCED_SYSTEM_CHECKS = [
 
 with suppress(ImportError):
     from .override_settings import *  # noqa
+
+if "--no-pretalx-information" in sys.argv:
+    sys.argv.remove("--no-pretalx-information")
+elif not os.environ.get("PRETALX_NO_INITIAL_LOG"):
+    log_initial()


### PR DESCRIPTION
Currently 'log_initial' function which shows  pretalx configuration in the console ignores settings from 'override_settings.py'

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.