### PR TITLE
Improve stable sort for Feedbacks list

### DIFF
--- a/src/pretalx/orga/views/submission.py
+++ b/src/pretalx/orga/views/submission.py
@@ -1112,7 +1112,7 @@ class AllFeedbacksList(EventPermissionRequired, PaginationMixin, ListView):
 
     def get_queryset(self):
         return (
-            Feedback.objects.order_by("-pk")
+            Feedback.objects.order_by("-talk_id", "-pk")
             .select_related("talk")
             .filter(talk__event=self.request.event)
         )


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
When regrouping Feedback objects by talk for paginated display on `orga/submission/feedbacks_list.html`, a single talk could appear on multiple pages. This would be highly surprising (except for first and last talk on a page).

<!--- If it fixes an open issue, please link to the issue here. -->

 This change makes it so that Feedback objects for the same talk stay together.

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
