### PR TITLE
Make daily submission stats clearer

### DIFF
--- a/src/pretalx/orga/templates/orga/submission/stats.html
+++ b/src/pretalx/orga/templates/orga/submission/stats.html
@@ -32,7 +32,7 @@
             <div class="card stats-timeline">
                 <div class="card-header submissions">{% translate "Proposals by submission date" %}</div>
                 <div class="card-header talks d-none">{% translate "Sessions by submission date" %}</div>
-                <div id="submission-timeline-data" class="d-none" data-timeline="{{ submission_timeline_data }}" data-label="{% translate "Proposals" %}"></div>
+                <div id="submission-timeline-data" class="d-none" data-timeline="{{ submission_timeline_data }}" data-label="{% translate "Daily proposals" %}"></div>
                 <div id="talk-timeline-data" class="d-none" data-timeline="{{ talk_timeline_data }}" data-label="{{ phrases.schedule.sessions }}"></div>
                 <div id="total-submission-timeline-data" class="d-none" data-timeline="{{ total_submission_timeline_data }}" data-label="{% translate "Total proposals" %}"></div>
                 <div id="timeline" class="card-body submissions"></div>


### PR DESCRIPTION
I remember being a bit unsure what the "proposals" line meant on this page, it would have been useful to explicitly label it as daily submitted proposals.