### PR TITLE
 Allow plugins to inject additional Forms in orga area

### DIFF
--- a/src/pretalx/common/templatetags/form_signal.py
+++ b/src/pretalx/common/templatetags/form_signal.py
@@ -1,0 +1,28 @@
+from django import template
+from django.utils.module_loading import import_string
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def form_signal(context, signal_name: str, **kwargs):
+    """
+    Usage:
+        {% form_signal "path.to.signal" argument="value" ...  as extra_forms %}
+        {% for form in extra_forms %}
+            {{ form }}
+        {% endfor %}
+    """
+    signal = import_string(signal_name)
+    request = kwargs.pop("request", context.get("request"))
+    sender = kwargs.pop("sender", request.event)
+    forms = []
+    for _, response in signal.send_robust(sender=sender, request=request, **kwargs):
+        if isinstance(response, Exception):
+            continue
+        if isinstance(response, list):
+            forms.extend(response)
+        elif response:
+            forms.append(response)
+
+    return forms

--- a/src/pretalx/common/templatetags/html_signal.py
+++ b/src/pretalx/common/templatetags/html_signal.py
@@ -12,7 +12,7 @@ def html_signal(signal_name: str, **kwargs):
 
     Usage::
 
-        {% html_signal event "path.to.signal" argument="value" ... %}
+        {% html_signal "path.to.signal" argument="value" ... %}
     """
     signal = import_string(signal_name)
     _html = []

--- a/src/pretalx/common/views/generic.py
+++ b/src/pretalx/common/views/generic.py
@@ -22,6 +22,7 @@ from i18nfield.forms import I18nModelForm
 
 from pretalx.cfp.forms.auth import ResetForm
 from pretalx.common.exceptions import SendMailException
+from pretalx.common.templatetags.form_signal import form_signal
 from pretalx.common.text.phrases import phrases
 from pretalx.common.views.mixins import (
     Filterable,
@@ -43,8 +44,26 @@ def get_next_url(request):
     return url
 
 
+class FormSignalMixin:
+    def get_form_signal_name(self):
+        return "pretalx.orga.signals.extra_form"
+
+    def form_valid(self, form):
+        valid = super().form_valid(form)
+        forms = form_signal(
+            {"request": self.request}, self.get_form_signal_name(), instance=self.object
+        )
+        for f in forms:
+            if not f.is_valid():
+                if f.errors:
+                    messages.error(self.request, f.errors[0])
+            else:
+                f.save()
+        return valid
+
+
 class CreateOrUpdateView(
-    SingleObjectTemplateResponseMixin, ModelFormMixin, ProcessFormView
+    SingleObjectTemplateResponseMixin, FormSignalMixin, ModelFormMixin, ProcessFormView
 ):
     def set_object(self):
         with suppress(self.model.DoesNotExist, AttributeError):
@@ -472,7 +491,7 @@ class CRUDView(PaginationMixin, Filterable, View):
         ]
 
 
-class OrgaCRUDView(CRUDView):
+class OrgaCRUDView(FormSignalMixin, CRUDView):
 
     @cached_property
     def event(self):

--- a/src/pretalx/orga/signals.py
+++ b/src/pretalx/orga/signals.py
@@ -85,3 +85,118 @@ keyword argument will contain the event slug to **copy from**. The keyword argum
 mappings from object IDs in the original event to objects in the new event of the respective
 types.
 """
