### PR TITLE
Add editable API tokens

### DIFF
--- a/src/pretalx/common/log_display.py
+++ b/src/pretalx/common/log_display.py
@@ -140,8 +140,10 @@ LOG_NAMES = {
     "pretalx.speaker_information.create": _("A speaker information note was added."),
     "pretalx.speaker_information.update": _("A speaker information note was modified."),
     "pretalx.speaker_information.delete": _("A speaker information note was deleted."),
+    "pretalx.user.token.create": _("An API token was created."),
     "pretalx.user.token.reset": _("The API token was reset."),
     "pretalx.user.token.revoke": _("The API token was revoked."),
+    "pretalx.user.token.update": _("The API token was modified."),
     "pretalx.user.token.upgrade": _(
         "The API token was upgraded to the latest version."
     ),

--- a/src/pretalx/orga/templates/orga/token_edit.html
+++ b/src/pretalx/orga/templates/orga/token_edit.html
@@ -1,0 +1,64 @@
+<!--
+SPDX-FileCopyrightText: 2025-present Tobias Kunze
+SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
+-->
+
+{% extends "orga/base.html" %}
+
+{% load i18n %}
+{% load static %}
+
+{% block extra_title %}{% translate "Edit API Token" %} :: {% endblock extra_title %}
+
+{% block content %}
+<fieldset class="m-2">
+    <legend>{% translate "Edit API Token" %}: {{ token.name }}</legend>
+
+    <div id="edit-token">
+        <form method="post">
+            {% csrf_token %}
+
+            {{ edit_form.name.as_field_group }}
+            {{ edit_form.events.as_field_group }}
+            {{ edit_form.expires.as_field_group }}
+            {{ edit_form.permission_preset.as_field_group }}
+
+            <div class="form-group row" id="permission-endpoints">
+                <div class="col-md-3"></div>
+                <div class="col-md-9 table-responsive">
+                    <table class="table table-condensed table-flip no-hover" id="endpoint-permissions-table">
+                        <thead>
+                            <tr>
+                                <th></th>
+                                {% for option in edit_form.fields.endpoint_events.choices %}
+                                    <th class="text-center">
+                                        {{ option.1 }}<br>
+                                        <input type="checkbox" class="permission-col-all" data-permission="{{ option.0 }}">
+                                    </th>
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for name, field in edit_form.get_endpoint_fields %}
+                                <tr data-endpoint="{{ name }}">
+                                    <th class="d-flex align-items-center justify-content-end">
+                                        {{ field.label }}
+                                        <input type="checkbox" class="permission-row-all" data-endpoint="{{ name }}">
+                                    </th>
+                                    {% for option in field.field.choices %}
+                                        <td class="text-center">
+                                            <input type="checkbox" name="{{ field.name }}" value="{{ option.0 }}" id="id_{{ field.name }}_{{ option.0 }}" data-permission="{{ option.0 }}" {% if option.0 in field.value %}checked{% endif %}>
+                                        </td>
+                                    {% endfor %}
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            {% include "orga/includes/submit_row.html" with submit_buttons=submit_buttons submit_buttons_extra=submit_buttons_extra %}
+        </form>
+    </div>
+</fieldset>
+{% endblock content %}

--- a/src/pretalx/orga/templates/orga/user.html
+++ b/src/pretalx/orga/templates/orga/user.html
@@ -63,8 +63,8 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
                                             </form>
                                         {% endif %}
                                     </td>
-                                    <td>
-                                        <ul>
+                                    <td class="align-top">
+                                        <ul class="mb-0">
                                             {% for event in token.events.all %}
                                                 <li><a href="{{ event.orga_urls.base }}">{{ event.name }}</a></li>
                                             {% endfor %}
@@ -93,6 +93,9 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
                                     <td>{{ token.expires|date:"SHORT_DATETIME_FORMAT"|default:"-" }}</td>
                                     <td>
                                         {% if token.is_active %}
+                                            <a href="{% url 'orga:user.token.edit' pk=token.pk %}" class="btn btn-outline-primary btn-sm">
+                                                {% translate "Edit" %}
+                                            </a>
                                             <form method="post" class="d-inline">
                                                 {% csrf_token %}
                                                 <button type="submit" name="revoke" value="{{ token.id }}" class="btn btn-danger btn-sm">

--- a/src/pretalx/orga/urls.py
+++ b/src/pretalx/orga/urls.py
@@ -39,6 +39,7 @@ urlpatterns = [
         actions=("list", "detail", "delete"),
     ),
     path("me", person.UserSettings.as_view(), name="user.view"),
+    path("me/token/<int:pk>/edit/", person.TokenEditView.as_view(), name="user.token.edit"),
     path("me/subuser", person.SubuserView.as_view(), name="user.subuser"),
     path(
         "invitation/<code>",

--- a/src/pretalx/person/forms/auth_token.py
+++ b/src/pretalx/person/forms/auth_token.py
@@ -3,6 +3,7 @@
 
 from django import forms
 from django.utils.safestring import mark_safe
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
 from pretalx.common.forms.widgets import EnhancedSelect, EnhancedSelectMultiple
@@ -39,17 +40,27 @@ class AuthTokenForm(forms.ModelForm):
         )
 
         self.endpoint_fields = {}
