### PR TITLE
Make Speaker.GUID in frab export non-leaky

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Release Notes
 The following changes will be part of the upcoming pretalx release.
 For already released changes, head over here:
 
+- :feature:`dev` The public frab JSON schedule export no longer exposes a speaker identifier derived from the speaker's email address. The per-speaker GUID is now a stable, instance-specific value that cannot be used to confirm or correlate a speaker's email.
 - :security:`schedule` The event social-media card (``og-image``) is now only served for public events, matching the visibility rules of the rest of the public event pages, so an event's branding images can no longer be retrieved before the event is public.
 - :bug:`orga` Logos uploaded during the initial event creation wizard are now saved, instead of being silently dropped on submission.
 - :bug:`cfp` Track names and descriptions are now consistently escaped when shown in the enhanced dropdown widget, matching how they are handled elsewhere.

--- a/src/pretalx/person/models/profile.py
+++ b/src/pretalx/person/models/profile.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2017-present Tobias Kunze
 # SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
 
+import uuid
+
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -8,6 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from pretalx.agenda.rules import can_view_schedule, is_speaker_viewable
 from pretalx.common.models.fields import MarkdownField
 from pretalx.common.models.mixins import GenerateCode, PretalxModel
+from pretalx.common.models.settings import GlobalSettings
 from pretalx.common.text.phrases import phrases
 from pretalx.common.urls import EventUrls
 from pretalx.orga.rules import can_view_speaker_names
@@ -110,6 +113,23 @@ class SpeakerProfile(ProfilePictureMixin, GenerateCode, PretalxModel):
             self.name
             or (self.user.name if self.user else None)
             or str(_("Unnamed speaker"))
+        )
+
+    @cached_property
+    def guid(self) -> str | None:
+        prefix = None
+        code = None
+        if self.user_id:
+            prefix = "user"
+            code = self.user.code
+        if not code:
+            prefix = "speaker"
+            code = self.code
+        if not code:
+            # code is always set except for unsaved objects
+            return None
+        return str(
+            uuid.uuid5(GlobalSettings().get_instance_identifier(), f"{prefix}:{code}")
         )
 
     @cached_property

--- a/src/pretalx/person/models/user.py
+++ b/src/pretalx/person/models/user.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
 
 import html
-import uuid
 from contextlib import suppress
 
 from django.conf import settings