+
+extra_form = EventPluginSignal()
+"""
+This signal allows you to add custom form elements to existing forms in the
+organiser backend. The signal is sent for all forms that use the
+``basic_form.html`` template, which includes — but is not limited to — the
+forms for tracks, session tags and types, access codes, and rooms, for example.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing and the ``instance`` that the form is working on.
+
+Receivers of this generic signal must identify the kind of form and the type
+of data they are working on by checking the ``request`` or the type of the
+``instance`` argument. The form extension should be used to edit data related
+to the instance of the main form.
+
+The elements of the form will be rendered inside a ``<fieldset>`` below the
+existing fields of the form. If you want to add a label, you can return a form
+with a ``label`` attribute set, which will be rendered as a ``<legend>``
+element for the fieldset.
+
+Separate signals are sent for submission-, speaker-, review-, and email-related
+forms, which are documented in the respective sections below. These signals
+are sent with the ``speaker_form``, ``submission_form``, ``review_form``, and
+``mail_form`` names.
+
+Receivers may return either a single form or a list of forms.
+"""
+
+speaker_form = EventPluginSignal()
+"""
+This signal allows you to add custom form elements to speaker-related forms in
+the organiser backend. Unlike the generic ``extra_form`` signal, this signal is
+only sent for forms that specifically deal with speakers.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing and the ``instance`` the form is working on. The ``instance``
+argument is always an instance of ``SpeakerProfile``.
+
+This signal is only sent for speaker-related forms. For generic form
+extensions, use the ``extra_form`` signal instead.
+
+The person associated with the speaker profile is accessible via the ``user``
+attribute of the ``instance`` argument. This signal is well-suited for adding
+personal data fields related to the speaker, potentially even pulling
+information from external systems such as ticketing platforms or CRMs.
+
+Receivers may return either a single form or a list of forms.
+"""
+
+submission_form = EventPluginSignal()
+"""
+This signal allows you to add custom form elements to submission-related forms
+in the organiser backend. Unlike the generic ``extra_form`` signal, this signal
+is only sent for forms that specifically deal with submissions.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing and the ``instance`` the form is working on. The ``instance``
+argument is always an instance of ``Submission``.
+
+This signal is only sent for submission-related forms. For generic form
+extensions, use the ``extra_form`` signal instead.
+
+This signal is well-suited for integrating with external ticketing or support
+systems to track submission-specific communication or requirements — both
+during the preparation phase and throughout the event itself. Possible use
+cases include special technical arrangements or billing-related coordination.
+
+Receivers may return either a single form or a list of forms.
+"""
+
+review_form = EventPluginSignal()
+"""
+This signal allows you to add custom form elements to review-related forms in
+the organiser backend. Unlike the generic ``extra_form`` signal, this signal is
+only sent for forms that specifically deal with reviews.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing and the ``instance`` the form is working on. The ``instance``
+argument is always an instance of ``Review``.
+
+This signal is only sent for review-related forms. For generic form
+extensions, use the ``extra_form`` signal instead.
+
+This signal is useful for capturing additional information about speakers and
+submissions during the review phase. Similar to the custom fields that submitters
+fill out during the CFP phase, these fields are intended solely for internal use.
+
+Receivers may return either a single form or a list of forms.
+"""
+
+mail_form = EventPluginSignal()
+"""
+This signal allows you to add custom form elements to email-related forms in
+the organiser backend. Unlike the generic ``extra_form`` signal, this signal is
+only sent for forms that specifically deal with emails.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the
+event. Additionally, the signal will be called with the ``request`` it is
+processing and the ``instance`` the form is working on. The ``instance``
+argument is always an instance of ``QueuedMail``.
+
+This signal is only sent for email-related forms. For generic form
+extensions, use the ``extra_form`` signal instead.
+
+This signal can, for example, be used to integrate with an external ticketing
+system used for speaker communication, by adding fields to store or display
+related ticket information directly in the email form.
+
+Receivers may return either a single form or a list of forms.
+"""

--- a/src/pretalx/orga/templates/orga/includes/base_form.html
+++ b/src/pretalx/orga/templates/orga/includes/base_form.html
@@ -1,5 +1,13 @@
+{% load form_signal %}
 <form method="post" {% if form.is_multipart %}enctype="multipart/form-data"{% endif %}{% if form_class %} class="{{ form_class }}"{% endif %}>
     {% csrf_token %}
     {{ form }}
