### PR TITLE
fix(orga): prevent race condition in team invite acceptance

### DIFF
--- a/src/pretalx/orga/views/event.py
+++ b/src/pretalx/orga/views/event.py
@@ -613,7 +613,12 @@ class InvitationView(FormView):
 
     @transaction.atomic()
     def accept_invite(self, user):
-        invite = self.invitation
+        from pretalx.event.models import TeamInvite
+        try:
+            invite = TeamInvite.objects.select_for_update().get(token__iexact=self.kwargs.get("code"))
+        except TeamInvite.DoesNotExist:
+            messages.info(self.request, _("This invitation has already been used."))
+            return
         invite.team.members.add(user)
         invite.team.save()
         invite.team.organiser.log_action(


### PR DESCRIPTION
## Bug

When a team invite is accepted near-simultaneously by multiple requests (e.g. double-click or concurrent tabs), the invitation object is already resolved via `self.invitation` before `accept_invite` enters the `@transaction.atomic` block. Both requests proceed to add the user to the team and delete the invite, causing duplicate membership or errors.

## Fix

Re-fetch the `TeamInvite` inside the transaction using `select_for_update()`, which acquires a database-level row lock. If the invite was already deleted by a concurrent request, catch `DoesNotExist` and show a friendly message instead of crashing.

Closes #2392