### PR TITLE
preserve GET parameters in login url

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@
 Release Notes
 =============
 
+- :bug:`common` Login button doesn't preserve GET parameters.
 - :bug:`orga:submission,2147` The room, start and end times of submissions can now be edited.
 - :feature:`dev` Plugins can now inject additional form elements in the organisers area with the ``form_signal`` similar to ``html_signal``.
 - :feature:`cfp` Uploaded resources can now be marked as private (available only to organisers).

--- a/src/pretalx/common/templates/common/base.html
+++ b/src/pretalx/common/templates/common/base.html
@@ -140,7 +140,11 @@
                             </details>
                         {% elif not is_html_export %}
                             {% if request.event %}
-                                <a href="{{ request.event.urls.login }}?next={{ request.path|urlencode }}">login</a>
+                                {% if submit_qs  %}
+                                    <a href="{{ request.event.urls.login }}{{ submit_qs }}&next={{ request.path|urlencode }}">login</a>
+                                {% else %}
+                                    <a href="{{ request.event.urls.login }}?next={{ request.path|urlencode }}">login</a>
+                                {% endif %}
                             {% else %}
                                 <a href="{% url "orga:login" %}">login</a>
                             {% endif %}


### PR DESCRIPTION
The login URL does not preserve GET parameters. As a result, URLs containing the access_code parameter do not work when the user clicks 'login'.

## How has this been tested?
Tested manually

## Checklist

- [~] I have added tests to cover my changes.
- [~] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
