### PR TITLE
Restore margin beween languages after minimizing HTML

### DIFF
--- a/src/pretalx/static/common/css/public.css
+++ b/src/pretalx/static/common/css/public.css
@@ -83,6 +83,10 @@ header {
       color: white;
     }
 
+    a + a {
+      margin-left: 0.3em;
+    }
+    
     .locales a:hover {
       border-bottom: 1px dashed white;
       text-decoration: none;


### PR DESCRIPTION
Due to the HTML mimimization, the whitespace between the languages in the top right selection row was lost.

<img width="546" height="105" alt="grafik" src="https://github.com/user-attachments/assets/b822deaf-977d-4ae6-9818-5b814e53a956" />

This change restores the whitespace:

<img width="560" height="106" alt="grafik" src="https://github.com/user-attachments/assets/b9cb0c15-b121-478d-973f-125550b33a1f" />

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
