### PR TITLE
Fix apostrophe breaking card rendering (#1897)

### DIFF
--- a/src/pretalx/submission/cards.py
+++ b/src/pretalx/submission/cards.py
@@ -33,13 +33,17 @@ def _text(text, max_length=None):
     if not text:
         return ""
 
+    # Truncate the raw text before HTML-escaping so that we never split
+    # an HTML entity (e.g. &#x27; for an apostrophe) in the middle.
+    # See https://github.com/pretalx/pretalx/issues/1897
+    if max_length and len(text) > max_length:
+        text = text[: max_length - 1] + "…"
+
     # add an almost-invisible space &hairsp; after hyphens as word-wrap in ReportLab only works on space chars
     text = conditional_escape(text).replace("-", "-&hairsp;")
     # Reportlab does not support unicode combination characters
     text = unicodedata.normalize("NFC", text)
 
-    if max_length and len(text) > max_length:
-        return text[: max_length - 1] + "…"
     return text
 
 

--- a/src/tests/orga/views/test_orga_views_submission_cards.py
+++ b/src/tests/orga/views/test_orga_views_submission_cards.py
@@ -12,6 +12,9 @@ from pretalx.submission.cards import _text
     (
         ("12345", 3, "12…"),
         ("12345", 5, "12345"),
+        # Apostrophe at truncation boundary must not split HTML entities (#1897)
+        ("x" * 140 + "'", 140, "x" * 139 + "…"),
+        ("x" * 130 + "'rest", 140, "x" * 130 + "&#x27;rest"),
     ),
 )
 def test_ellipsize(text, length, expected):


### PR DESCRIPTION
## Summary

Fixes #1897 — An apostrophe in the wrong position breaks card (PDF) rendering.

## Root Cause

The `_text()` function in `src/pretalx/submission/cards.py` was:
1. First HTML-escaping the text via `conditional_escape()` (e.g. `'` → `&#x27;`, expanding 1 char to 6)
2. Then truncating to `max_length`

This meant truncation could cut an HTML entity in the middle (e.g. `&#x2` instead of `&#x27;`), producing invalid markup that crashes ReportLab PDF generation.

## Fix

Moved truncation **before** HTML-escaping so `max_length` applies to raw text length. HTML entities are never partially cut off.

## Tests

Added two parametrized test cases to `test_orga_views_submission_cards.py::test_ellipsize`:
- Apostrophe at exact truncation boundary (141 raw chars, max_length=140) → truncated before escaping
- Apostrophe well within limit (135 raw chars, max_length=140) → properly escaped, no truncation

Existing tests continue to pass. (Note: full test suite requires Python 3.12+ which was not available in my CI environment, but the card-specific tests were verified independently.)

## CLA

Signed CLA sent to support@pretalx.com.