### PR TITLE
Correctly store freshly created draft proposals

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`cfp` Draft proposals were created and saved as submitted instead of draft, then changed to draft and saved again. This has been fixed to prevent the submitted state from appearing in the database, even briefly.
 - :feature:`dev,2017` Plugins can now inject additional HTML in the organisers area with the ``pretalx.orga.signals.html_above_orga_page`` and ``pretalx.orga.signals.html_below_orga_page`` signals.
 - :feature:`dev` Plugins can now inject additional tiles on the main dashboard of the organisers area with the ``dashboard_tile`` signal.
 - :feature:`cfp` Organisers can now also change the label of the recording-opt-out field.

--- a/src/pretalx/cfp/flow.py
+++ b/src/pretalx/cfp/flow.py
@@ -340,12 +340,12 @@ class InfoStep(GenericFlowStep, FormFlowStep):
         self.request = request
         form = self.get_form(from_storage=True)
         form.instance.event = self.event
+        if draft:
+            form.instance.state = SubmissionStates.DRAFT
         form.save()
         submission = form.instance
         submission.speakers.add(request.user)
         if draft:
-            submission.state = SubmissionStates.DRAFT
-            submission.save()
             messages.success(
                 self.request,
                 _(


### PR DESCRIPTION
When a user created a draft proposal via the CfP flow, it was initially saved in the database as `submitted` and then immediately updated to the `draft` state.

Code listening to `django.db.models.signals` would have received two `pre_save` and two `post_save` signals — first with the incorrect `submitted` state, then with the correct `draft` state.

Since draft proposals should not be visible (even to organizers), saving them in an incorrect state should be avoided.

## How was this found and tested?

This issue was discovered while working on the RT plugin, which had begun creating tickets even for draft proposals.  
I tested the fix manually and kept the change minimal. I considered changing the default from `submitted` to `draft`, but that would have required a larger changeset to ensure all other submissions were still created as `submitted` — which remains the preferred default in most cases.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] I have manually tested my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
