### PR TITLE
Fix sending of e-mails by plugin

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ The following changes will be part of the upcoming pretalx release.
 For already released changes, head over here:
 
 - :bug:`orga` Copying an event's settings when creating a new event did not copy email signatures, attendee signup settings, or tags.
+- :feature:`dev,2758` A plugin handling ``queuedmail_pre_send`` asynchronously can now prevent a mail from being sent via SMTP by setting ``mail.state`` to ``SENDING``.
 - :bug:`orga:schedule` Changing a session's state, for example cancelling a scheduled session, did not update the "unreleased changes" marker in the schedule navigation.
 - :feature:`api` Requests to API URLs that lead to an error now all return JSON errors instead of full HTML pages.
 - :bug:`api` Expanding ``submission.speakers`` on the talk slot endpoint returned the speakers of a session in arbitrary order instead of the order set on the session.

--- a/src/pretalx/mail/domain/send.py
+++ b/src/pretalx/mail/domain/send.py
@@ -69,10 +69,14 @@ def send_draft(mail, *, requestor=None, orga: bool = True) -> None:
         if event:
             queuedmail_pre_send.send_robust(sender=event, mail=mail)
 
-        if mail.sent is not None or mail.state == QueuedMailStates.SENT:
-            # A pre_send signal handler did the sending; nothing left to do.
-            mail.state = QueuedMailStates.SENT
-            mail.save(update_fields=["state", "sent"])
+        if mail.sent is not None or mail.state in (
+            QueuedMailStates.SENT,
+            QueuedMailStates.SENDING,
+        ):
+            # A pre_send signal handler does the sending; nothing left to do.
+            if mail.sent and mail.state != QueuedMailStates.SENT:
+                mail.state = QueuedMailStates.SENT
+                mail.save(update_fields=["state", "sent"])
             return
 
         mail.state = QueuedMailStates.SENDING

--- a/src/pretalx/mail/signals.py
+++ b/src/pretalx/mail/signals.py
@@ -32,8 +32,11 @@ queuedmail_pre_send = EventPluginSignal()
 """
 This signal is sent out before a ``QueuedMail`` will been sent.
 Receivers may set the ``sent`` timestamp to skip sending via the regular
-email backend. The email text and HTML is rendered after this signal has
-been processed, so you can also alter the email’s content here.
+email backend. If delivery is asynchronous or not yet confirmed, receivers
+may instead set ``mail.state`` to ``sending``; pretalx will then leave the
+mail as-is rather than sending it via SMTP or marking it as sent.
+The email text and HTML is rendered after this signal has been processed,
+so you can also alter the email’s content here.
 Any exceptions raised by receivers will be ignored.
 
 Please note that this signal is only sent for ``QueuedMail`` instances that

--- a/src/tests/mail/domain/test_send.py
+++ b/src/tests/mail/domain/test_send.py
@@ -141,6 +141,41 @@ def test_send_draft_skips_when_signal_sets_sent(event, register_signal_handler):
     assert len(djmail.outbox) == 0
 
 
+@pytest.mark.parametrize("state", (QueuedMailStates.SENT, QueuedMailStates.SENDING))
+def test_send_draft_skips_when_signal_sets_state(event, register_signal_handler, state):
+
+    def mark_as_sent(signal, sender, mail, **kwargs):
+        mail.state = state
+
+    register_signal_handler(queuedmail_pre_send, mark_as_sent)
+    djmail.outbox = []
+    mail = QueuedMailFactory(event=event, to="test@pretalx.org")
+
+    send_draft(mail)
+
+    assert mail.state == state
+    assert len(djmail.outbox) == 0
+
+
+@pytest.mark.parametrize("state", (QueuedMailStates.SENT, QueuedMailStates.SENDING))
+def test_send_draft_skips_when_signal_sets_sent_and_state(
+    event, register_signal_handler, state
+):
+
+    def mark_as_sent(signal, sender, mail, **kwargs):
+        mail.sent = tz_now()
+        mail.state = state
+
+    register_signal_handler(queuedmail_pre_send, mark_as_sent)
+    djmail.outbox = []
+    mail = QueuedMailFactory(event=event, to="test@pretalx.org")
+
+    send_draft(mail)
+
+    assert mail.state == QueuedMailStates.SENT
+    assert len(djmail.outbox) == 0
+
+
 def test_send_draft_broker_failure_marks_failed(event, monkeypatch):
     def broken_broker(*args, **kwargs):
         raise OSError("Broker unavailable")


### PR DESCRIPTION
Plugins can now signal that they're handling delivery by setting the mail to `SENDING` state, without needing mail.sent set immediately.

This avoids the mail also going out via SMTP if the plugin has a momentary problem or sends asynchronously.

This PR closes/references issue #2758.
