### PR TITLE
Add shortcut URLs

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`orga` Shortcut links (``/redirect/<code>``) are now available. They will redirect to the corresponding organisers page if the requesting user is an organiser or to the public page if the requesting user is not logged in or does not have organiser permissions. The code can be a submission code or a user code.
 - :bug:`orga:email,2116` The email outbox could not be sorted by email recipient name or by sent date.
 - :bug:`orga:speaker` Speakers could not be marked as arrived from their detail page.
 - :bug:`cfp` Draft proposals were created and saved as submitted instead of draft, then changed to draft and saved again. This has been fixed to prevent the submitted state from appearing in the database, even briefly.

--- a/doc/developer/plugins/customview.rst
+++ b/doc/developer/plugins/customview.rst
@@ -64,7 +64,7 @@ your views::
     from pretalx.common.mixins.views import PermissionRequired
 
     class AdminView(PermissionRequired, View):
-        permission_required = "orga.view_submissions"
+        permission_required = "submission.orga_list_submission"
 
 
 There is also a signal that allows you to add the view to the event sidebar navigation like this::
@@ -80,7 +80,7 @@ There is also a signal that allows you to add the view to the event sidebar navi
     @receiver(nav_event, dispatch_uid="friends_tickets_nav")
     def navbar_info(sender, request, **kwargs):
         url = resolve(request.path_info)
-        if not request.user.has_perm("orga.view_orga_area", request.event):
+        if not request.user.has_perm("event.orga_access_event", request.event):
             return []
         return [{
             "label": _("My plugin view"),

--- a/src/pretalx/common/views/__init__.py
+++ b/src/pretalx/common/views/__init__.py
@@ -8,6 +8,7 @@ from .generic import (
 )
 from .helpers import get_static, is_form_bound
 from .redirect import redirect_view
+from .shortlink import shortlink_view
 
 __all__ = [
     "CreateOrUpdateView",
@@ -20,4 +21,5 @@ __all__ = [
     "handle_500",
     "is_form_bound",
     "redirect_view",
+    "shortlink_view",
 ]

--- a/src/pretalx/common/views/shortlink.py
+++ b/src/pretalx/common/views/shortlink.py
@@ -1,0 +1,31 @@
+from contextlib import suppress
+
+from django.http import Http404, HttpResponseRedirect
+from django_scopes import scopes_disabled
+
+from pretalx.person.models.user import User
+from pretalx.submission.models.submission import Submission
+
+
+@scopes_disabled()
+def shortlink_view(request, code, *args, **kwargs):
+    with suppress(Submission.DoesNotExist):
+        submission = Submission.objects.select_related("event").get(code=code)
+        if request.user.has_perm("submission.orga_list_submission", submission):
+            return HttpResponseRedirect(submission.orga_urls.base)
+        if request.user.has_perm("submission.view_public_submission", submission):
+            return HttpResponseRedirect(submission.urls.public)
+    with suppress(User.DoesNotExist):
+        user = User.objects.get(code=code)
+        if request.user.has_perm("person.administrator_user", user):
+            return HttpResponseRedirect(user.orga_urls.admin)
+        profiles = user.profiles.select_related("event").order_by("-created")
+        for profile in profiles:
+            if request.user.has_perm("person.orga_list_speakerprofile", profile):
+                return HttpResponseRedirect(profile.orga_urls.base)
+        if profile := profiles.first():
+            if request.user == user:
+                return HttpResponseRedirect(profile.event.urls.user)
+            if request.user.has_perm("person.view_speakerprofile", profile):
+                return HttpResponseRedirect(profile.urls.public)
+    raise Http404()

--- a/src/pretalx/urls.py
+++ b/src/pretalx/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls.static import static
 from django.urls import include, path
 from django.utils.module_loading import import_string
 
-from pretalx.common.views import error_view, redirect_view
+from pretalx.common.views import error_view, redirect_view, shortlink_view
 
 plugin_patterns = []
 for app in apps.get_app_configs():
@@ -25,6 +25,7 @@ urlpatterns = [
     path("orga/", include("pretalx.orga.urls", namespace="orga")),
     path("api/", include("pretalx.api.urls", namespace="api")),
     path("redirect/", redirect_view, name="redirect"),
+    path("redirect/<code>", shortlink_view, name="shortlink"),
     # Root patterns are ordered by precedence:
     # Plugins last, so that they cannot break anything
     path("", include("pretalx.agenda.urls", namespace="agenda")),


### PR DESCRIPTION
This PR adds shortcut URLs of the form ~`/goto/<code>`~ `/redirect/<code>`.

The idea came up while writing the RT plugin. RT allows custom fields that can automatically create links — in this case, back to pretalx. Unfortunately, the link pattern cannot vary by queue in RT (we have one queue per event in pretalx), so I could only create working links to one pretalx event at a time.

The proposed shortcut URLs work independently of the event. Codes are unique across the entire pretalx installation, not just within a single event, so the corresponding event for a code can be determined easily.

The implementation first tries to find a matching submission, then a matching person.  
If the request is made in a browser by an authenticated pretalx user with organizer permissions, the link redirects to the organizer area. If the user is anonymous or lacks organizer permissions, it redirects to the public page.

## How has this been tested?
Only manual tests have been made. Very similar code (without support for speaker codes) has been used during the last congress wir the RT plugin.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] I have manually tested my changes.
- [x] I have updated the documentation (minor fix for changed permissions).
- [x] My change is listed in the ``doc/changelog.rst``.
