### PR TITLE
Fix card rendering crash when apostrophe falls at truncation boundary

### DIFF
--- a/src/pretalx/submission/cards.py
+++ b/src/pretalx/submission/cards.py
@@ -33,13 +33,17 @@ def _text(text, max_length=None):
     if not text:
         return ""
 
-    # add an almost-invisible space &hairsp; after hyphens as word-wrap in ReportLab only works on space chars
-    text = conditional_escape(text).replace("-", "-&hairsp;")
     # Reportlab does not support unicode combination characters
     text = unicodedata.normalize("NFC", text)
 
+    # Truncate before HTML-escaping to avoid splitting HTML entities (e.g.
+    # an apostrophe escaped as &#x27;) which would produce invalid XML for
+    # ReportLab's Paragraph parser.
     if max_length and len(text) > max_length:
-        return text[: max_length - 1] + "…"
+        text = text[: max_length - 1] + "…"
+
+    # add an almost-invisible space &hairsp; after hyphens as word-wrap in ReportLab only works on space chars
+    text = conditional_escape(text).replace("-", "-&hairsp;")
     return text
 
 


### PR DESCRIPTION
## Problem

The `_text()` helper in `submission/cards.py` was truncating text **after** HTML-escaping via `conditional_escape()`. Characters like apostrophes get escaped to `&#x27;` (5 chars), so when truncation at `max_length` cuts mid-entity, it produces invalid XML that crashes ReportLab's Paragraph parser.

This explains the bug in #1897 — an apostrophe at position ~128+ in the abstract gets escaped to a multi-char HTML entity, and the truncation to 140 chars splits it, leaving a dangling `&#x2` or similar fragment.

## Fix

Move truncation **before** HTML-escaping so the cut always happens on actual character boundaries. Also moved `unicodedata.normalize()` before truncation for consistency (normalize first, then truncate, then escape).

Fixes #1897