### PR TITLE
Internal notes for speakers and access codes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :feature:`orga` Internal notes are now available for speaker profiles and access codes. The notes are only visible to organisers and reviewers.
 - :bug:`orga:email,2116` The email outbox could not be sorted by email recipient name or by sent date.
 - :bug:`orga:speaker` Speakers could not be marked as arrived from their detail page.
 - :bug:`cfp` Draft proposals were created and saved as submitted instead of draft, then changed to draft and saved again. This has been fixed to prevent the submitted state from appearing in the database, even briefly.

--- a/src/pretalx/api/serializers/access_code.py
+++ b/src/pretalx/api/serializers/access_code.py
@@ -17,6 +17,7 @@ class SubmitterAccessCodeSerializer(FlexFieldsSerializerMixin, PretalxSerializer
             "valid_until",
             "maximum_uses",
             "redeemed",
+            "internal_notes",
         )
         expandable_fields = {
             "track": (

--- a/src/pretalx/api/serializers/speaker.py
+++ b/src/pretalx/api/serializers/speaker.py
@@ -119,6 +119,7 @@ class SpeakerOrgaSerializer(AvailabilitiesMixin, SpeakerSerializer):
             "locale",
             "has_arrived",
             "availabilities",
+            "internal_notes",
         )
         expandable_fields = {
             "submissions": (

--- a/src/pretalx/orga/forms/cfp.py
+++ b/src/pretalx/orga/forms/cfp.py
@@ -441,6 +441,7 @@ class SubmitterAccessCodeForm(forms.ModelForm):
             "maximum_uses",
             "track",
             "submission_type",
+            "internal_notes",
         )
         field_classes = {
             "track": SafeModelChoiceField,

--- a/src/pretalx/orga/templates/orga/speaker/form.html
+++ b/src/pretalx/orga/templates/orga/speaker/form.html
@@ -82,6 +82,8 @@
             {{ form.availabilities.as_field_group }}
         {% endif %}
 
+        {{ form.internal_notes.as_field_group }}
+
         {{ questions_form }}
 
         {% include "orga/includes/submit_row.html" %}

--- a/src/pretalx/person/forms/profile.py
+++ b/src/pretalx/person/forms/profile.py
@@ -153,7 +153,10 @@ class SpeakerProfileForm(
 
     class Meta:
         model = SpeakerProfile
-        fields = ("biography",)
+        fields = (
+            "biography",
+            "internal_notes",
+        )
         public_fields = ["name", "biography", "avatar"]
         widgets = {
             "biography": MarkdownWidget,

--- a/src/pretalx/person/models/profile.py
+++ b/src/pretalx/person/models/profile.py
@@ -42,6 +42,14 @@ class SpeakerProfile(PretalxModel):
     has_arrived = models.BooleanField(
         default=False, verbose_name=_("The speaker has arrived")
     )
+    internal_notes = models.TextField(
+        null=True,
+        blank=True,
+        verbose_name=_("Internal notes"),
+        help_text=_(
+            "Internal notes for other organisers/reviewers. Not visible to the speakers or the public."
+        ),
+    )
 
     log_prefix = "pretalx.user.profile"
 

--- a/src/pretalx/submission/models/access_code.py
+++ b/src/pretalx/submission/models/access_code.py
@@ -63,6 +63,14 @@ class SubmitterAccessCode(GenerateCode, PretalxModel):
         blank=True,
     )
     redeemed = models.PositiveIntegerField(default=0, editable=False)
+    internal_notes = models.TextField(
+        null=True,
+        blank=True,
+        verbose_name=_("Internal notes"),
+        help_text=_(
+            "Internal notes for other organisers/reviewers. Not visible to the speakers or the public."
+        ),
+    )
 
     _code_length = 32
 

--- a/src/tests/api/test_api_access_code.py
+++ b/src/tests/api/test_api_access_code.py
@@ -21,6 +21,7 @@ def test_access_code_serializer(submission_type, event, track):
             "valid_until",
             "maximum_uses",
             "redeemed",
+            "internal_notes",
         }
         assert data["track"] == track.pk
 


### PR DESCRIPTION
Internal notes are now available for speaker profiles (#2031) and access codes (#2084).
The notes are only visible to organisers and reviewers.
They can only be accessed in the organizer area or via the API when authenticated.

API `schema.yml` and migrations have _not_ been updated.

## How has this been tested?
This has only been manually tested in the web prowser and `curl` for the API part.

## Checklist

- [ ] I have added tests to cover my changes.
- [x] I have manually tested my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