@@ -14,7 +13,6 @@ from django.contrib.auth.models import (
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.db.models.functions import Lower
-from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from rules.contrib.models import RulesModelBase, RulesModelMixin
 
@@ -261,10 +259,6 @@ class User(
         for picture in self.pictures.all():
             picture.delete()
         return super().delete_files()
-
-    @cached_property
-    def guid(self) -> str:
-        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"acct:{self.email.strip()}"))
 
     def get_events_with_any_permission(self):
         """Returns a queryset of events for which this user has any type of

--- a/src/pretalx/schedule/interfaces/exporters.py
+++ b/src/pretalx/schedule/interfaces/exporters.py
@@ -242,7 +242,7 @@ class FrabJsonExporter(ScheduleData):
                                             ),
                                             "biography": person.biography,
                                             "public_name": person.get_display_name(),  # deprecated
-                                            "guid": person.user.guid,
+                                            "guid": person.guid,
                                             "url": person.urls.public.full(),
                                         }
                                         for person in talk.submission.sorted_speakers

--- a/src/tests/person/models/test_profile.py
+++ b/src/tests/person/models/test_profile.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: 2026-present Tobias Kunze
 # SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
+import uuid
+
 import pytest
 from django.db.utils import IntegrityError
 from django.utils.translation import gettext_lazy as _
 from django_scopes import scope
 
+from pretalx.common.models.settings import GlobalSettings
 from pretalx.person.models.profile import SpeakerProfile
 from tests.factories import (
     AnswerFactory,
@@ -12,6 +15,7 @@ from tests.factories import (
     EventFactory,
     QuestionFactory,
     SpeakerFactory,
+    UserFactory,
 )
 
 pytestmark = [pytest.mark.unit, pytest.mark.django_db]
@@ -143,3 +147,36 @@ def test_speaker_profile_full_availability_merges_overlapping(event):
     assert len(result) == 1
     assert result[0].start == start
     assert result[0].end == event.datetime_to
+
+
+def test_speaker_guid_derived_from_user_code():
+    speaker = SpeakerFactory(user=UserFactory())
+    expected = str(
+        uuid.uuid5(
+            GlobalSettings().get_instance_identifier(), f"user:{speaker.user.code}"
+        )
+    )
+    assert speaker.guid == expected
+
+
+def test_speaker_guid_without_user_uses_own_code():
+    speaker = SpeakerFactory(user=None)
+    expected = str(
+        uuid.uuid5(
+            GlobalSettings().get_instance_identifier(), f"speaker:{speaker.code}"
+        )
+    )
+    assert speaker.guid == expected
+
+
+def test_speaker_guid_stable_for_user_across_events():
+    user = UserFactory()
+    assert SpeakerFactory(user=user).guid == SpeakerFactory(user=user).guid
+
+
+def test_speaker_guid_different_speakers():
+    assert SpeakerFactory().guid != SpeakerFactory().guid
+
+
+def test_speaker_guid_none_without_user_or_code():
+    assert SpeakerProfile(event=EventFactory(), user=None).guid is None

--- a/src/tests/person/models/test_user.py
+++ b/src/tests/person/models/test_user.py
@@ -1,7 +1,5 @@
 # SPDX-FileCopyrightText: 2026-present Tobias Kunze
 # SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
-import uuid
-
 import pytest
 from django.core.exceptions import ValidationError
 
@@ -92,18 +90,6 @@ def test_user_clean_accepts_empty_email():
     user = User(email="", name="New")
     user.clean()
     assert user.email == ""
-
-
-def test_user_guid_deterministic():
-    user = User(email="test@example.com")
-    expected = str(uuid.uuid5(uuid.NAMESPACE_URL, "acct:test@example.com"))
-    assert user.guid == expected
-
-
-def test_user_guid_different_emails():
-    user1 = User(email="a@example.com")
-    user2 = User(email="b@example.com")
-    assert user1.guid != user2.guid
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@Kunsi @saerdnaer I looked at #1538 again when I reviewed the speaker GUID that is generated only for the frab-compatible JSON export. The GUID is generated from the speaker email address, so a) it will change when the speaker changes their email address, and b) provides an oracle for determining speaker email addresses.

I have not found any place that currently uses speaker GUID, but as the code using the frab exports is pretty scattered, I may have overlooked something. I have some questions:

1. To the best of your knowledge, is the JSON export speaker GUID in active use in a way where changing it *once* in the next pretalx upgrade for historical data will break anything? Like I said, it would already change any time a speaker changes their email address, so I would *hope* that this is not the case.
2. Does the speaker GUID need to be consistent across different conferences? I.e. if F. Nord has a session in 36C3 and 37C3, does the GUID need to be the same? pretalx has been moving slowly away from this kind of model (allowing speakers to use different names and profile pictures for different events, as well as different `code`/ID properties), so I wouldn't class this as a *leak* per se right now, but it would be nonstandard for pretalx. I'd be fine to keep this behaviour if you or others rely on it though, at least for now.
3. The JSON schema (including the new suggested feature for the v2 version) explicitly calls for `Person UUID generated from email address via uuid5(NS_URL, 'acct:user@domain.tld') or random uuid4() if email not available` -- as `NS_URL` is generally known, this approach by design allows people to confirm a speaker's email address given the public GUID, which I do not feel great about. How strongly do you feel about this design choice in general? This PR would change the GUID generation to using the stable speaker code/ID as basis together with the `NS_URL`, so we'd still provide a stable UUID, which as an added bonus cannot be changed by a speaker changing their email address.