### PR TITLE
Note that skipping feature releases is unsupported

### DIFF
--- a/doc/administrator/maintenance.rst
+++ b/doc/administrator/maintenance.rst
@@ -107,7 +107,11 @@ We try to make upgrades as painless as possible. To this end, we provide
 important upgrade notes and warnings. Also, make sure you have a current
 backup.
 
-Next, execute the following commands in the same environment as your
+Note that skipping feature releases during upgrades is not supported. If you
+are more than one version behind, please upgrade through all intermediate
+feature releases.
+
+To upgrade, execute the following commands in the same environment as your
 installation. This may be your pretalx user, or a virtualenv, if you chose a
 different installation path.
 


### PR DESCRIPTION
[We](https://seagl.org) hit problems upgrading from 2025.1 to 2026.2 - migrations would fail with an error about a missing `submission_attendeesignup` table.

The problem appears to be that `0092_delete_soft_deleted_submissions` (added in 2026.1) invokes app code, not just migration SQL. AFAICT it invokes enough of the model layer that Django performs validation on the schema that's in the database, and because the newer model code expects `submission_attendeesignup` (which was added later in a migration in 2026.2) to exist, Django crashes despite the fact that `0092_delete_soft_deleted_submissions` would have completed just fine without it.

Since this class of error is likely to reoccur, just document that skipping feature releases is unsupported.

<!--
We only accept PRs that reference an issue that is labelled `accepted` and
assigned to you. The only exception is trivial fixes like typo corrections. See
https://docs.pretalx.org/developer/contributing/ for details.
-->

~This PR closes/references issue #XX.~