### PR TITLE
schedule.xml: add code as attribute to events

### DIFF
--- a/src/pretalx/agenda/templates/agenda/schedule.xml
+++ b/src/pretalx/agenda/templates/agenda/schedule.xml
@@ -20,7 +20,7 @@
     </conference>
     {% for day in data %}<day index='{{ day.index }}' date='{{ day.start.date|date:"c" }}' start='{{ day.start|date:"c" }}' end='{{ day.end|date:"c" }}'>
         {% for room in day.rooms %}<room name='{{ room.name|xmlescape }}' guid='{{ room.guid }}'>
-            {% for talk in room.talks %}<event guid='{{ talk.uuid }}' id='{{ talk.submission.id }}'>
+            {% for talk in room.talks %}<event guid='{{ talk.uuid }}' id='{{ talk.submission.id }}' code='{{ talk.submission.code }}'>
                 <room>{{ room.name|xmlescape }}</room>
                 <title>{{ talk.submission.title|xmlescape }}</title>
                 <subtitle></subtitle>


### PR DESCRIPTION
This adds the code attribute to schedule.xml as well, as stated here: https://github.com/voc/schedule/blob/master/validator/xsd/schedule.xml.xsd#L112 (implemented in https://github.com/voc/schedule/commit/805094bf5645058f567d005abe50612d8b4ab7ec).

Will get imported to VOC infrastructure here: https://github.com/crs-tools/tracker/pull/260 and then used on media.ccc.de instead of the numeric ids.