### PR TITLE
Allow to add custom middleware

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,7 +2,7 @@
 
 Release Notes
 =============
-
+- :feature:`dev` Plugins can now add middleware(s).
 - :feature:`orga:email` The URL to the private speaker profile page (where speakers can e.g. edit their biography) is now available as an email placeholder.
 - :bug:`orga:email` The list of available email placeholders was hidden when editing email templates.
 - :bug:`orga:email` If the email signature contained URLs, those URLs were broken in the HTML version of the email.

--- a/doc/developer/plugins/plugins.rst
+++ b/doc/developer/plugins/plugins.rst
@@ -176,6 +176,23 @@ the “Writing a … plugin” pages.
    and more. You can use mixins and permissions from pretalx to help you with this,
    but by default, all views are public to all users, authenticated or not.
 
+Middleware
+----------
+
+.. highlight:: ini
+
+   Sometimes a plugin may require adding middleware. To add your middleware to Pretalx, create
+   ``middlewares`` section in the ``pretalx.cfg``. It is possible to add more than one middleware.
+   Each middleware is defined by its ``path``, and optionally a ``position``. If position is not
+   specified, the middleware will be added at the end of the middleware stack. For example::
+
+   [middleware]
+   midleware1_path=plugin.middleware.Plugin2Middleware
+   middleware1_position = insert_after:django.middleware.common.CommonMiddleware
+   middleware2_path = plugin.middleware.Plugin1Middleware
+   middleware2_position = insert_before:django.middleware.common.CommonMiddleware
+
+
 Configuration
 -------------
 

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -540,6 +540,31 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",  # Protects against clickjacking
 ]
 
+if "middlewares" in config:
+    additional_middlewares = {}
+    for key, value in config["middlewares"].items():
+        prefix, attr = key.split("_", 1)
+        additional_middlewares.setdefault(prefix, {})[attr] = value
+
+    for value in additional_middlewares.values():
+        middleware = value["path"]
+        # position is optional
+        position = value.get("position", "")
+        if position.startswith("insert_after:"):
+            position = position.split("insert_after:")[1]
+            MIDDLEWARE.insert(
+                MIDDLEWARE.index(position) + 1,
+                middleware,
+            )
+        elif position.startswith("insert_before:"):
+            position = position.split("insert_before:")[1]
+            MIDDLEWARE.insert(
+                MIDDLEWARE.index(position),
+                middleware,
+            )
+        else:
+            MIDDLEWARE.append(middleware)
+
 
 ## TEMPLATE AND STATICFILES SETTINGS
 template_loaders = (


### PR DESCRIPTION
Sometimes plugins might require custom middleware. For example, when custom auth backend is used middleware can help to control validity/expiration of the user session.

## Checklist
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
