### PR TITLE
Fix admin_user_events template syntax error

### DIFF
--- a/src/pretalx/orga/templates/orga/tables/columns/admin_user_events.html
+++ b/src/pretalx/orga/templates/orga/tables/columns/admin_user_events.html
@@ -5,7 +5,8 @@ SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-Pretalx-AGPL-3.0-Terms
 {% load i18n %}
 
 {% if record.is_administrator %}
-    {% translate "All events" } {% else %}
+    {% translate "All events" %}
+{% else %}
     <ul>
         {% for event in record.get_events_with_any_permission %}
             <li>


### PR DESCRIPTION
<!--
We only accept PRs that reference an issue that is labelled `accepted` and
assigned to you. The only exception is trivial fixes like typo corrections. See
https://docs.pretalx.org/developer/contributing/ for details.
-->

This PR closes/references issue #XX.

The `translate` tag was broken when introduced in 9bd5c4011f925f74aed17ddfc7f33827e26dbd36. I assume the reformat in eb203a06ec4529328a2450cbb74705707a788837 was due to the broken tag.