+        is_editing = self.instance and self.instance.pk
         for endpoint in ENDPOINTS:
+            # When editing, use existing permissions; otherwise default to read
+            if is_editing:
+                initial_permissions = self.instance.endpoints.get(endpoint, [])
+            else:
+                initial_permissions = READ_PERMISSIONS
             self.fields[f"endpoint_{endpoint}"] = forms.MultipleChoiceField(
                 label=f"/{endpoint}",
                 required=False,
                 choices=PERMISSION_CHOICES,
                 widget=forms.CheckboxSelectMultiple,
-                initial=READ_PERMISSIONS,
+                initial=initial_permissions,
             )
             self.endpoint_fields[f"endpoint_{endpoint}"] = self.fields[
                 f"endpoint_{endpoint}"
             ]
+
+        # Set permission preset based on existing token when editing
+        if is_editing:
+            self.fields["permission_preset"].initial = self.instance.permission_preset
 
     def get_endpoint_fields(self):
         """Used in templates, so has to return the actual fields."""
@@ -71,6 +82,25 @@ class AuthTokenForm(forms.ModelForm):
         widgets = {
             "events": EnhancedSelectMultiple,
         }
+
+    def clean_events(self):
+        events = self.cleaned_data.get("events")
+        if not events:
+            raise forms.ValidationError(
+                _("Please select at least one event for this API token.")
+            )
+        return events
+
+    def clean_expires(self):
+        expires = self.cleaned_data.get("expires")
+        if expires:
+            # Allow today but not past dates
+            today_start = now().replace(hour=0, minute=0, second=0, microsecond=0)
+            if expires < today_start:
+                raise forms.ValidationError(
+                    _("The expiration date cannot be in the past.")
+                )
+        return expires
 
     def clean(self):
         data = super().clean()

--- a/src/pretalx/static/common/css/forms/select.css
+++ b/src/pretalx/static/common/css/forms/select.css
@@ -156,6 +156,15 @@
   align-self: flex-start;
 }
 