+    {% form_signal "pretalx.orga.signals.extra_form" sender=request.event request=request instance=form.instance as extra_forms %}
+    {% for form in extra_forms %}
+        <fieldset>
+            {% if form.label %}<legend>{{ form.label }}</legend>{% endif %}
+            {{ form }}
+        </fieldset>
+    {% endfor %}
     {% include "orga/includes/submit_row.html" %}
 </form>

--- a/src/pretalx/orga/templates/orga/mails/outbox_form.html
+++ b/src/pretalx/orga/templates/orga/mails/outbox_form.html
@@ -1,4 +1,5 @@
 {% extends "orga/mails/base.html" %}
+{% load form_signal %}
 {% load i18n %}
 {% load rich_text %}
 
@@ -18,6 +19,13 @@
 
         {% if not form.read_only %}
             {{ form }}
+            {% form_signal "pretalx.orga.signals.mail_form" instance=form.instance as extra_forms %}
+            {% for form in extra_forms %}
+                <fieldset>
+                    {% if form.label %}<legend>{{ form.label }}</legend>{% endif %}
+                    {{ form }}
+                </fieldset>
+            {% endfor %}
         {% else %}
             <div class="d-flex flex-column">
                 <div class="row form-group">
@@ -79,6 +87,21 @@
                     <div class="col col-md-9">{{ form.instance.text|rich_text }}</div>
                 </div>
             </div>
+
+            {% form_signal "pretalx.orga.signals.mail_form" instance=form.instance as extra_forms %}
+            {% for form in extra_forms %}
+                <div>
+                    {% if form.label %}<h3>{{ form.label }}</h3>{% endif %}
+                    {% for field in form %}
+                        <div class="row form-group">
+                            <div class="col col-md-3 flip text-right font-weight-bold">
+                                <div class="font-weight-bold">{{ field.label }}</div>
+                            </div>
+                            <div class="col col-md-9">{{ field.value|default:"-" }}</div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endfor %}
         {% endif %}
 
         <div class="submit-group">

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -1,6 +1,7 @@
 {% extends "orga/base.html" %}
 
 {% load compress %}
+{% load form_signal %}
 {% load i18n %}
 {% load rules %}
 {% load static %}
@@ -83,6 +84,14 @@
         {% endif %}
 
         {{ questions_form }}
+
+        {% form_signal "pretalx.orga.signals.speaker_form" instance=form.instance as extra_forms %}
+        {% for form in extra_forms %}
+            <fieldset>
+                {% if form.label %}<legend>{{ form.label }}</legend>{% endif %}
+                {{ form }}
+            </fieldset>
+        {% endfor %}
 
         {% include "orga/includes/submit_row.html" %}
 

--- a/src/pretalx/orga/templates/orga/submission/content.html
+++ b/src/pretalx/orga/templates/orga/submission/content.html
@@ -2,6 +2,7 @@
 
 {% load compress %}
 {% load filesize %}
+{% load form_signal %}
 {% load formset_tags %}
 {% load i18n %}
 {% load static %}
@@ -88,6 +89,13 @@
                 <div><legend id="custom">{{ phrases.cfp.custom_fields }}</legend></div>
                 {{ questions_form }}
             {% endif %}
+            {% form_signal "pretalx.orga.signals.submission_form" instance=submission as extra_forms %}
+            {% for form in extra_forms %}
+                <fieldset>
+                    {% if form.label %}<legend>{{ form.label }}</legend>{% endif %}
+                    {{ form }}
+                </fieldset>
+            {% endfor %}
 
             {% if not form.read_only %}
                 <div class="submit-group panel">

--- a/src/pretalx/orga/templates/orga/submission/review.html
+++ b/src/pretalx/orga/templates/orga/submission/review.html
@@ -1,6 +1,7 @@
 {% extends "orga/submission/base.html" %}
 
 {% load compress %}
+{% load form_signal %}
 {% load i18n %}
 {% load rich_text %}
 {% load rules %}
