### PR TITLE
feat(api): include is_public field in resource serializer

### DIFF
--- a/src/pretalx/api/serializers/submission.py
+++ b/src/pretalx/api/serializers/submission.py
@@ -36,7 +36,7 @@ class ResourceSerializer(FlexFieldsSerializerMixin, PretalxSerializer):
 
     class Meta:
         model = Resource
-        fields = ("id", "resource", "description")
+        fields = ("id", "resource", "description", "is_public")
 
 
 @register_serializer(versions=CURRENT_VERSIONS)

--- a/src/tests/api/test_api_submissions.py
+++ b/src/tests/api/test_api_submissions.py
@@ -1456,6 +1456,10 @@ def test_orga_can_see_all_resources(
     resource_ids = {r["id"] for r in submission_data["resources"]}
     assert resource.id in resource_ids
     assert private_resource.id in resource_ids
+    # Verify is_public field is included in response
+    resources_by_id = {r["id"]: r for r in submission_data["resources"]}
+    assert resources_by_id[resource.id]["is_public"] is True
+    assert resources_by_id[private_resource.id]["is_public"] is False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Adds the `is_public` field to the ResourceSerializer, allowing API consumers to determine whether individual resources attached to submissions are public or private

Fixes #2249