### PR TITLE
Check access code validity when editing submission drafts

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`cfp,2131` Access codes are now checked for validity when editing draft proposals.
 - :bug:`orga:email,2116` The email outbox could not be sorted by email recipient name or by sent date.
 - :bug:`orga:speaker` Speakers could not be marked as arrived from their detail page.
 - :bug:`cfp` Draft proposals were created and saved as submitted instead of draft, then changed to draft and saved again. This has been fixed to prevent the submitted state from appearing in the database, even briefly.

--- a/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_DE/LC_MESSAGES/django.po
@@ -380,8 +380,12 @@ msgstr ""
 "direkt an uns, wenn das verkehrt ist."
 
 #: pretalx/cfp/phrases.py:32
-msgid "This proposal cannot be edited anymore."
-msgstr "Die Einreichung kann nicht mehr bearbeitet werden."
+msgid ""
+"This proposal cannot be edited at this time. Please contact the organisers "
+"if you need to make changes."
+msgstr ""
+"Die Einreichung kann zur Zeit nicht bearbeitet werden – bitte wende dich an die "
+"Veranstalter, wenn Änderungen nötig sind."
 
 #: pretalx/cfp/phrases.py:34
 msgid "Speaker email"

--- a/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
+++ b/src/pretalx/locale/de_Formal/LC_MESSAGES/django.po
@@ -379,8 +379,12 @@ msgstr ""
 "direkt an uns, wenn das verkehrt ist."
 
 #: pretalx/cfp/phrases.py:32
-msgid "This proposal cannot be edited anymore."
-msgstr "Die Einreichung kann nicht mehr bearbeitet werden."
+msgid ""
+"This proposal cannot be edited at this time. Please contact the organisers "
+"if you need to make changes."
+msgstr ""
+"Die Einreichung kann zur Zeit nicht bearbeitet werden – bitte wenden Sie sich "
+"an die Veranstalter, wenn Änderungen nötig sind."
 
 #: pretalx/cfp/phrases.py:34
 msgid "Speaker email"


### PR DESCRIPTION
This PR closes issue #2131.
Access codes are now checked if needed for a track or submission type when a proposal draft shall be edited.

## How has this been tested?
Has been manually tested also for submission types.
Automated tests are included for track access codes.

## Checklist

- [X] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [X] My change is listed in the ``doc/changelog.rst``.
