### PR TITLE
Frab exports shall contain public attachments and links

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.xml
+++ b/src/pretalx/agenda/templates/agenda/schedule.xml
@@ -41,10 +41,10 @@
                     <license>{{ talk.submission.license|xmlescape }}</license>
                     <optout>{{ talk.submission.do_not_record|yesno:"true,false" }}</optout>
                 </recording>
-                <links>{% for resource in submission.resources.all %}{% if resource.link %}
+                <links>{% for resource in talk.submission.public_resources.all %}{% if resource.link %}
                     <link href="{{ resource.link }}">{{ resource.description }}</link>
                 {% endif %}{% endfor %}</links>
-                <attachments>{% for resource in submission.resources.all %}{% if resource.resource %}
+                <attachments>{% for resource in talksubmission.public_resources.all %}{% if resource.resource %}
                     <attachment href="{{ base_url }}{{ resource.resource.url }}">{{ resource.description }}</attachment>
                 {% endif %}{% endfor %}</attachments>
 

--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -254,7 +254,7 @@ class FrabJsonExporter(ScheduleData):
                                             "url": resource.link,
                                             "type": "related",
                                         }
-                                        for resource in talk.submission.resources.all()
+                                        for resource in talk.submission.public_resources.all()
                                         if resource.link
                                     ],
                                     "feedback_url": talk.submission.urls.feedback.full(),
@@ -265,7 +265,7 @@ class FrabJsonExporter(ScheduleData):
                                             "url": resource.resource.url,
                                             "type": "related",
                                         }
-                                        for resource in talk.submission.resources.all()
+                                        for resource in talk.submission.public_resources.all()
                                         if not resource.link
                                     ],
                                 }


### PR DESCRIPTION
This PR fixes two issues with the frab exports: the XML import contained no attachments or links, the JSON export contained public and non-public data.

## How has this been tested?
During 39c3.

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
