### PR TITLE
Handle invalid review assignment import JSON

### DIFF
--- a/src/pretalx/orga/forms/review.py
+++ b/src/pretalx/orga/forms/review.py
@@ -200,6 +200,9 @@ class ReviewAssignImportForm(DirectionForm):
     )
 
     JSON_ERROR_MESSAGE = _("Cannot parse JSON file.")
+    JSON_FORMAT_ERROR_MESSAGE = _(
+        "JSON file must contain an object mapping identifiers to assignment lists."
+    )
 
     def __init__(self, event, **kwargs):
         self.event = event
@@ -239,6 +242,8 @@ class ReviewAssignImportForm(DirectionForm):
             data = json.load(uploaded_file)
         except (ValueError, UnicodeDecodeError):
             raise forms.ValidationError(self.JSON_ERROR_MESSAGE) from None
+        if not isinstance(data, dict):
+            raise forms.ValidationError(self.JSON_FORMAT_ERROR_MESSAGE)
         return data
 
     def clean(self):

--- a/src/pretalx/orga/views/review.py
+++ b/src/pretalx/orga/views/review.py
@@ -1004,6 +1004,11 @@ class ReviewAssignmentImport(EventPermissionRequired, FormView):
         messages.success(self.request, _("The reviewers were assigned successfully."))
         return redirect(self.request.event.orga_urls.review_assignments)
 
+    def form_invalid(self, form):
+        response = super().form_invalid(form)
+        response.status_code = 400
+        return response
+
 
 class ReviewExport(EventPermissionRequired, FormView):
     permission_required = "event.update_event"

--- a/src/tests/orga/forms/test_review.py
+++ b/src/tests/orga/forms/test_review.py
@@ -452,6 +452,34 @@ def test_review_assign_import_form_clean_import_file_binary():
     assert "import_file" in form.errors
 
 
+@pytest.mark.parametrize(
+    "data",
+    (
+        pytest.param(123),
+        pytest.param("hello"),
+        pytest.param(True),
+        pytest.param(None),
+        pytest.param(["not", "a", "mapping"]),
+    ),
+)
+def test_review_assign_import_form_clean_import_file_rejects_non_object_json(data):
+    """clean_import_file rejects JSON values that cannot describe assignments."""
+    event = EventFactory()
+    uploaded = SimpleUploadedFile(
+        "assignments.json", json.dumps(data).encode(), content_type="application/json"
+    )
+
+    form = ReviewAssignImportForm(
+        event=event,
+        data={"direction": "reviewer", "replace_assignments": "0"},
+        files={"import_file": uploaded},
+    )
+    form.is_valid()
+
+    assert "import_file" in form.errors
+    assert "mapping identifiers to assignment lists" in str(form.errors["import_file"])
+
+
 def test_review_assign_import_form_clean_reviewer_direction():
     """clean() resolves users as keys and submissions as values for 'reviewer' direction."""
     event = EventFactory()

--- a/src/tests/orga/views/integration/test_review.py
+++ b/src/tests/orga/views/integration/test_review.py
@@ -838,6 +838,23 @@ def test_review_assignment_via_import_submission_direction_replace(client, event
         assert reviewer.assigned_reviews.count() == 1
 
 
+def test_review_assignment_import_rejects_non_object_json(client, event):
+    with scopes_disabled():
+        orga_user = make_orga_user(event, can_change_event_settings=True)
+
+    with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as f:
+        f.write(json.dumps(123))
+        f.seek(0)
+        client.force_login(orga_user)
+        response = client.post(
+            event.orga_urls.reviews + "assign/import",
+            {"import_file": f, "replace_assignments": 0, "direction": "reviewer"},
+        )
+
+    assert response.status_code == 400
+    assert b"mapping identifiers to assignment lists" in response.content
+
+
 def test_review_assignment_htmx_reviewer_to_submission(client, event):
     with scopes_disabled():
         orga_user = make_orga_user(event, can_change_event_settings=True)


### PR DESCRIPTION
## Summary
- validate review assignment import JSON before resolving reviewer/proposal mappings
- return HTTP 400 for invalid review assignment import submissions
- add form and integration regression tests for non-object JSON payloads

## Tests
- All checks passed!
- .........................................                                [100%]
41 passed in 1.44s

Closes #2511