### PR TITLE
Allow filtering the schedule before exporting

### DIFF
--- a/src/pretalx/schedule/exporters.py
+++ b/src/pretalx/schedule/exporters.py
@@ -19,11 +19,12 @@ from pretalx.schedule.ical import get_slots_ical
 
 
 class ScheduleData(BaseExporter):
-    def __init__(self, event, schedule=None, with_accepted=False, with_breaks=False):
+    def __init__(self, event, schedule=None, with_accepted=False, with_breaks=False, filter=None):
         super().__init__(event)
         self.schedule = schedule
         self.with_accepted = with_accepted
         self.with_breaks = with_breaks
+        self.filter = filter if filter else {}
 
     @cached_property
     def metadata(self):
@@ -44,7 +45,7 @@ class ScheduleData(BaseExporter):
         schedule = self.schedule
 
         base_qs = (
-            schedule.talks.all()
+            schedule.talks.filter(self.filter)
             if self.with_accepted
             else schedule.talks.filter(is_visible=True)
         )


### PR DESCRIPTION
This is a small proposal for adding a filter filed to the schedule exporter.

This allows plugins to reuse much of the logic,  but adding a custom filter, eg only a specific track, day or whatever other field they choose.

## How has this been tested?
I have not yet added a unit test, but I will do so if this seems useful.  Idem for documentation.

We have this change in our branch for FOSDEM (we have a field to hide tracks from the website)

## Checklist

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
