### PR TITLE
Add dashboard tile signals for plugin integration

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`dev` Plugins can now inject additional tiles on the main dashboard of the organisers area with the ``dashboard_tile`` signal.
 - :feature:`cfp` Organisers can now also change the label of the recording-opt-out field.
 - :feature:`orga:email` The URL to the private speaker profile page (where speakers can e.g. edit their biography) is now available as an email placeholder.
 - :bug:`orga:email` The list of available email placeholders was hidden when editing email templates.

--- a/doc/developer/plugins/general.rst
+++ b/doc/developer/plugins/general.rst
@@ -39,7 +39,7 @@ Organiser area
 --------------
 
 .. automodule:: pretalx.orga.signals
-   :members: nav_event, nav_global, html_head, activate_event, nav_event_settings, event_copy_data
+   :members: nav_event, nav_global, html_head, activate_event, nav_event_settings, event_copy_data, dashboard_tile
 
 .. automodule:: pretalx.common.signals
    :no-index:

--- a/src/pretalx/orga/signals.py
+++ b/src/pretalx/orga/signals.py
@@ -85,3 +85,23 @@ keyword argument will contain the event slug to **copy from**. The keyword argum
 mappings from object IDs in the original event to objects in the new event of the respective
 types.
 """
+
+dashboard_tile = EventPluginSignal()
+"""
+This signal is sent out to collect additional tiles for the main dashboard of an
+event. Receivers are expected to return a dictionary or a list of dictionaries.
+
+The dictionaries should contain at least the keys ``large`` for a tile heading and
+``small`` for a subtitle or content. Optionally, you can return a ``url`` key to make
+the tile clickable and a ``priority`` to determine the order in which tiles are
+displayed. The ``priority`` should be a number between 0 and 100, with lower numbers
+being displayed first. Actions should be between 10 and 30, with 20 being the
+"go to cfp" action. General statistics start at 50.
+The tile dictionary may optionally also contain a ``left`` or ``right`` key, which
+should contain a dictionary with the keys ``text`` and optionally ``url`` and
+``color``. The ``text`` key will be displayed as a button on the left or right side
+of the tile, the optional ``url`` key will make the button clickable, and the
+``color`` key should be one of ``success``, `info``, ``error`` or ``secondary``.
+
+As with all plugin signals, the ``sender`` keyword argument will contain the event.
+"""

--- a/src/pretalx/orga/views/dashboard.py
+++ b/src/pretalx/orga/views/dashboard.py
@@ -15,9 +15,9 @@ from pretalx.common.text.phrases import phrases
 from pretalx.common.views.mixins import EventPermissionRequired, PermissionRequired
 from pretalx.event.models import Event, Organiser
 from pretalx.event.stages import get_stages
+from pretalx.orga.signals import dashboard_tile
 from pretalx.submission.models import Submission, SubmissionStates
 from pretalx.submission.rules import get_missing_reviews
-
 
 def start_redirect_view(request):
     with scopes_disabled():
@@ -223,6 +223,15 @@ class EventDashboardView(EventPermissionRequired, TemplateView):
                 )
         return result
 
+    def get_plugin_tiles(self):
+        tiles = []
+        for receiver, response in dashboard_tile.send_robust(sender=self.request.event):
+            if isinstance(response, list):
+                tiles.extend(response)
+            else:
+                tiles.append(response)
+        return tiles
+
     @context
     def history(self):
         return ActivityLog.objects.filter(event=self.request.event).select_related(
@@ -409,5 +418,6 @@ class EventDashboardView(EventPermissionRequired, TemplateView):
         result["tiles"] += self.get_review_tiles(
             can_change_settings=can_change_settings
         )
+        result["tiles"] += self.get_plugin_tiles()
         result["tiles"].sort(key=lambda tile: tile.get("priority") or 100)
         return result


### PR DESCRIPTION
This PR adds a signal to allow plugins to add tiles on the main dashboard in the  organizers area.

## How has this been tested?

The following code snippet in a small dummy plugin creates a sample tile on the dashboard:
```python
from pretalx.orga.signals import dashboard_tile

@receiver(dashboard_tile)
def dashboard_tile(sender, **kwargs):
    return {
            "large": "large",
            "small": "small",
            "url": "http://example.com",
            "priority": 5,
            "left": {
                "text": "left",
                "url": "http://example.com",
                "color": "info",
            },
            "right": {
                "text": "right",
                "url": "http://example.com",
                "color": "secondary",
            },
        }
    )
```
<img width="369" height="160" alt="image" src="https://github.com/user-attachments/assets/ef8c4815-0406-4abd-9948-fa45a0f988a3" />

## Checklist

- [ ] I have added tests to cover my changes.
- [x] I have manually tested my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
