### PR TITLE
Add tab as data delimiter option in CSV export

### DIFF
--- a/src/pretalx/orga/forms/export.py
+++ b/src/pretalx/orga/forms/export.py
@@ -29,7 +29,7 @@ class ExportForm(forms.Form):
         help_text=_(
             "How do you want to separate data within a single cell (for example, multiple speakers in one session/multiple sessions for one speaker)?"
         ),
-        choices=(("newline", _("Newline")), ("comma", _("Comma"))),
+        choices=(("newline", _("Newline")), ("comma", _("Comma")), ("tab", _("Tab"))),
         widget=forms.RadioSelect,
     )
 
@@ -142,7 +142,7 @@ class ExportForm(forms.Form):
         return self.json_export(data)
 
     def csv_export(self, data):
-        delimiters = {"newline": "\n", "comma": ", "}
+        delimiters = {"newline": "\n", "comma": ", ", "tab": "\t"}
         delimiter = delimiters[self.cleaned_data.get("data_delimiter") or "newline"]
 
         for row in data:


### PR DESCRIPTION
Closes #2265

Adds "Tab" as a third choice for the within-cell data delimiter in CSV exports, alongside the existing "Newline" and "Comma" options.

Two changes in `src/pretalx/orga/forms/export.py`:
- Added `("tab", _("Tab"))` to the `data_delimiter` choices
- Added `"tab": "\t"` to the delimiter mapping in `csv_export`

---
*This change was made with AI assistance.*

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)