### PR TITLE
fix(cfp wizard): handle ValueError when invalid GET params are passed

### DIFF
--- a/src/pretalx/cfp/flow.py
+++ b/src/pretalx/cfp/flow.py
@@ -388,7 +388,7 @@ class InfoStep(DedraftMixin, FormFlowStep):
         for field, model in (("submission_type", SubmissionType), ("track", Track)):
             request_value = self.request.GET.get(field)
             if request_value:
-                with suppress(AttributeError, TypeError):
+                with suppress(AttributeError, ValueError, TypeError):
                     pk = int(request_value.split("-")[0])
                     obj = model.objects.filter(event=self.request.event, pk=pk).first()
                     if obj:

--- a/src/tests/cfp/views/test_cfp_wizard.py
+++ b/src/tests/cfp/views/test_cfp_wizard.py
@@ -211,15 +211,19 @@ class TestWizard:
     def test_info_wizard_query_string_handling(self, event, client, track):
         # build query string
         params_dict = QueryDict(f"track={track.pk}&submission_type=academic_talk")
-        current_url = "/test/submit/?{params_dict}"
+        params_encoded = params_dict.urlencode()
+        url = f"/test/submit/?{params_encoded}"
         # Start wizard
-        _, current_url = self.get_response_and_url(client, current_url, method="GET")
+        _, current_url = self.get_response_and_url(client, url, method="GET")
         # get query string from current URL
         url_parts = urlparse(current_url)
-        q = QueryDict(url_parts.query)
+        q_dict = QueryDict(url_parts.query)
         assert url_parts.path.endswith("/info/") is True
-        assert q.get("track") == params_dict.get("academic")
-        assert q.get("submission_type") == params_dict.get("academic_talk")
+        # check if GET params are preserved
+        assert q_dict.get("track") and q_dict.get("track") == params_dict.get("track")
+        assert q_dict.get("submission_type") and q_dict.get(
+            "submission_type"
+        ) == params_dict.get("submission_type")
 
     @pytest.mark.django_db
     def test_wizard_new_user(self, event, question, client):


### PR DESCRIPTION
This fix ensures graceful handling of AttributeError caused by invalid submission_type or track values in GET parameters.
```
Internal Server Error: /democonf/submit/paPgsd/info/
ValueError at /democonf/submit/paPgsd/info/
invalid literal for int() with base 10: 'anystring'

Request Method: GET
Request URL: http://localhost/democonf/submit/paPgsd/info/?submission_type=any_string
```

## How has this been tested?
I have fixed the test that suppose to catch the error. Test was incorrect and  did test empty values.

## Checklist

- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
