### PR TITLE
Fix typo with the correct word to refers to something from Brazil

### DIFF
--- a/doc/api/schema.yml
+++ b/doc/api/schema.yml
@@ -4021,7 +4021,7 @@ components:
         * `ja-jp` - Japanese
         * `nl` - Dutch
         * `pl` - Polish
-        * `pt-br` - Brasilian Portuguese
+        * `pt-br` - Brazilian Portuguese
         * `pt-pt` - Portuguese
         * `vi` - Vietnamese
         * `zh-hant` - Traditional Chinese (Taiwan)

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -427,7 +427,7 @@ LANGUAGES_INFORMATION = {
         "official": False,
     },
     "pt-br": {
-        "name": _("Brasilian Portuguese"),
+        "name": _("Brazilian Portuguese"),
         "natural_name": "Português brasileiro",
         "official": False,
         "public_code": "pt",


### PR DESCRIPTION
The correct English word to refer to something or someone from Brazil in `Brazilian` (with a `Z`).

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
