### PR TITLE
Fix & improve marking speakers as arrived

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ Chris Wolf
 David Ellis
 Dominik Helle
 Emmanouil Kampitakis
+Felix Dreissig
 Florian Klien
 Florian Mösch
 Frantisek Holop

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`orga:speaker` Speakers could not be marked as arrived from their detail page.
 - :feature:`dev,2017` Plugins can now inject additional HTML in the organisers area with the ``pretalx.orga.signals.html_above_orga_page`` and ``pretalx.orga.signals.html_below_orga_page`` signals.
 - :feature:`dev` Plugins can now inject additional tiles on the main dashboard of the organisers area with the ``dashboard_tile`` signal.
 - :feature:`cfp` Organisers can now also change the label of the recording-opt-out field.

--- a/src/pretalx/orga/templates/orga/includes/mark_speakers_arrived.html
+++ b/src/pretalx/orga/templates/orga/includes/mark_speakers_arrived.html
@@ -2,10 +2,14 @@
 
 {# Permission check has to take place outside of this template, so we don’t run it a gazillion times in list views #}
 
-<a class="btn btn-{{ speaker.has_arrived|yesno:"success,info" }} {{ arrived_btn_class }}" href="{{ speaker.orga_urls.toggle_arrived }}?next={{ request.path|urlencode }}">
-    {% if speaker.has_arrived %}
-        {% translate "Mark speaker as not arrived" %}
-    {% else %}
-        {% translate "Mark speaker as arrived" %}
-    {% endif %}
-</a>
+<form method="post" action="{{ speaker.orga_urls.toggle_arrived }}?next={{ request.path|urlencode }}" class="d-inline">
+    {% csrf_token %}
+
+    <button type="submit" class="btn btn-{{ speaker.has_arrived|yesno:"success,info" }} {{ arrived_btn_class }}">
+        {% if speaker.has_arrived %}
+            {% translate "Mark speaker as not arrived" %}
+        {% else %}
+            {% translate "Mark speaker as arrived" %}
+        {% endif %}
+    </button>
+</form>

--- a/src/pretalx/orga/templates/orga/includes/mark_speakers_arrived.html
+++ b/src/pretalx/orga/templates/orga/includes/mark_speakers_arrived.html
@@ -2,7 +2,7 @@
 
 {# Permission check has to take place outside of this template, so we don’t run it a gazillion times in list views #}
 
-<a class="btn btn-{{ arrived_btn_class }}{{ speaker.has_arrived|yesno:"success,info" }}" href="{{ speaker.orga_urls.toggle_arrived }}?next={{ request.path|urlencode }}">
+<a class="btn btn-{{ speaker.has_arrived|yesno:"success,info" }} {{ arrived_btn_class }}" href="{{ speaker.orga_urls.toggle_arrived }}?next={{ request.path|urlencode }}">
     {% if speaker.has_arrived %}
         {% translate "Mark speaker as not arrived" %}
     {% else %}

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -34,7 +34,7 @@
             {{ proposal_title }})
         </span>
         <div class="ml-auto mb-1">
-            {% if can_mark_speakers and accepted_submissions.exists %}
+            {% if can_mark_speaker and accepted_submissions.exists %}
                 {% include "orga/includes/mark_speakers_arrived.html" with speaker=form.instance %}
             {% endif %}
             <a href="{{ form.instance.orga_urls.password_reset }}" class="btn btn-info flip">{{ phrases.base.password_reset_heading }}</a>

--- a/src/pretalx/orga/templates/orga/speaker/list.html
+++ b/src/pretalx/orga/templates/orga/speaker/list.html
@@ -54,13 +54,7 @@
                         <td class="text-right">
                             {% if profile.accepted_submission_count %}
                                 {% if can_mark_speaker %}
-                                    <a class="btn btn-sm btn-{{ profile.has_arrived|yesno:"success,info" }}" href="{{ profile.orga_urls.toggle_arrived }}?from=list">
-                                        {% if profile.has_arrived %}
-                                            {% translate "Mark speaker as not arrived" %}
-                                        {% else %}
-                                            {% translate "Mark speaker as arrived" %}
-                                        {% endif %}
-                                    </a>
+                                    {% include "orga/includes/mark_speakers_arrived.html" with speaker=profile arrived_btn_class="btn-sm" %}
                                 {% else %}
                                     {% if profile.has_arrived %}
                                         <a><i class="fa fa-check"></i> {% translate "Arrived" %}</a>

--- a/src/pretalx/orga/views/speaker.py
+++ b/src/pretalx/orga/views/speaker.py
@@ -242,7 +242,7 @@ class SpeakerPasswordReset(SpeakerViewMixin, ActionConfirmMixin, DetailView):
 class SpeakerToggleArrived(SpeakerViewMixin, View):
     permission_required = "person.update_speakerprofile"
 
-    def dispatch(self, request, event, code):
+    def post(self, request, event, code):
         self.profile.has_arrived = not self.profile.has_arrived
         self.profile.save()
         action = (

--- a/src/tests/orga/views/test_orga_views_speaker.py
+++ b/src/tests/orga/views/test_orga_views_speaker.py
@@ -177,14 +177,14 @@ def test_orga_can_edit_speaker_status(orga_client, speaker, event, submission):
     with scope(event=event):
         assert speaker.profiles.first().has_arrived is False
         url = speaker.profiles.first().orga_urls.toggle_arrived
-    response = orga_client.get(url, follow=True)
+    response = orga_client.post(url, follow=True)
     assert response.status_code == 200
     with scope(event=event):
         speaker.refresh_from_db()
         assert speaker.profiles.first().has_arrived is True
     with scopes_disabled():
         assert speaker.logged_actions().count() == logs + 1
-    response = orga_client.get(url + "?from=list", follow=True)
+    response = orga_client.post(url + "?from=list", follow=True)
     assert response.status_code == 200
     with scope(event=event):
         speaker.refresh_from_db()


### PR DESCRIPTION
This PR can be seen as a follow-up to #1942. It improves various aspects of marking speakers as arrived:

- Fix typo that prevented marking speakers as arrived from their orga detail page
- Restore usage of "mark_speakers_arrived" include in orga speakers list (Had originally been introduced in 3e7a583, apparently got lost in d0617bd1d.)
- Switch marking speakers as arrived to POST request (It alters data, so it shouldn't use GET.)

## How has this been tested?

Ran and updated tests, checked the templates manually.

## Checklist

- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.