### PR TITLE
DRAFT Feedback rating display and basic API access

### DIFF
--- a/src/pretalx/agenda/templates/agenda/feedback.html
+++ b/src/pretalx/agenda/templates/agenda/feedback.html
@@ -34,6 +34,9 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
                 {% endif %}
                 <i class="fa fa-quote-left quote" aria-hidden="true"></i>
                 <div class="feedback-text">
+                    <span class="text-muted float-right">
+                        {{ opinion.created|date:"SHORT_DATETIME_FORMAT" }}
+                    </span>
                     {{ opinion.rating|stars }}
                     {{ opinion.review|rich_text }}
                 </div>

--- a/src/pretalx/agenda/templates/agenda/feedback.html
+++ b/src/pretalx/agenda/templates/agenda/feedback.html
@@ -7,10 +7,12 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
 
 {% load i18n %}
 {% load rich_text %}
+{% load stars %}
 {% load static %}
 
 {% block agenda_stylesheets %}
     <link rel="stylesheet" href="{% static "agenda/css/feedback.css" %}" />
+    <link rel="stylesheet" href="{% static "common/css/forms/stars.css" %}" />
 {% endblock agenda_stylesheets %}
 
 {% block content %}
@@ -31,7 +33,10 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
                     </div>
                 {% endif %}
                 <i class="fa fa-quote-left quote" aria-hidden="true"></i>
-                <div class="feedback-text">{{ opinion.review|rich_text }}</div>
+                <div class="feedback-text">
+                    {{ opinion.rating|stars }}
+                    {{ opinion.review|rich_text }}
+                </div>
                 <i class="fa fa-quote-right quote float-right" aria-hidden="true"></i>
             </div>
         {% empty %}

--- a/src/pretalx/common/forms/widgets.py
+++ b/src/pretalx/common/forms/widgets.py
@@ -164,6 +164,23 @@ class MarkdownWidget(forms.Textarea):
         }
 
 
+class StarsWidget(forms.Textarea):
+    template_name = "common/widgets/stars.html"
+
+    def __init__(self, attrs=None, max=5):
+        self.max = max
+        super().__init__(attrs)
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context["widget"]["stars"] = range(1, self.max)
+        return context
+
+    class Media:
+        js = [forms.Script("common/js/forms/stars.js", defer="")]
+        css = {"all": ["common/css/forms/stars.css"]}
+
+
 class EnhancedSelectMixin(forms.Select):
     # - add the "class: enhanced" attribute to the select widget
     # - if `description_field` is set, set data-description on options

--- a/src/pretalx/common/templates/common/widgets/stars.html
+++ b/src/pretalx/common/templates/common/widgets/stars.html
@@ -1,0 +1,13 @@
+<!--
+SPDX-FileCopyrightText: 2025-present Florian Moesch
+SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
+-->
+
+{% load i18n %}
+
+<div class="star-rating">
+  {% for star in widget.stars %}
+    <button type="button" class="star" data-value="{{ star }}"><i class="fa fa-star fa-lg"></i></button>
+  {% endfor %}
+  <input type="hidden" id="id_{{ widget.name }}" name="{{ widget.name }}">
+</div>

--- a/src/pretalx/common/templatetags/stars.py
+++ b/src/pretalx/common/templatetags/stars.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025-present Florian Moesch
+# SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.filter
+def stars(stars: int, max_stars: int = 5):
+    result = '<span class="star-rating">'
+    if stars is None:
+        return ""
+    for i in range(max_stars):
+        if i < stars:
+            result += '<span class="star color-active"><i class="fa fa-star fa-lg"></i></span>'
+        else:
+            result += '<span class="star"><i class="fa fa-star-o fa-lg"></i></span>'
+    result += "</span>"
+    return mark_safe(result)

--- a/src/pretalx/orga/templates/orga/submission/feedback_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedback_list.html
@@ -7,13 +7,23 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
 
 {% load i18n %}
 {% load rich_text %}