+/* Validation error state for enhanced selects */
+.choices.is-invalid .choices__inner {
+  border-color: var(--color-danger);
+}
+
+.choices.is-invalid .choices__inner:has(input:focus) {
+  box-shadow: 0 0 0 0.2rem rgba(var(--color-danger-rgb), 0.25);
+}
+
 .select-all-events[role=button] {
   &:hover,
   &:focus {

--- a/src/pretalx/static/common/js/forms/token.js
+++ b/src/pretalx/static/common/js/forms/token.js
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const handleTokenTable = () => {
-    const table = document.querySelector('#create-token #permission-endpoints')
+    const table = document.querySelector('#permission-endpoints')
     const presetField = document.querySelector('#id_permission_preset')
-    table.style.display = (presetField.value === 'custom') ? 'flex' : 'none'
+    if (table && presetField) {
+        table.style.display = (presetField.value === 'custom') ? 'flex' : 'none'
+    }
 }
 
 const updateRowAllCheckbox = (endpoint) => {

--- a/src/tests/orga/views/test_orga_views_person.py
+++ b/src/tests/orga/views/test_orga_views_person.py
@@ -101,3 +101,197 @@ def test_orga_update_profile_info(orga_client, orga_user):
     assert "have been saved" in response.text
     orga_user.refresh_from_db()
     assert orga_user.name == "New name"
+
+
+@pytest.mark.django_db
+def test_token_edit_view_accessible(orga_client, orga_user_token):
+    """Test that the edit view is accessible for active tokens."""
+    response = orga_client.get(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk})
+    )
+    assert response.status_code == 200
+    assert orga_user_token.name in response.text
+
+
+@pytest.mark.django_db
+def test_token_edit_update_name(orga_client, orga_user_token):
+    """Test updating the token name."""
+    response = orga_client.post(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        {
+            "name": "Updated Token Name",
+            "events": [e.pk for e in orga_user_token.events.all()],
+            "permission_preset": "read",
+        },
+        follow=True,
+    )
+    assert response.status_code == 200
+    assert "has been updated" in response.text
+    orga_user_token.refresh_from_db()
+    assert orga_user_token.name == "Updated Token Name"
+
+
+@pytest.mark.django_db
+def test_token_edit_update_events(orga_client, orga_user_token, event, other_event):
+    """Test updating token events."""
+    # First verify current state
+    current_events = list(orga_user_token.events.all())
+    assert len(current_events) > 0
+
+    # Update to just one event
+    response = orga_client.post(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        {
+            "name": orga_user_token.name,
+            "events": [event.pk],
+            "permission_preset": "read",
+        },
+        follow=True,
+    )
+    assert response.status_code == 200
+    orga_user_token.refresh_from_db()
+    assert list(orga_user_token.events.all()) == [event]
+
+
+@pytest.mark.django_db
+def test_token_edit_cannot_edit_expired(orga_client, orga_user_token):
+    """Test that expired tokens cannot be edited."""
+    from django.utils.timezone import now, timedelta
+
+    orga_user_token.expires = now() - timedelta(days=1)
+    orga_user_token.save()
+
+    response = orga_client.get(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        follow=True,
+    )
+    assert response.status_code == 200
+    # Should redirect to user settings with error
+    assert "not found or already expired" in response.text
+
+
+@pytest.mark.django_db
+def test_token_edit_cannot_edit_other_user_token(orga_client, other_orga_user):
+    """Test that users cannot edit tokens belonging to other users."""
+    from pretalx.person.models.auth_token import UserApiToken
+
+    other_token = UserApiToken.objects.create(name="other", user=other_orga_user)
+
+    response = orga_client.get(
+        reverse("orga:user.token.edit", kwargs={"pk": other_token.pk}),
+        follow=True,
+    )
+    assert response.status_code == 200
+    # Should redirect to user settings with error
+    assert "not found or already expired" in response.text
+
+
+@pytest.mark.django_db
+def test_token_value_unchanged_after_edit(orga_client, orga_user_token):
+    """Test that the token value is not changed when editing."""
+    original_token = orga_user_token.token
+
+    response = orga_client.post(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        {
+            "name": "Changed Name",
+            "events": [e.pk for e in orga_user_token.events.all()],
+            "permission_preset": "write",
+        },
+        follow=True,
+    )
+    assert response.status_code == 200
+    orga_user_token.refresh_from_db()
+    assert orga_user_token.token == original_token
+
+
+@pytest.mark.django_db
+def test_token_edit_permission_preset_change(orga_client, orga_user_token):
+    """Test changing permission preset from read to write."""
+    from pretalx.person.models.auth_token import UserApiToken, WRITE_PERMISSIONS
+
+    # Verify starting with read
+    assert orga_user_token.permission_preset == "read"
+
+    response = orga_client.post(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        {
+            "name": orga_user_token.name,
+            "events": [e.pk for e in orga_user_token.events.all()],
+            "permission_preset": "write",
+        },
+        follow=True,
+    )
+    assert response.status_code == 200
+    assert "has been updated" in response.text
+
+    # Get a fresh instance to avoid cached_property issues
+    updated_token = UserApiToken.objects.get(pk=orga_user_token.pk)
+    assert updated_token.permission_preset == "write"
+    # Verify all endpoints have write permissions
+    for endpoint, perms in updated_token.endpoints.items():
+        assert set(perms) == set(WRITE_PERMISSIONS)
+
+
+@pytest.mark.django_db
+def test_token_edit_requires_events(orga_client, orga_user_token):
+    """Test that editing a token without events shows an error."""
+    response = orga_client.post(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        {
+            "name": orga_user_token.name,
+            "events": [],
+            "permission_preset": "read",
+        },
+    )
+    assert response.status_code == 200
+    # Form should not save and should show the edit page again
+    assert "Edit API Token" in response.text
+    # Check for error message (may be in invalid-feedback div)
+    assert "at least one event" in response.text.lower() or "invalid-feedback" in response.text
+
+
+@pytest.mark.django_db
+def test_token_edit_rejects_past_expiration(orga_client, orga_user_token):
+    """Test that editing a token with a past expiration date shows an error."""
+    from django.utils.timezone import now, timedelta
+
+    past_date = (now() - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
+
+    response = orga_client.post(
+        reverse("orga:user.token.edit", kwargs={"pk": orga_user_token.pk}),
+        {
+            "name": orga_user_token.name,
+            "events": [e.pk for e in orga_user_token.events.all()],
+            "permission_preset": "read",
+            "expires": past_date,
+        },
+    )
+    assert response.status_code == 200
+    # Form should not save and should show the edit page again
+    assert "Edit API Token" in response.text
+    # Check for error message
+    assert "past" in response.text.lower() or "invalid-feedback" in response.text
+
+
+@pytest.mark.django_db
+def test_token_create_requires_events(orga_client):
+    """Test that creating a token without events shows an error."""
+    from pretalx.person.models.auth_token import UserApiToken
+
+    initial_count = UserApiToken.objects.count()
+
+    response = orga_client.post(
+        reverse("orga:user.view"),
+        {
+            "form": "token",
+            "name": "Test Token",
+            "events": [],
+            "permission_preset": "read",
+        },
+    )
+    assert response.status_code == 200
+    # Token should not be created
+    assert UserApiToken.objects.count() == initial_count
+    # Should show user settings page with form
+    assert "Create new token" in response.text


### PR DESCRIPTION
## Summary
- Allow editing existing API tokens (name, events, expiration, permissions)
- Token value remains unchanged during edits
- Fix validation display for required enhanced select fields

## Test plan
- [x] Create a new token and verify it works
- [x] Edit an existing token's name, events, and permissions
- [x] Verify token value doesn't change after editing
- [x] Test validation error displays when saving without events
- [x] Verify expired tokens cannot be edited
- [x] Verify other users' tokens cannot be edited
- [x] All existing tests pass