### PR TITLE
Allow plugins to inject HTML in orga area

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,8 @@
 Release Notes
 =============
 
+
+- :feature:`dev` Plugins can now inject additional HTML in the organisers area with the ``pretalx.orga.signals.html_above_orga_page`` and ``pretalx.orga.signals.html_below_orga_page`` signals.
 - :feature:`orga:email` The URL to the private speaker profile page (where speakers can e.g. edit their biography) is now available as an email placeholder.
 - :bug:`orga:email` The list of available email placeholders was hidden when editing email templates.
 - :bug:`orga:email` If the email signature contained URLs, those URLs were broken in the HTML version of the email.

--- a/doc/developer/plugins/general.rst
+++ b/doc/developer/plugins/general.rst
@@ -39,7 +39,7 @@ Organiser area
 --------------
 
 .. automodule:: pretalx.orga.signals
-   :members: nav_event, nav_global, html_head, activate_event, nav_event_settings, event_copy_data
+   :members: nav_event, nav_global, html_head, html_above_orga_page, html_below_orga_page, activate_event, nav_event_settings, event_copy_data
 
 .. automodule:: pretalx.common.signals
    :no-index:

--- a/src/pretalx/orga/signals.py
+++ b/src/pretalx/orga/signals.py
@@ -70,6 +70,34 @@ Additionally, the signal will be called with the ``request`` it is processing.
 The receivers are expected to return HTML.
 """
 
+html_above_orga_page = EventPluginSignal()
+"""
+This signal is sent out to display additional information on orga pages,
+above all other content.
+
+This is intended for important, somewhat urgent messages that should be displayed
+prominently, such as a warning about an upcoming deadline or a change in the event
+schedule.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+Additionally, the signal will be called with the ``request`` it is processing.
+The receivers are expected to return HTML.
+"""
+
+html_below_orga_page = EventPluginSignal()
+"""
+This signal is sent out to display additional information on orga pages,
+below all other content.
+
+This is intended to show additional information that is not as urgent as the
+information displayed by the ``html_above_orga_page`` signal, such as additional
+information about individual sessions or speakers.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+Additionally, the signal will be called with the ``request`` it is processing.
+The receivers are expected to return HTML.
+"""
+
 event_copy_data = EventPluginSignal()
 """
 This signal is sent out when a new event is created as a clone of an existing event, i.e.

--- a/src/pretalx/orga/signals.py
+++ b/src/pretalx/orga/signals.py
@@ -72,8 +72,8 @@ The receivers are expected to return HTML.
 
 html_above_orga_page = EventPluginSignal()
 """
-This signal is sent out to display additional information on orga pages,
-above all other content.
+This signal is sent out to display additional information on every page in the
+organiser backend, above all other content.
 
 This is intended for important, somewhat urgent messages that should be displayed
 prominently, such as a warning about an upcoming deadline or a change in the event
@@ -86,8 +86,8 @@ The receivers are expected to return HTML.
 
 html_below_orga_page = EventPluginSignal()
 """
-This signal is sent out to display additional information on orga pages,
-below all other content.
+This signal is sent out to display additional information on every page in the
+organiser backend, below all other content.
 
 This is intended to show additional information that is not as urgent as the
 information displayed by the ``html_above_orga_page`` signal, such as additional

--- a/src/pretalx/orga/templates/orga/base.html
+++ b/src/pretalx/orga/templates/orga/base.html
@@ -1,5 +1,6 @@
 {% load compress %}
 {% load event_tags %}
+{% load html_signal %}
 {% load i18n %}
 {% load rules %}
 {% load static %}
@@ -504,8 +505,10 @@
                         {% endfor %}
                     {% endif %}
 
+                    {% html_signal "pretalx.orga.signals.html_above_orga_page" sender=request.event request=request %}
                     {% block content %}
                     {% endblock content %}
+                    {% html_signal "pretalx.orga.signals.html_below_orga_page" sender=request.event request=request %}
                 </main>
                 <footer>
                     {% include "common/powered_by.html" %}


### PR DESCRIPTION
This is a stripped down proposal for https://github.com/pretalx/pretalx/pull/2017.

This PR only includes the rather leightweight but very generic ``pretalx.orga.signals.html_above_orga_page`` and ``pretalx.orga.signals.html_below_orga_page`` HTML signals.

The signals are sent out to display additional information on all event related orga pages, above or below all other content.

``pretalx.orga.signals.html_above_orga_page`` is intended for important, somewhat urgent messages that should be displayed prominently, such as a warning about an upcoming deadline or a change in the event schedule.

``pretalx.orga.signals.html_below_orga_page``, on the other hand, is intended to show additional information that is not as urgent as the information displayed by the ``html_above_orga_page`` signal, such as additional information about individual sessions or speakers.

It has currently only been tested manually (but rather extensively) using modified versions of the plugins pretalx-signal-demo, pretalx-rt, and pretalx-zammad which have been developed against the previous proposals. The necessary modifications in these plugins are light weight.

As far as I'm aware of, the previous approaches have not yet been adopted by anyone else. I do like this version more than the previous.

- [ ] I have added tests to cover my changes.
- [x] I have manually tested my changes.
- [x] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
