### PR TITLE
Order teams by team name instead of ID.

### DIFF
--- a/src/pretalx/orga/views/organiser.py
+++ b/src/pretalx/orga/views/organiser.py
@@ -43,7 +43,7 @@ class TeamView(OrgaCRUDView):
     permission_required = "event.update_team"
 
     def get_queryset(self):
-        return self.request.organiser.teams.all().order_by("-all_events", "-id")
+        return self.request.organiser.teams.all().order_by("-all_events", "name")
 
     def get_permission_required(self):
         return self.permission_required


### PR DESCRIPTION
This is only a cosmetic change and minor enough that I only tested it manually.

I’d prefer sorting Teams by name (while keeping Teams with permissions for all Events at the top) instead of by ID.
This way, users can control the order of their Teams by choosing appropriate names, without the overhead of using an OrderedModel — which I find unnecessary.