### PR TITLE
Fix sorting emails by date

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,7 @@
 Release Notes
 =============
 
-- :bug:`orga:email,2116` The email outbox could not be sorted by email recipient name.
+- :bug:`orga:email,2116` The email outbox could not be sorted by email recipient name or by sent date.
 - :bug:`orga:speaker` Speakers could not be marked as arrived from their detail page.
 - :bug:`cfp` Draft proposals were created and saved as submitted instead of draft, then changed to draft and saved again. This has been fixed to prevent the submitted state from appearing in the database, even briefly.
 - :feature:`dev,2017` Plugins can now inject additional HTML in the organisers area with the ``pretalx.orga.signals.html_above_orga_page`` and ``pretalx.orga.signals.html_below_orga_page`` signals.

--- a/src/pretalx/orga/views/mails.py
+++ b/src/pretalx/orga/views/mails.py
@@ -113,7 +113,7 @@ class SentMail(
         "to_users__email__icontains",
     )
     default_sort_field = "-sent"
-    sortable_fields = ("to_users__name", "subject", "pk")
+    sortable_fields = ("to_users__name", "subject", "sent")
     secondary_sort = {
         "to_users__name": ["to"],
         "-to_users__name": ["-to"],


### PR DESCRIPTION
This PR is only a tiny followup to 439f9e936146d97e2376de2448051a428721f940.
(This is strictly speaking not a fix for the `outbox` but rather the `sent` view.)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [X] My change is listed in the ``doc/changelog.rst``.
