### PR TITLE
Markdown lists without preceding empty lines

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ Release Notes
 The following changes will be part of the upcoming pretalx release.
 For already released changes, head over here:
 
+- :feature:`cfp,2529` Markdown lists now also render correctly when they are not preceded by an empty line, matching most Markdown inputs on the web as well as our preview tab.
 - :bug:`cfp,2501` Uploading a tall portrait image to the profile picture cropper no longer pushes the "Apply Crop" button out of view.
 - :feature:`schedule` The frab-compatible XML and JSON schedule exports now identify the generating instance.
 - :bug:`schedule` The schedule no longer shows the "you are not logged in" hint when embedded as a widget, where there is no way to log in anyway.

--- a/src/pretalx/common/templatetags/rich_text.py
+++ b/src/pretalx/common/templatetags/rich_text.py
@@ -10,6 +10,7 @@
 # at startup time in development/check mode, that hurts in development.
 
 import html
+import re
 from functools import cache, partial
 
 from django import template
@@ -70,6 +71,14 @@ ALLOWED_ATTRIBUTES = {
 ALLOWED_PROTOCOLS = {"http", "https", "mailto", "tel"}
 
 STRIKETHROUGH_RE = "(~{2})(.+?)(~{2})"
+
+# Regex matching list markers at the start of line, including all markers
+# supported for unordered lists (*, +, -) as well as 1. for ordered lists.
+# All other numbers are not supported without a preceding empty line in
+# CommonMark and other common implementations due to the risk of false
+# positives when people use line breaks. Capped to three preceding spaces
+# to prevent matching indent-based code blocks.
+LIST_INTERRUPT_RE = re.compile(r"^ {0,3}(?:[*+-]|1\.)[ ]+\S")
 
 
 def link_callback(attrs, is_new, **kwargs):
@@ -208,11 +217,11 @@ def plaintext_cleaner():
 
 @cache
 def markdown_engine():
-    """Return the shared ``markdown.Markdown`` instance.
+    """Return the shared ``markdown.Markdown`` instance. Inline because
+    importing Markdown is slow.
 
-    Stateful — callers must ``.reset()`` before each ``.convert()``. This
-    matches the previous module-level singleton; concurrent template renders
-    are not safe against this instance, but that was already the case."""
+    The Markdown instance is stateful, you must call .reset() before
+    calling .convert()."""
     import markdown  # noqa: PLC0415 -- slow import
 
     class StrikeThroughExtension(markdown.Extension):
@@ -221,6 +230,40 @@ def markdown_engine():
                 markdown.inlinepatterns.SimpleTagPattern(STRIKETHROUGH_RE, "del"),
                 "strikethrough",
                 200,
+            )
+
+    class BreaklessListPreprocessor(markdown.preprocessors.Preprocessor):
+        """Insert a blank line before a list.
+
+        Python-Markdown is committed to matching Markdown.pl rather
+        de-facto standards like CommonMark, GHFM etc. Requiring an
+        empty line before lists is a super common footgun, so we insert
+        an empty line when we infer (see regex comment) that the user
+        intended to start a list."""
+
+        def run(self, lines):
+            new_lines = []
+            previous_was_list_item = False
+            for line in lines:
+                if LIST_INTERRUPT_RE.match(line):
+                    # Only inserting before the first list item so that
+                    # a tight list remains tight.
+                    if not previous_was_list_item:
+                        new_lines.append("")
+                    previous_was_list_item = True
+                elif not line.strip():
+                    previous_was_list_item = False
+                new_lines.append(line)
+            return new_lines
+
+    class BreaklessListExtension(markdown.Extension):
+        def extendMarkdown(self, md):
+            md.preprocessors.register(
+                # Low priority chosen to not accidentally put lists in
+                # fenced code blocks.
+                BreaklessListPreprocessor(md),
+                "breakless_lists",
+                6,
             )
 
     return markdown.Markdown(
@@ -232,6 +275,7 @@ def markdown_engine():
             "markdown.extensions.codehilite",
             "markdown.extensions.md_in_html",
             StrikeThroughExtension(),
+            BreaklessListExtension(),
         ]
     )
 

