### PR TITLE
Changed 'str' to 'string' in API schema

### DIFF
--- a/doc/api/schema.yml
+++ b/doc/api/schema.yml
@@ -4910,7 +4910,7 @@ components:
         answer:
           type: string
         answer_file:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -4951,7 +4951,7 @@ components:
         answer:
           type: string
         answer_file:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -4986,7 +4986,7 @@ components:
           type: string
           minLength: 1
         answer_file:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -5118,7 +5118,7 @@ components:
           type: string
           minLength: 1
         answer_file:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -5211,17 +5211,17 @@ components:
           description: Enter a custom domain, such as https://my.event.example.org
           maxLength: 200
         logo:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
         header_image:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
         og_image:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -6456,7 +6456,7 @@ components:
         field to provide an uploaded file.
       properties:
         resource:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -6877,7 +6877,7 @@ components:
           description: You can use <a href="https://docs.pretalx.org/user/markdown/"
             target="_blank" rel="noopener">Markdown</a> here.
         resource:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -6919,7 +6919,7 @@ components:
           description: You can use <a href="https://docs.pretalx.org/user/markdown/"
             target="_blank" rel="noopener">Markdown</a> here.
         resource:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -7031,7 +7031,7 @@ components:
           description: Internal notes for other organisers/reviewers. Not visible
             to the speakers or the public.
         avatar:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -7112,7 +7112,7 @@ components:
           type: boolean
           title: Don’t record this session.
         image:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -7196,7 +7196,7 @@ components:
           type: boolean
           title: Don’t record this session.
         image:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -7342,7 +7342,7 @@ components:
           type: boolean
           title: Don’t record this session.
         image:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.
@@ -7437,7 +7437,7 @@ components:
           type: boolean
           title: Don’t record this session.
         image:
-          type: str
+          type: string
           description: When reading data, a URL pointing to a downloadable file. When
             writing adata, a reference to a file uploaded via the <a href="https://docs.pretalx.org/api/fundamentals/#file-uploads">file
             uploads endpoint</a>.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Release Notes
 The following changes will be part of the upcoming pretalx release.
 For already released changes, head over here:
 
+- :bug:`api` OpenAPI schema file now uses 'string' type rather than 'str'.
 - :feature:`dev` Plugins responding to the ``footer_link`` signal may now include an optional ``cssclass`` key to style their footer links.
 - :bug:`schedule` The embedded schedule widget now renders titles, tracks, rooms and language names in the locale it was configured with, instead of falling back to the surrounding page's language when embedded on a site in a different language.
 - :bug:`orga:email` Composing a session email to speakers only with a submission-level placeholder (such as ``{proposal_code}``) in the subject or body no longer raises a server error; the placeholder is now correctly rejected with a validation message.


### PR DESCRIPTION
Changed the type of multiple properties from 'str' to 'string' in `doc/api/schema.yml`, as they were inconsistently named. This issue was noticed when parsing the schema file.