@@ -166,6 +167,14 @@
                     {{ form.text.as_field_group }}
                 </div>
             {% endif %}
+
+            {% form_signal "pretalx.orga.signals.review_form" instance=form.instance as extra_forms %}
+            {% for form in extra_forms %}
+                <fieldset>
+                    {% if form.label %}<legend>{{ form.label }}</legend>{% endif %}
+                    {{ form }}
+                </fieldset>
+            {% endfor %}
 
             {% if can_view_other_reviews or form.instance.pk %}
                 <div class="table-responsive-always">

--- a/src/pretalx/orga/views/mails.py
+++ b/src/pretalx/orga/views/mails.py
@@ -317,6 +317,9 @@ class MailDetail(PermissionRequired, ActionFromUrl, CreateOrUpdateView):
     def get_success_url(self):
         return self.object.event.orga_urls.outbox
 
+    def get_form_signal_name(self):
+        return "pretalx.orga.signals.mail_form"
+
     def form_valid(self, form):
         form.instance.event = self.request.event
         result = super().form_valid(form)

--- a/src/pretalx/orga/views/review.py
+++ b/src/pretalx/orga/views/review.py
@@ -618,6 +618,9 @@ class ReviewSubmission(ReviewViewMixin, PermissionRequired, CreateOrUpdateView):
         kwargs["categories"] = self.score_categories
         return kwargs
 
+    def get_form_signal_name(self):
+        return "pretalx.orga.signals.review_form"
+
     def form_valid(self, form):
         if not self.qform.is_valid():
             messages.error(self.request, phrases.base.error_saving_changes)

--- a/src/pretalx/orga/views/speaker.py
+++ b/src/pretalx/orga/views/speaker.py
@@ -185,6 +185,9 @@ class SpeakerDetail(SpeakerViewMixin, ActionFromUrl, CreateOrUpdateView):
             ),
         )
 
+    def get_form_signal_name(self):
+        return "pretalx.orga.signals.speaker_form"
+
     @transaction.atomic()
     def form_valid(self, form):
         result = super().form_valid(form)

--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -441,12 +441,15 @@ class SubmissionContent(
     def get_success_url(self) -> str:
         return self.object.orga_urls.base
 
+    def get_form_signal_name(self):
+        return "pretalx.orga.signals.submission_form"
+
     @transaction.atomic()
     def form_valid(self, form):
         created = not self.object
         self.object = form.instance
         self._questions_form.submission = self.object
-        if not self._questions_form.is_valid():
+        if not (super().form_valid(form) and self._questions_form.is_valid()):
             messages.error(self.request, phrases.base.error_saving_changes)
             return self.get(self.request, *self.args, **self.kwargs)
         form.instance.event = self.request.event


### PR DESCRIPTION
This is a stripped down proposal for https://github.com/pretalx/pretalx/pull/2017.

This PR only includes the wechanism for form extensions.

The `form_signal` has ben defined analoguously to `html_signal`. It can be used to place additional form elements into existing templates. In order to add Forms the `form_signal` triggers sending another signal to plugins which can in tur retunr a django `Form` or a list of forms.

`pretalx.orga.signals.extra_form` is a generic signal that covers a huge number of existing forms - basically all that are based on the `basic_form.html` template and the `OrgaCRUDView`. In addition to the generic signal - where the plugin has to figure out in which context the additional form is needed - signals `speaker_form`, `submission_form`, `review_form` and `mail_form` have been defined to extend the corresponding forms.

It has currently only been tested manually (but rather extensively) using modified versions of the plugins pretalx-signal-demo, pretalx-rt, and pretalx-zammad which have been developed against the previous proposals. The necessary modifications in these plugins are light weight.

As far as I'm aware of, the previous approaches have not yet been adopted by anyone else. I do like this version more than the previous.

- [ ] I have added tests to cover my changes.
- [x] I have manually tested my changes.
- [x] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.