### PR TITLE
don't html-minimize event settings form

### DIFF
--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -24,6 +24,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext_lazy
 from django.views.generic import FormView, ListView, TemplateView, UpdateView, View
 from django_context_decorator import context
+from django_minify_html.decorators import no_html_minification
 from django_scopes import scope, scopes_disabled
 from formtools.wizard.views import SessionWizardView
 
@@ -73,6 +74,7 @@ class EventSettingsPermission(EventPermissionRequired):
         return self.request.event
 
 
+@method_decorator(no_html_minification, name="dispatch")
 class EventDetail(EventSettingsPermission, ActionFromUrl, UpdateView):
     model = Event
     form_class = EventForm


### PR DESCRIPTION
mimimizing the form strips the value="" part of the radio button for the plain header pattern

This PR closes issue #2167. It does so by disabling the HTML minimizer for the EventDetails view which was broken, because the empty `value=""` part of the radio button for the plain header pattern was inadvertently stripped.

## How has this been tested?
Tested manually in a dev. environment.

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