--- a/src/tests/common/templatetags/test_rich_text.py
+++ b/src/tests/common/templatetags/test_rich_text.py
@@ -53,6 +53,87 @@ def test_render_markdown_strikethrough():
 
 
 @pytest.mark.parametrize(
+    ("text", "kind"),
+    (
+        # Matches
+        ("intro\n- a\n- b", "list"),
+        ("intro\n+ a\n+ b", "list"),
+        ("intro\n* a\n* b", "list"),
+        ("intro\n1. a\n2. b", "list"),
+        # Not matching higher numbers
+        ("intro\n2. a\n3. b", "para"),
+        ("The year was\n2020. wild", "para"),
+        ("intro\n10. a\n11. b", "para"),
+        # Not matching empty markers (paragraph or heading)
+        ("intro\n1.", "para"),
+        ("intro\n- ", "heading"),
+        ("Heading\n---", "heading"),
+        # Not matching hrs
+        ("intro\n* * *", "hr"),
+        ("intro\n- - -", "hr"),
+        # Not matching inside code blocks
+        ("Run:\n```\n1. not a list\n- not a list\n```\ndone", "code"),
+        ("Run:\n```\ncode line\n1. not a list\n```\ndone", "code"),
+        ("Example:\n\n    code line\n    1. not a list", "code"),
+    ),
+)
+def test_render_markdown_breakless_lists(text, kind):
+    result = str(render_markdown(text))
+
+    has_list = "<ul>" in result or "<ol" in result
+    assert has_list is (kind == "list")
+    assert ("<hr" in result) is (kind == "hr")
+    if kind == "heading":
+        assert "<h2" in result
+    if kind == "code":
+        assert "<li>" not in result
+        assert "<code>" in result or "codehilite" in result
+
+
+def test_render_markdown_breakless_list_keeps_intro_paragraph():
+    result = str(render_markdown("Here are the options:\n- first\n- second"))
+
+    assert "<p>Here are the options:</p>" in result
+    assert "<li>first</li>" in result
+    assert "<li>second</li>" in result
+    assert "- first" not in result
+
+
+def test_render_markdown_breakless_list_stays_tight():
+    result = str(render_markdown("intro\n- a\n- b"))
+
+    assert "<li>a</li>" in result
+    assert "<li><p>" not in result
+
+
+def test_render_markdown_breakless_ordered_only_interrupts_on_one():
+    interrupting = str(render_markdown("intro\n1. a\n2. b"))
+    assert "<ol>" in interrupting
+    assert "<li>a</li>" in interrupting
+
+    not_interrupting = str(render_markdown("intro\n2. a\n3. b"))
+    assert "<ol" not in not_interrupting
+
+    with_blank_line = str(render_markdown("intro\n\n2. a\n3. b"))
+    assert "<ol" in with_blank_line
+    assert "<li>a</li>" in with_blank_line
+
+
+def test_render_markdown_breakless_does_not_split_code_block_content():
+    result = str(render_markdown("```\ncode line\n1. still code\n```"))
+
+    assert "<li>" not in result
+    assert "\n\n" not in result.split("<code>")[1].split("</code>", maxsplit=1)[0]
+
+
+def test_render_markdown_breakless_leaves_raw_html_block_untouched():
+    result = str(render_markdown('<div markdown="0">\n- a\n- b\n</div>'))
+
+    assert "<li>" not in result
+    assert "- a" in result
+
+
+@pytest.mark.parametrize(
     ("text", "link_substring", "has_noopener"),
     (
         ("foo.notatld", "foo.notatld", False),


### PR DESCRIPTION
ref #1574, ref #2529

Render things as lists even without a preceding empty line.
- like this