### PR TITLE
Add tab as CSV delimiter option

### DIFF
--- a/src/pretalx/orga/forms/export.py
+++ b/src/pretalx/orga/forms/export.py
@@ -35,6 +35,7 @@ class ExportForm(forms.Form):
         choices=(
             ("newline", _("Newline")),
             ("comma", _("Comma")),
+            ("tab", _("Tab")),
         ),
         widget=forms.RadioSelect,
     )
@@ -151,6 +152,7 @@ class ExportForm(forms.Form):
         delimiters = {
             "newline": "\n",
             "comma": ", ",
+            "tab": "\t",
         }
         delimiter = delimiters[self.cleaned_data.get("data_delimiter") or "newline"]
 


### PR DESCRIPTION
This PR adds 'tab' as a CSV delimiter option in the export settings.

## Changes
- Added ('tab', _('Tab')) to the data_delimiter choices in ExportForm
- Added 'tab': '\t' to the delimiters dictionary in csv_export method

## Why
Tab-separated values (TSV) format provides better compatibility with tools like Excel
and is a commonly requested export format for conference data.

Fixes #2265