### PR TITLE
feat: add tab as CSV data delimiter option

### DIFF
--- a/src/pretalx/orga/forms/export.py
+++ b/src/pretalx/orga/forms/export.py
@@ -29,7 +29,7 @@ class ExportForm(forms.Form):
         help_text=_(
             "How do you want to separate data within a single cell (for example, multiple speakers in one session/multiple sessions for one speaker)?"
         ),
-        choices=(("newline", _("Newline")), ("comma", _("Comma"))),
+        choices=(("newline", _("Newline")), ("comma", _("Comma")), ("tab", _("Tab"))),
         widget=forms.RadioSelect,
     )
 
@@ -142,7 +142,7 @@ class ExportForm(forms.Form):
         return self.json_export(data)
 
     def csv_export(self, data):
-        delimiters = {"newline": "\n", "comma": ", "}
+        delimiters = {"newline": "\n", "comma": ", ", "tab": "\t"}
         delimiter = delimiters[self.cleaned_data.get("data_delimiter") or "newline"]
 
         for row in data:


### PR DESCRIPTION
## Summary

Adds "Tab" as a third option for the CSV data delimiter, alongside "Newline" and "Comma".

## Why this matters

Per #2265, both newline and comma delimiters have drawbacks when data contains those characters. Tab is a common alternative that avoids issues with commas in text fields and newlines in multi-line content.

## Changes

- `src/pretalx/orga/forms/export.py:32`: Added `("tab", _("Tab"))` to the `data_delimiter` choices
- `src/pretalx/orga/forms/export.py:145`: Added `"tab": "\t"` to the `delimiters` dict in `csv_export()`

A previous attempt (PR #2292) was closed without merge. This PR takes the same minimal approach - two lines changed.

## Testing

The existing delimiter tests in `test_orga_views_speaker.py` and `test_orga_views_schedule.py` cover the delimiter selection flow. Tab follows the same code path as newline and comma.

Fixes #2265

This contribution was developed with AI assistance (Claude Code).