### PR TITLE
Fix SelectMultipleWithCount widget: show correct submissions count wh…

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`orga` 'Filter by tracks' dropdown displays an incorrect submission count.
 - :bug:`orga:submission,2147` The room, start and end times of submissions can now be edited.
 - :feature:`dev` Plugins can now inject additional form elements in the organisers area with the ``form_signal`` similar to ``html_signal``.
 - :feature:`cfp` Uploaded resources can now be marked as private (available only to organisers).

--- a/src/pretalx/common/forms/widgets.py
+++ b/src/pretalx/common/forms/widgets.py
@@ -161,11 +161,10 @@ class EnhancedSelectMultiple(EnhancedSelectMixin, SelectMultiple):
 
 
 def get_count(value, label):
-    count = None
     instance = getattr(value, "instance", None)
-    if instance:
-        count = getattr(instance, "count", 0)
-    count = count or getattr(label, "count", 0)
+    if instance and hasattr(instance, "count"):
+        return instance.count
+    count = getattr(label, "count", 0)
     if callable(count):
         return count(label)
     return count


### PR DESCRIPTION
'Filter by tracks' dropdown displays an incorrect submission count. 
It shows '1' for all tracks that has no submissions. 

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.

## Screenshots

### Before fix
<img width="391" height="287" alt="Screenshot 2025-10-09 at 23 04 18" src="https://github.com/user-attachments/assets/0a24eba8-5931-48b7-8f00-42037c42fe8f" />

### After fix
<img width="394" height="260" alt="Screenshot 2025-10-09 at 23 04 40" src="https://github.com/user-attachments/assets/fc99b8b5-aac5-4b81-abf2-a3bf08ff14ae" />