+{% load stars %}
+{% load static %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{% static "orga/css/ui/submission.css" %}" />
+    <link rel="stylesheet" href="{% static "common/css/forms/stars.css" %}" />
+{% endblock stylesheets %}
 
 {% block submission_title %}{% translate "Attendee feedback" %} :: {% endblock submission_title %}
 
 {% block submission_content %}
     {% for entry in feedback %}
         <div class="card mb-2">
-            <div class="card-body pb-0">{{ entry.review|rich_text }}</div>
+            <div class="card-body pb-0">
+                {{ entry.rating|stars }}
+                {{ entry.review|rich_text }}
+            </div>
         </div>
     {% empty %}
         {{ phrases.schedule.no_feedback }}

--- a/src/pretalx/orga/templates/orga/submission/feedback_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedback_list.html
@@ -21,6 +21,9 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
     {% for entry in feedback %}
         <div class="card mb-2">
             <div class="card-body pb-0">
+                <span class="text-muted float-right">
+                    {{ entry.created|date:"SHORT_DATETIME_FORMAT" }}
+                </span>
                 {{ entry.rating|stars }}
                 {{ entry.review|rich_text }}
             </div>

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -35,6 +35,9 @@ SPDX-FileContributor: michalpirchala
             {% if can_see_feedback %}
                 <div class="card mb-2">
                     <div class="card-body pb-0">
+                        <span class="text-muted float-right">
+                            {{ entry.created|date:"SHORT_DATETIME_FORMAT" }}
+                        </span>
                         {{ entry.rating|stars }}
                         {{ entry.review|rich_text }}
                     </div>

--- a/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
+++ b/src/pretalx/orga/templates/orga/submission/feedbacks_list.html
@@ -11,6 +11,12 @@ SPDX-FileContributor: michalpirchala
 {% load i18n %}
 {% load rich_text %}
 {% load rules %}
+{% load stars %}
+{% load static %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{% static "common/css/forms/stars.css" %}" />
+{% endblock stylesheets %}
 
 {% block extra_title %}{% translate "Attendee feedback" %} :: {% endblock extra_title %}
 
@@ -28,7 +34,10 @@ SPDX-FileContributor: michalpirchala
             {% has_perm "submission.view_feedback_submission" request.user entry.talk as can_see_feedback %}
             {% if can_see_feedback %}
                 <div class="card mb-2">
-                    <div class="card-body pb-0">{{ entry.review|rich_text }}</div>
+                    <div class="card-body pb-0">
+                        {{ entry.rating|stars }}
+                        {{ entry.review|rich_text }}
+                    </div>
                 </div>
             {% endif %}
         {% endfor %}

--- a/src/pretalx/static/common/css/forms/stars.css
+++ b/src/pretalx/static/common/css/forms/stars.css
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: 2025-present Florian Moesch
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+ .star-rating .star {
+  padding: 0.1rem;
+  color: var(--color-grey-light);
+  transition: color 0.3s ease;
+}
+
+.star-rating .star.color-active {
+  color:  var(--color-warning);
+}
+

--- a/src/pretalx/static/common/js/forms/stars.js
+++ b/src/pretalx/static/common/js/forms/stars.js
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025-present Florian Moesch
+// SPDX-License-Identifier: Apache-2.0
+
+function initStarRating(root) {
+    const stars = Array.from(root.querySelectorAll(".star"));
+    const hiddenInput = root.querySelector("input[type=hidden]");
+    let currentValue = Number(hiddenInput.value || 0);
+    
+    function render(value) {
+        stars.forEach((star) => {
+            const starValue = Number(star.dataset.value);
+            star.classList.toggle("color-active", starValue <= value);
+        });
+    }
+    
+    render(currentValue);
+    
+    stars.forEach((star) => {
+        star.addEventListener("mouseenter", () => {
+            render(Number(star.dataset.value));
+        });
+        star.addEventListener("mouseleave", () => {
+            render(currentValue);
+        });
+        star.addEventListener("click", () => {
+            currentValue = Number(star.dataset.value);
+            hiddenInput.value = String(currentValue);
+            render(currentValue);
+        });
+    });
+    
+    function syncAria() {
+        root.setAttribute("aria-valuenow", String(currentValue));
+    }
+    root.addEventListener("click", syncAria);
+    root.addEventListener("keydown", syncAria);
+}
+
+// onReady(() =>
+document.addEventListener("DOMContentLoaded", () => {
+    document
+    .querySelectorAll(".star-rating")
+    .forEach((element) => initStarRating(element))
+})

--- a/src/pretalx/submission/forms/feedback.py
+++ b/src/pretalx/submission/forms/feedback.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from pretalx.common.forms.fields import HoneypotField
 from pretalx.common.forms.renderers import InlineFormRenderer
+from pretalx.common.forms.widgets import StarsWidget
 from pretalx.submission.models import Feedback
 
 
@@ -21,6 +22,7 @@ class FeedbackForm(forms.ModelForm):
         self.fields["speaker"].empty_label = _("All speakers")
         if len(speakers) == 1:
             self.fields["speaker"].widget = forms.HiddenInput()
+        self.fields["rating"].widget = StarsWidget()
 
     def save(self, *args, **kwargs):
         if (
@@ -32,4 +34,4 @@ class FeedbackForm(forms.ModelForm):
 
     class Meta:
         model = Feedback
-        fields = ["speaker", "review"]
+        fields = ["speaker", "rating", "review"]


### PR DESCRIPTION
This is a proposal for a display of feedback ratings (as 1-5 stars, similar to Frab) in addition to textual feedback.
~This also shows an approach to offer a dedicated API endpoint for feedback which would allow creation of feedback without any access to other API endpoints.~
API access has been added in 207a3f5093e32fb05c206860265c813d318734fa.

## How has this been tested?

> [!NOTE]
> This has currently only been tested manually in a dev. environment.

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
