### PR TITLE
Drop semi-supported SVGs

### DIFF
--- a/doc/api/schema.yml
+++ b/doc/api/schema.yml
@@ -4809,7 +4809,7 @@ paths:
     post:
       operationId: File upload
       description: 'Upload a file (image or PDF) for temporary storage. Allowed file
-        types: PNG, JPEG, GIF, SVG, PDF.'
+        types: PNG, JPEG, GIF, PDF.'
       tags:
       - file-uploads
       requestBody:

--- a/src/pretalx/api/views/upload.py
+++ b/src/pretalx/api/views/upload.py
@@ -34,14 +34,13 @@ class UploadView(APIView):
         "image/png": [".png"],
         "image/jpeg": [".jpg", ".jpeg"],
         "image/gif": [".gif"],
-        "image/svg+xml": [".svg"],
         "application/pdf": [".pdf"],
     }
 
     @extend_schema(
         operation_id="File upload",
         description="Upload a file (image or PDF) for temporary storage. "
-        "Allowed file types: PNG, JPEG, GIF, SVG, PDF.",
+        "Allowed file types: PNG, JPEG, GIF, PDF.",
         request={
             "multipart/form-data": {
                 "type": "object",

--- a/src/pretalx/common/forms/fields.py
+++ b/src/pretalx/common/forms/fields.py
@@ -32,7 +32,6 @@ IMAGE_EXTENSIONS = {
     ".jpg": ["image/jpeg", ".jpg"],
     ".jpeg": ["image/jpeg", ".jpeg"],
     ".gif": ["image/gif", ".gif"],
-    ".svg": ["image/svg+xml", ".svg"],
     ".webp": ["image/webp", ".webp"],
 }
 

--- a/src/pretalx/common/forms/mixins.py
+++ b/src/pretalx/common/forms/mixins.py
@@ -314,7 +314,6 @@ class QuestionFieldsMixin:
                     ".jpg": ["image/jpeg", ".jpg"],
                     ".gif": ["image/gif", ".gif"],
                     ".jpeg": ["image/jpeg", ".jpeg"],
-                    ".svg": ["image/svg+xml", ".svg"],
                     ".bmp": ["image/bmp", ".bmp"],
                     ".tif": ["image/tiff", ".tif"],
                     ".tiff": ["image/tiff", ".tiff"],


### PR DESCRIPTION
We in some places say that we support SVGs, but our image pipeline is only actually supporting rastered images.
