### PR TITLE
Also allow changes to the page size limitation for paginated lists.

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,7 +7,7 @@ Release Notes
 =============
 
 - :developer:`dev,1964` If your plugin provides an exporter, you can likely simplify it. If you split up the ``identifier`` into a ``filename_identifier`` and an ``extension`` property, you can then use the ``filename`` property to get a standardised filename including the event name, your exporter's name, and a timestamp, just like all pretalx exporters now do. You can also delegate that part to pretalx by implementing the new ``get_data`` method instead of ``render`` if you set a ``content_type`` attribute on your exporter class.
-- :feature:`administrator,2155` Administrators of self-hosted instances can now change the maximum page size of API responses.
+- :feature:`administrator,2155` Administrators of self-hosted instances can now change the maximum page size of API responses and paginated lists.
 - :announcement:`dev` In an effort to make our pages smaller and faster, we reworked our static files. They are now broken up into smaller chunks, and are placed in different locations. If you use any upstream static files explicitly, please check if they are impacted. Please also do a quick visual inspection of your plugin pages to make sure that you were not relying on styles or scripts that used to be included in all pages and are now only included on the relevant pages. You can a detailed list of changes in our `2025.2.0 release notes <https://gist.github.com/rixx/0dc12119daf467d93b7bc822f63f90e3>`_.
 - :bug:`orga:submission,2147` The room, start and end times of submissions can now be edited.
 - :feature:`dev` Plugins can now inject additional form elements in the organisers area with the ``form_signal`` similar to ``html_signal``.

--- a/src/pretalx/common/settings/config.py
+++ b/src/pretalx/common/settings/config.py
@@ -153,6 +153,12 @@ CONFIG = {
             "env": os.getenv("PRETALX_FILE_UPLOAD_LIMIT"),
         }
     },
+    "ui": {
+        "max_pagination_limit": {
+            "default": 250,
+            "env": os.getenv("PRETALX_MAX_PAGINATION_LIMIT"),
+        }
+    },
     "api": {
         "max_pagination_limit": {
             "default": 50,

--- a/src/pretalx/common/views/generic.py
+++ b/src/pretalx/common/views/generic.py
@@ -8,6 +8,7 @@ import datetime as dt
 from contextlib import suppress
 from urllib.parse import quote
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login
 from django.core.paginator import InvalidPage, Paginator
@@ -575,8 +576,12 @@ class OrgaTableMixin(SingleTableMixin):
         )
         if self.request.GET.get("page_size"):
             try:
-                max_page_size = getattr(self, "max_page_size", 250)
-                size = min(max_page_size, int(self.request.GET.get("page_size")))
+                if max_page_size := getattr(
+                    self, "max_page_size", settings.MAX_PAGINATION_LIMIT
+                ):
+                    size = min(max_page_size, int(self.request.GET.get("page_size")))
+                else:
+                    size = int(self.request.GET.get("page_size"))
                 self.request.session[skey] = size
                 return size
             except ValueError:

--- a/src/pretalx/common/views/mixins.py
+++ b/src/pretalx/common/views/mixins.py
@@ -275,8 +275,12 @@ class PaginationMixin:
         )
         if self.request.GET.get("page_size"):
             try:
-                max_page_size = getattr(self, "max_page_size", 250)
-                size = min(max_page_size, int(self.request.GET.get("page_size")))
+                if max_page_size := getattr(
+                    self, "max_page_size", settings.MAX_PAGINATION_LIMIT
+                ):
+                    size = min(max_page_size, int(self.request.GET.get("page_size")))
+                else:
+                    size = int(self.request.GET.get("page_size"))
                 self.request.session[skey] = size
                 return size
             except ValueError:

--- a/src/pretalx/settings.py
+++ b/src/pretalx/settings.py
@@ -631,6 +631,11 @@ if DEBUG:
 
 DJANGO_TABLES2_TEMPLATE = "orga/generic/table.html"
 
+## UI SETTINGS
+MAX_PAGINATION_LIMIT = int(config.get("ui", "max_pagination_limit"))
+if MAX_PAGINATION_LIMIT == -1:
+    MAX_PAGINATION_LIMIT = None
+
 ## API SETTINGS
 API_MAX_PAGINATION_LIMIT = int(config.get("api", "max_pagination_limit"))
 if API_MAX_PAGINATION_LIMIT == -1:


### PR DESCRIPTION
This PR adds to issue #2155.

I'd like to propose to also allow overriding the limit for paginated lists.
The performance impact should be in the same ballpark as for the API pagination - I am unsure if a separate setting is needed or the same limit should simply be appied to API and lists.
I didn't know in which section of the config the option would fit best...

## How has this been tested?
Manually. With a _huge_ DemoCon...

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [x] My change is listed in the ``doc/changelog.rst``.
